### PR TITLE
Build CI with GitHub Actions(windows runner)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    paths:
+      - '.github/workflows/build.yml'
+      - 'ExtLibraries/**'
+      - 'CMakeLists.txt'
+      - 'src/**'
+
+jobs:
+  build_s2e:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure build for x86
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_x86
+
+      - name: build extlib
+        shell: powershell
+        working-directory: ExtLibraries
+        run: |
+          cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug"
+          cmake --build .
+      - name: install extlib
+        shell: powershell
+        working-directory: ExtLibraries
+        run: |
+          cmake --install .
+      - name: check extlib
+        shell: powershell
+        run: |
+          ls ..
+          ls ../ExtLibraries
+          ls ../ExtLibraries/cspice
+          ls ../ExtLibraries/cspice/cspice_msvs
+          ls ../ExtLibraries/cspice/include
+          ls ../ExtLibraries/cspice/generic_kernels
+          ls ../ExtLibraries/nrlmsise00
+          ls ../ExtLibraries/nrlmsise00/table
+          ls ../ExtLibraries/nrlmsise00/lib
+          ls ../ExtLibraries/nrlmsise00/lib/libnrlmsise00.lib
+          ls ../ExtLibraries/nrlmsise00/src
+      - name: build
+        shell: cmd
+        run: |
+          cl.exe
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+          cmake -G "Visual Studio 16 2019" -A Win32  -DCMAKE_CONFIGURATION_TYPES:STRING="Debug"
+          cmake --build .

--- a/ExtLibraries/CMakeLists.txt
+++ b/ExtLibraries/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+
+set(EXT_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../../ExtLibraries/")
+
+add_subdirectory(nrlmsise00)
+add_subdirectory(cspice)
+
+install(TARGETS libnrlmsise00)

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.13)
+
+include(ExternalProject)
+include(FetchContent)
+
+set(CSPICE_INSTALL_DIR ${EXT_LIB_DIR}/cspice)
+set(CSPICE_URL http://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Windows_VisualC_32bit/packages/cspice.zip)
+set(GENERIC_KERNEL_URL_BASE https://naif.jpl.nasa.gov/pub/naif/generic_kernels)
+
+# build & install cspice
+ExternalProject_Add(cspice
+  URL ${CSPICE_URL}
+  SOURCE_DIR "cspice"
+  CONFIGURE_COMMAND ""
+  BUILD_IN_SOURCE true
+  BUILD_COMMAND makeall.bat
+  INSTALL_COMMAND
+    ${CMAKE_COMMAND} -DCSPICE_INSTALL_DIR=${CSPICE_INSTALL_DIR} -P ${CMAKE_CURRENT_LIST_DIR}/install_step.cmake
+)
+
+# install generic kernels
+function(download_generic_kernel dir kernel)
+  message("downloading ${dir}/${kernel}...")
+  FetchContent_Declare(${kernel}
+    URL ${GENERIC_KERNEL_URL_BASE}/${dir}/${kernel}
+    DOWNLOAD_NO_EXTRACT true
+    SOURCE_DIR ${CSPICE_INSTALL_DIR}/generic_kernels
+  )
+  FetchContent_MakeAvailable(${kernel})
+endfunction(download_generic_kernel)
+
+download_generic_kernel(lsk/a_old_versions naif0010.tls)
+download_generic_kernel(pck de-403-masses.tpc)
+download_generic_kernel(pck gm_de431.tpc)
+download_generic_kernel(pck pck00010.tpc)
+download_generic_kernel(spk/planets de430.bsp)

--- a/ExtLibraries/cspice/install_step.cmake
+++ b/ExtLibraries/cspice/install_step.cmake
@@ -1,0 +1,18 @@
+message("install cspice to ${CSPICE_INSTALL_DIR}")
+message("  source: ${CMAKE_SOURCE_DIR}")
+
+file(MAKE_DIRECTORY "${CSPICE_INSTALL_DIR}")
+
+message("install cspice/include")
+file(
+  INSTALL ${CMAKE_SOURCE_DIR}/include
+  DESTINATION ${CSPICE_INSTALL_DIR}
+)
+
+message("install cspice/lib")
+file(
+  COPY ${CMAKE_SOURCE_DIR}/lib
+  DESTINATION ${CSPICE_INSTALL_DIR}/cspice_msvs
+)
+
+message("install cspice done.")

--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(nrlmsise00)
+
+include(ExternalProject)
+include(FetchContent)
+
+set(NRLMSISE_INSTALL_DIR ${EXT_LIB_DIR}/nrlmsise00)
+
+set(NRLMSISE_URL_BASE https://ccmc.gsfc.nasa.gov/pub/modelweb/atmospheric/msis/nrlmsise00/nrlmsis00_c_version)
+set(NRLMSISE_TABLE_URL_BASE ftp://ftp.agi.com/pub/DynamicEarthData)
+set(NRLMSISE_TABLE_FILE SpaceWeather-v1.2.txt)
+
+set(NRLMSISE_TMP_DIR "nrlmsise")
+
+# download files
+function(download_file base_url file)
+  message("downloading ${file}")
+  FetchContent_Declare(
+    ${file}
+    SOURCE_DIR ${NRLMSISE_TMP_DIR}
+    URL ${base_url}/${file}
+    DOWNLOAD_NO_EXTRACT true
+  )
+  FetchContent_MakeAvailable(${file})
+endfunction()
+
+## download source files
+download_file(${NRLMSISE_URL_BASE} makefile)
+download_file(${NRLMSISE_URL_BASE} nrlmsise-00.c)
+download_file(${NRLMSISE_URL_BASE} nrlmsise-00.h)
+download_file(${NRLMSISE_URL_BASE} nrlmsise-00_data.c)
+download_file(${NRLMSISE_URL_BASE} nrlmsise-00_test.c)
+
+## download table
+download_file(${NRLMSISE_TABLE_URL_BASE} ${NRLMSISE_TABLE_FILE})
+
+
+# build
+add_library(libnrlmsise00 STATIC ${NRLMSISE_TMP_DIR}/nrlmsise-00.c ${NRLMSISE_TMP_DIR}/nrlmsise-00_data.c)
+
+
+# install
+message("install nrlmsise to ${NRLMSISE_INSTALL_DIR}")
+
+## install CMake config
+install(EXPORT nrlmsise00-config
+  NAMESPACE nrlmsise00::
+  DESTINATION ${NRLMSISE_INSTALL_DIR}
+)
+
+## install library
+install(TARGETS libnrlmsise00
+  EXPORT nrlmsise00-config
+  ARCHIVE DESTINATION ${NRLMSISE_INSTALL_DIR}/lib
+)
+
+## install source
+## TODO: .c要るのか？ヘッダだけにしてディレクトリもincludeでよいのでは？
+install(FILES ${NRLMSISE_TMP_DIR}/nrlmsise-00.h
+  DESTINATION ${NRLMSISE_INSTALL_DIR}/src
+)
+install(FILES ${NRLMSISE_TMP_DIR}/nrlmsise-00.c
+  DESTINATION ${NRLMSISE_INSTALL_DIR}/src
+)
+install(FILES ${NRLMSISE_TMP_DIR}/nrlmsise-00_data.c
+  DESTINATION ${NRLMSISE_INSTALL_DIR}/src
+)
+
+## install table
+install(FILES nrlmsise/${NRLMSISE_TABLE_FILE}
+  DESTINATION ${NRLMSISE_INSTALL_DIR}/table
+)


### PR DESCRIPTION
## Overview
- Add CMake for build `../ExtLibraries`
  - support windows only(currently)
- Add build CI with GitHub Actions windows runner

## Issue
- #29 

## Details
- `ExtLibraries/CMakeLists.txt` download & build external dependencies and install to `../ExtLibraries`

##  Validation results
- https://github.com/ut-issl/s2e-core/runs/4920971176?check_suite_focus=true

## Scope of influence
N/A

## Supplement
- `../ExtLibraries` will be controlled by `ExtLibraries/CMakeLists.txt`(not on this PR)

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
