### PR TITLE
Fix IGRF path in the ini file

### DIFF
--- a/data/SampleSat/ini/SampleLocalEnvironment.ini
+++ b/data/SampleSat/ini/SampleLocalEnvironment.ini
@@ -1,7 +1,7 @@
 [MAG_ENVIRONMENT]
 calculation = ENABLE
 logging = ENABLE
-coeff_file = ../../../S2E_CORE_OSS/src/Library/igrf/igrf13.coef
+coeff_file = ../../../s2e-core/src/Library/igrf/igrf13.coef
 mag_rwdev = 10.0     //Random Walk speed[nT]
 mag_rwlimit = 400.0  //Random Walk max limit[nT]
 mag_wnvar = 50.0     //White noise standard deviation [nT]


### PR DESCRIPTION
## Overview
Fix the IGRF path in the ini file.

## Issue
NA

## Details
IGRF relative path in the default ini file was fixed.

##  Validation results
Confirmed that S2E works well.

## Scope of influence
NA

## Supplement
NA

## Note
NA
