### PR TITLE
Add cache ExtLibraries in build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,24 @@ jobs:
         with:
           arch: amd64_x86
 
+      - name: cache extlib
+        id: cache-extlib
+        uses: actions/cache@v2
+        with:
+          key: extlib-${{ runner.os }}-${{ hashFiles('s2e-core/ExtLibraries/**') }}
+          restore-keys: |
+            extlib-${{ runner.os }}-
+          path: ExtLibraries
+
       - name: build extlib
+        if: steps.cache-extlib.outputs.cache-hit != 'true'
         shell: powershell
         working-directory: s2e-core/ExtLibraries
         run: |
           cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug"
           cmake --build .
       - name: install extlib
+        if: steps.cache-extlib.outputs.cache-hit != 'true'
         shell: powershell
         working-directory: s2e-core/ExtLibraries
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          path: s2e-core
 
       - name: Configure build for x86
         uses: ilammy/msvc-dev-cmd@v1
@@ -26,30 +28,31 @@ jobs:
 
       - name: build extlib
         shell: powershell
-        working-directory: ExtLibraries
+        working-directory: s2e-core/ExtLibraries
         run: |
           cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug"
           cmake --build .
       - name: install extlib
         shell: powershell
-        working-directory: ExtLibraries
+        working-directory: s2e-core/ExtLibraries
         run: |
           cmake --install .
       - name: check extlib
         shell: powershell
         run: |
-          ls ..
-          ls ../ExtLibraries
-          ls ../ExtLibraries/cspice
-          ls ../ExtLibraries/cspice/cspice_msvs
-          ls ../ExtLibraries/cspice/include
-          ls ../ExtLibraries/cspice/generic_kernels
-          ls ../ExtLibraries/nrlmsise00
-          ls ../ExtLibraries/nrlmsise00/table
-          ls ../ExtLibraries/nrlmsise00/lib
-          ls ../ExtLibraries/nrlmsise00/lib/libnrlmsise00.lib
-          ls ../ExtLibraries/nrlmsise00/src
+          ls ExtLibraries
+          ls ExtLibraries/cspice
+          ls ExtLibraries/cspice/cspice_msvs
+          ls ExtLibraries/cspice/include
+          ls ExtLibraries/cspice/generic_kernels
+          ls ExtLibraries/nrlmsise00
+          ls ExtLibraries/nrlmsise00/table
+          ls ExtLibraries/nrlmsise00/lib
+          ls ExtLibraries/nrlmsise00/lib/libnrlmsise00.lib
+          ls ExtLibraries/nrlmsise00/src
+
       - name: build
+        working-directory: s2e-core
         shell: cmd
         run: |
           cl.exe


### PR DESCRIPTION
## Overview
Speed-up build CI by cache `ExtLibraries`.

## Issue
N/A

## Details
- change `ExtLibraries` install directory into `${GITHUB_WORKSPACE}/ExtLibraries` (external deps install dir)
- change checkout directory into `${GITHUB_WORKSPACE}/s2e-core`
- cache `${GITHUB_WORKSPACE}/ExtLibraries`

##  Validation results
- without cache: https://github.com/ut-issl/s2e-core/runs/4935695447 (total 7m54s)
- cache hit: https://github.com/ut-issl/s2e-core/actions/runs/1745010060 (total 4m29s)

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
