### PR TITLE
Add build CI with C2A

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        use_c2a: ['OFF', 'ON']
+        use_c2a: ['USE_C2A=OFF', 'USE_C2A=ON']
 
     steps:
       - uses: actions/checkout@v2
 
       - name: checkout C2A core
-        if: matrix.use_c2a == 'ON'
+        if: contains(matrix.use_c2a, 'ON')
         uses: actions/checkout@v2
         with:
           path: c2a-core
@@ -33,12 +33,12 @@ jobs:
           ref: v3.4.0
           fetch-depth: 1
       - name: move C2A to ../
-        if: matrix.use_c2a == 'ON'
+        if: contains(matrix.use_c2a, 'ON')
         shell: cmd
         run: move c2a-core ..\c2a-core
 
       - name: setup C2A
-        if: matrix.use_c2a == 'ON'
+        if: contains(matrix.use_c2a, 'ON')
         shell: cmd
         run: |
           cd ..
@@ -46,7 +46,7 @@ jobs:
           dir
           setup.bat
       - name: setup C2A user
-        if: matrix.use_c2a == 'ON'
+        if: contains(matrix.use_c2a, 'ON')
         shell: cmd
         working-directory: ..
         run: |
@@ -100,7 +100,7 @@ jobs:
         run: |
           cl.exe
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-          cmake -G "Visual Studio 16 2019" -A Win32  -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DUSE_C2A=${{ matrix.use_c2a }}
+          cmake -G "Visual Studio 16 2019" -A Win32  -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -D${{ matrix.use_c2a }}
           cmake --build .
 
   build_s2e_linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,26 @@ jobs:
           repository: ut-issl/c2a-core
           ref: v3.4.0
           fetch-depth: 1
+      - name: move C2A to ../
+        if: matrix.use_c2a == 'ON'
+        shell: cmd
+        run: move c2a-core ..\c2a-core
 
       - name: setup C2A
         if: matrix.use_c2a == 'ON'
-        working-directory: c2a-core
         shell: cmd
-        run: setup.bat
+        run: |
+          cd ..
+          cd c2a-core
+          dir
+          setup.bat
+      - name: setup C2A user
+        if: matrix.use_c2a == 'ON'
+        shell: cmd
+        working-directory: ..
+        run: |
+          mkdir FlightSW
+          mklink /j /d ".\FlightSW\c2a_oss" ".\c2a-core\Examples\minimum_user_for_s2e"
 
       - name: Configure build for x86
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,28 @@ jobs:
   build_s2e_win:
     name: Build on Windows
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        use_c2a: ['OFF', 'ON']
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: checkout C2A core
+        if: matrix.use_c2a == 'ON'
+        uses: actions/checkout@v2
+        with:
+          path: c2a-core
+          repository: ut-issl/c2a-core
+          ref: v3.4.0
+          fetch-depth: 1
+
+      - name: setup C2A
+        if: matrix.use_c2a == 'ON'
+        working-directory: c2a-core
+        shell: cmd
+        run: setup.bat
 
       - name: Configure build for x86
         uses: ilammy/msvc-dev-cmd@v1
@@ -67,7 +86,7 @@ jobs:
         run: |
           cl.exe
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-          cmake -G "Visual Studio 16 2019" -A Win32  -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries
+          cmake -G "Visual Studio 16 2019" -A Win32  -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DUSE_C2A=${{ matrix.use_c2a }}
           cmake --build .
 
   build_s2e_linux:


### PR DESCRIPTION
## Overview
Add build with C2A on build CI(windows runner).
C2A: `ut-issl/c2a-core/Examples/minimum_user_for_s2e`

## Issue
- Related issues

## Details
Write in detail.

##  Validation results
- https://github.com/ut-issl/s2e-core/runs/5004780832?check_suite_focus=true

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
