### PR TITLE
Custom FlightSW/C2A directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,6 @@ jobs:
         shell: cmd
         run: |
           cl.exe
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
           cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DFLIGHT_SW_DIR=./c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -D${{ matrix.use_c2a }}
           cmake --build .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,26 +32,12 @@ jobs:
           repository: ut-issl/c2a-core
           ref: v3.4.0
           fetch-depth: 1
-      - name: move C2A to ../
-        if: contains(matrix.use_c2a, 'ON')
-        shell: cmd
-        run: move c2a-core ..\c2a-core
 
       - name: setup C2A
         if: contains(matrix.use_c2a, 'ON')
         shell: cmd
-        run: |
-          cd ..
-          cd c2a-core
-          dir
-          setup.bat
-      - name: setup C2A user
-        if: contains(matrix.use_c2a, 'ON')
-        shell: cmd
-        working-directory: ..
-        run: |
-          mkdir FlightSW
-          mklink /j /d ".\FlightSW\c2a_oss" ".\c2a-core\Examples\minimum_user_for_s2e"
+        working-directory: c2a-core
+        run: setup.bat
 
       - name: Configure build for x86
         uses: ilammy/msvc-dev-cmd@v1
@@ -100,7 +86,7 @@ jobs:
         run: |
           cl.exe
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-          cmake -G "Visual Studio 16 2019" -A Win32  -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -D${{ matrix.use_c2a }}
+          cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DFLIGHT_SW_DIR=./c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -D${{ matrix.use_c2a }}
           cmake --build .
 
   build_s2e_linux:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,18 @@ if(NOT DEFINED EXT_LIB_DIR)
 endif()
 set(CSPICE_DIR ${EXT_LIB_DIR}/cspice)
 set(NRLMSISE00_DIR ${EXT_LIB_DIR}/nrlmsise00)
-set(FLIGHT_SW_DIR ../FlightSW)
-set(C2A_DIR ${FLIGHT_SW_DIR}/c2a_oss)
+
+if(NOT DEFINED FLIGHT_SW_DIR)
+  set(FLIGHT_SW_DIR ../FlightSW)
+endif()
+if(NOT DEFINED C2A_NAME)
+  set(C2A_NAME "c2a_oss")
+endif()
 
 ## options to use C2A
 if(USE_C2A)
+  set(C2A_DIR ${FLIGHT_SW_DIR}/${C2A_NAME})
+  message("C2A dir: ${C2A_DIR}")
   add_definitions(-DUSE_C2A)
   add_definitions(-DSILS_FW)
   #include_directories


### PR DESCRIPTION
## Overview
The current CMake config expects C2A to be present in `../FlightSW/c2a_oss`.
This is very inconvenient, so this PR will make it customizable at build time.

## Issue/PR
- #47 

## Details
See diff.

##  Validation results
Link to tests or validation results.

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
