### PR TITLE
Fix IDE include path

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -7,6 +7,9 @@
       "inheritEnvironments": [
         "msvc_x86"
       ],
+      "includePath": [
+        "${workspaceRoot}\\src"
+      ],
       "buildRoot": "${thisFileDir}\\CMakeBuilds",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
       "cmakeCommandArgs": "",

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,7 @@
+-m32
+-std=c++14
+-Wall
+-Wextra
+-I./src
+-I../ExtLibraries/cspice/include
+-I../ExtLibraries/nrlmsise00/src/


### PR DESCRIPTION
## Overview
Fix include warning and completion on some IDE(happened by #49).

## Issue/PR
- #49 

## Details
- [x] Add `includePath` to `CMakeSettings.json` for Visual Studio(IntelliSense)
  - IntelliSense can load include path from CMake. But sometimes this feature broken(ref: https://developercommunity.visualstudio.com/t/intellisense-doesnt-understand-cmake-target-includ/193144).
  - `CppProperties.json`(`CMakeSettings.json`) docs: https://docs.microsoft.com/ja-jp/cpp/build/cppproperties-schema-reference?view=msvc-170
- [x] Add `compile_flags.txt` for other IDE or LSP server


##  Validation results
- Neovim on Linux with clangd :heavy_check_mark:
- VSCode(OSS version) on Linux with clangd extension: :heavy_check_mark: 

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
