### PR TITLE
Use Inertial frame to calculate SRP environment

### DIFF
--- a/data/SampleSat/ini/SampleLocalEnvironment.ini
+++ b/data/SampleSat/ini/SampleLocalEnvironment.ini
@@ -10,6 +10,7 @@ mag_wnvar = 50.0     //White noise standard deviation [nT]
 [SRP]
 calculation = ENABLE
 logging = ENABLE
+shadow_source_name = EARTH
 
 
 [ATMOSPHERE]

--- a/data/SampleSat/ini/SampleLocalEnvironment.ini
+++ b/data/SampleSat/ini/SampleLocalEnvironment.ini
@@ -10,7 +10,6 @@ mag_wnvar = 50.0     //White noise standard deviation [nT]
 [SRP]
 calculation = ENABLE
 logging = ENABLE
-shadow_source_name = EARTH
 
 
 [ATMOSPHERE]

--- a/src/Component/AOCS/SunSensor.cpp
+++ b/src/Component/AOCS/SunSensor.cpp
@@ -59,14 +59,15 @@ void SunSensor::Initialize(const double nr_stddev_c,const double nr_bias_stddev_
 }
 void SunSensor::MainRoutine(int count)
 {
-  Vector<3> sun_pos_b = local_celes_info_->GetPosFromSC_b("SUN");
-  Vector<3> sun_dir_b = normalize(sun_pos_b);
-  measure(sun_dir_b);
+  measure();
 }
 
-void SunSensor::measure(const Vector<3>& sun_b)
+void SunSensor::measure()
 {
-  sun_c_ = q_b2c_.frame_conv(sun_b);    // Frame conversion from body to component
+  Vector<3> sun_pos_b = local_celes_info_->GetPosFromSC_b("SUN");
+  Vector<3> sun_dir_b = normalize(sun_pos_b);
+
+  sun_c_ = q_b2c_.frame_conv(sun_dir_b);    // Frame conversion from body to component
 
   SunDetectionJudgement();  // Judge the sun is inside the FoV
 

--- a/src/Component/AOCS/SunSensor.cpp
+++ b/src/Component/AOCS/SunSensor.cpp
@@ -146,7 +146,7 @@ void SunSensor::SunDetectionJudgement()
 
   double sun_angle_ = acos(sun_direction_c[2]);
 
-  if (solar_illuminance_ < intensity_lower_threshold_percent_)
+  if (solar_illuminance_ < intensity_lower_threshold_percent_ / 100.0 * srp_->GetSolarConstant())
   {
     sun_detected_flag_ = false;
   }
@@ -211,7 +211,7 @@ string SunSensor::GetLogHeader() const
   const string st_id = std::to_string(static_cast<long long>(id_));
 
   str_tmp += WriteVector("sun"+st_id, "c", "-", 3);
-  str_tmp += WriteScalar("sun_detected_flag"+st_id,"-");;
+  str_tmp += WriteScalar("sun_detected_flag"+st_id,"-");
 
   return str_tmp;
 }

--- a/src/Component/AOCS/SunSensor.cpp
+++ b/src/Component/AOCS/SunSensor.cpp
@@ -61,7 +61,7 @@ void SunSensor::MainRoutine(int count)
 {
   Vector<3> sun_pos_b = local_celes_info_->GetPosFromSC_b("SUN");
   Vector<3> sun_dir_b = normalize(sun_pos_b);
-  measure(sun_dir_b, srp_->GetShadowFunction());
+  measure(sun_dir_b);
 }
 
 void SunSensor::measure(const Vector<3>& sun_b)

--- a/src/Component/AOCS/SunSensor.cpp
+++ b/src/Component/AOCS/SunSensor.cpp
@@ -18,10 +18,11 @@ SunSensor::SunSensor(
   const double nr_stddev_c,
   const double nr_bias_stddev_c,
   const double intensity_lower_threshold_percent,
-  const SRPEnvironment *srp)
+  const SRPEnvironment* srp,
+  const LocalCelestialInformation* local_celes_info)
   : ComponentBase(prescaler,clock_gen), id_(id),
     q_b2c_(q_b2c), detectable_angle_rad_(detectable_angle_rad), intensity_lower_threshold_percent_(intensity_lower_threshold_percent),
-    srp_(srp)
+    srp_(srp), local_celes_info_(local_celes_info)
 {
   Initialize(nr_stddev_c,nr_bias_stddev_c);
 }
@@ -36,10 +37,11 @@ SunSensor::SunSensor(
   const double nr_stddev_c,
   const double nr_bias_stddev_c,
   const double intensity_lower_threshold_percent,
-  const SRPEnvironment *srp)
+  const SRPEnvironment* srp,
+  const LocalCelestialInformation* local_celes_info)
   : ComponentBase(prescaler,clock_gen), id_(id),
     q_b2c_(q_b2c), detectable_angle_rad_(detectable_angle_rad), intensity_lower_threshold_percent_(intensity_lower_threshold_percent),
-    srp_(srp)
+    srp_(srp), local_celes_info_(local_celes_info)
 {
   Initialize(nr_stddev_c,nr_bias_stddev_c);
 }
@@ -57,7 +59,9 @@ void SunSensor::Initialize(const double nr_stddev_c,const double nr_bias_stddev_
 }
 void SunSensor::MainRoutine(int count)
 {
-  measure(srp_->GetSunDirectionFromSC_b(), srp_->GetShadowFunction());
+  Vector<3> sun_pos_b = local_celes_info_->GetPosFromSC_b("SUN");
+  Vector<3> sun_dir_b = normalize(sun_pos_b);
+  measure(sun_dir_b, srp_->GetShadowFunction());
 }
 
 void SunSensor::measure(const Vector<3>& sun_b)

--- a/src/Component/AOCS/SunSensor.cpp
+++ b/src/Component/AOCS/SunSensor.cpp
@@ -102,44 +102,6 @@ void SunSensor::measure(const Vector<3>& sun_b)
   CalcSolarIlluminance();
 }
 
-void SunSensor::measure(const Vector<3>& sun_b, bool is_eclipsed)
-{
-  sun_c_ = q_b2c_.frame_conv(sun_b);    // Frame conversion from body to component
-
-  SunDetectionJudgement(is_eclipsed);  // Judge the sun is inside the FoV
-
-  if (sun_detected_flag_)
-  {
-    alpha_ = atan2(sun_c_[0], sun_c_[2]);
-    beta_ = atan2(sun_c_[1], sun_c_[2]);
-    // Add constant bias noise
-    alpha_ += bias_alpha_;
-    beta_ += bias_beta_;
-
-    // Add Normal random noise
-    alpha_ += nrs_alpha_;
-    beta_ += nrs_beta_;
-
-    // Range [-π/2:π/2]
-    alpha_ = TanRange(alpha_);
-    beta_ = TanRange(beta_);
-
-    measured_sun_c_[0] = tan(alpha_);
-    measured_sun_c_[1] = tan(beta_);
-    measured_sun_c_[2] = 1.0;
-
-    measured_sun_c_ = normalize(measured_sun_c_);
-  }
-  else
-  {
-    measured_sun_c_ = Vector<3>(0);
-    alpha_ = 0.0;
-    beta_ = 0.0;
-  }
-
-  CalcSolarIlluminance();
-}
-
 void SunSensor::SunDetectionJudgement()
 {
   Vector<3> sun_direction_c = normalize(sun_c_);
@@ -156,27 +118,6 @@ void SunSensor::SunDetectionJudgement()
       sun_detected_flag_ = true;
     }
     else{
-      sun_detected_flag_ = false;
-    }
-  }
-}
-
-void SunSensor::SunDetectionJudgement(bool sun_eclipsed)
-{
-  Vector<3> sun_direction_c = normalize(sun_c_);
-
-  double sun_angle_ = acos(sun_direction_c[2]);
-
-  if (sun_eclipsed)
-  {
-    sun_detected_flag_ = false;
-  }
-  else {
-    if (sun_angle_ < detectable_angle_rad_)
-    {
-      sun_detected_flag_ = true;
-    }
-    else {
       sun_detected_flag_ = false;
     }
   }

--- a/src/Component/AOCS/SunSensor.h
+++ b/src/Component/AOCS/SunSensor.h
@@ -76,7 +76,7 @@ protected:
  
   // functions
   void SunDetectionJudgement();
-  void measure(const libra::Vector<3>& sun_b);
+  void measure();
   double TanRange(double x);
   void Initialize(const double nr_stddev_c,const double nr_bias_stddev_c);
   void CalcSolarIlluminance();

--- a/src/Component/AOCS/SunSensor.h
+++ b/src/Component/AOCS/SunSensor.h
@@ -76,9 +76,7 @@ protected:
  
   // functions
   void SunDetectionJudgement();
-  void SunDetectionJudgement(bool sun_eclipsed); // This function is old version, but retained for backward compatibility
   void measure(const libra::Vector<3>& sun_b);
-  void measure(const libra::Vector<3>& sun_b, bool sun_eclipsed); // This function is old version, but retained for backward compatibility
   double TanRange(double x);
   void Initialize(const double nr_stddev_c,const double nr_bias_stddev_c);
   void CalcSolarIlluminance();

--- a/src/Component/AOCS/SunSensor.h
+++ b/src/Component/AOCS/SunSensor.h
@@ -2,6 +2,7 @@
 #define __SunSensor_H__
 
 #include <Environment/Local/SRPEnvironment.h>
+#include <Environment/Local/LocalCelestialInformation.h>
 #include <Library/math/Vector.hpp>
 #include <Library/math/NormalRand.hpp>
 #include <Library/math/Quaternion.hpp>
@@ -20,7 +21,8 @@ public:
     const double nr_stddev_c,
     const double nr_bias_stddev_c,
     const double intensity_lower_threshold_percent,
-    const SRPEnvironment *srp
+    const SRPEnvironment* srp,
+    const LocalCelestialInformation* local_celes_info 
   );
   SunSensor(
     const int prescaler,
@@ -32,7 +34,8 @@ public:
     const double nr_stddev_c,
     const double nr_bias_stddev_c,
     const double intensity_lower_threshold_percent,
-    const SRPEnvironment *srp
+    const SRPEnvironment* srp,
+    const LocalCelestialInformation* local_celes_info
   );
 
   //ComponentBase override function
@@ -68,7 +71,8 @@ protected:
   double bias_beta_=0.0; // Normal random for bias
 
   // Measured variables
-  const SRPEnvironment *srp_;
+  const SRPEnvironment* srp_;
+  const LocalCelestialInformation* local_celes_info_;
  
   // functions
   void SunDetectionJudgement();

--- a/src/Component/Power/SAP.cpp
+++ b/src/Component/Power/SAP.cpp
@@ -10,17 +10,20 @@ SAP::SAP(ClockGenerator* clock_gen,
   libra::Vector<3> normal_vector,
   double cell_efficiency,
   double transmission_efficiency,
-  const SRPEnvironment* srp)
+  const SRPEnvironment* srp,
+  const LocalCelestialInformation* local_celes_info)
   :ComponentBase(1000,clock_gen), id_(id), number_of_series_(number_of_series), number_of_parallel_(number_of_parallel),
   cell_area_(cell_area), normal_vector_(libra::normalize(normal_vector)), cell_efficiency_(cell_efficiency),
-  transmission_efficiency_(transmission_efficiency),srp_(srp)
+  transmission_efficiency_(transmission_efficiency),srp_(srp), local_celes_info_(local_celes_info)
 {
+  voltage_ = 0.0;
+  power_generation_ = 0.0;
 }
 
 SAP::SAP(const SAP &obj)
   :ComponentBase(obj), id_(obj.id_), number_of_series_(obj.number_of_series_), number_of_parallel_(obj.number_of_parallel_),
   cell_area_(obj.cell_area_), normal_vector_(obj.normal_vector_), cell_efficiency_(obj.cell_efficiency_),
-  transmission_efficiency_(obj.transmission_efficiency_),srp_(obj.srp_)
+  transmission_efficiency_(obj.transmission_efficiency_),srp_(obj.srp_), local_celes_info_(obj.local_celes_info_)
 {
   voltage_ = 0.0;
   power_generation_ = 0.0;
@@ -68,10 +71,10 @@ void SAP::MainRoutine(int time_count)
   else
   {
     const auto power_density = srp_->CalcPowerDensity();
-    libra::Vector<3> sun_direction = srp_->GetSunDirectionFromSC_b();
-    libra::Vector<3> normalized_sun_direction = libra::normalize(sun_direction);
+    libra::Vector<3> sun_pos_b = local_celes_info_->GetPosFromSC_b("SUN");
+    libra::Vector<3> sun_dir_b = libra::normalize(sun_pos_b);
     power_generation_ = cell_efficiency_ * transmission_efficiency_ * power_density * cell_area_ * number_of_parallel_ * number_of_series_ *
-      inner_product(normal_vector_, normalized_sun_direction); //仮の実装．実際は太陽方向などからIVカーブを更新．動作電圧に応じた発電電力を求める
+      inner_product(normal_vector_, sun_dir_b); //仮の実装．実際は太陽方向などからIVカーブを更新．動作電圧に応じた発電電力を求める
   }
   if (power_generation_ < 0) power_generation_ = 0.0;
 }

--- a/src/Component/Power/SAP.h
+++ b/src/Component/Power/SAP.h
@@ -5,6 +5,7 @@
 #include <Library/math/Vector.hpp>
 #include <Environment/Local/LocalCelestialInformation.h>
 #include <Environment/Local/SRPEnvironment.h>
+#include <Environment/Local/LocalCelestialInformation.h>
 
 class SAP : public ComponentBase, public ILoggable
 {
@@ -17,7 +18,8 @@ public:
     libra::Vector<3> normal_vector,
     double cell_efficiency,
     double transmission_efficiency,
-    const SRPEnvironment* srp);
+    const SRPEnvironment* srp,
+    const LocalCelestialInformation* local_celes_info);
   SAP(const SAP &obj);
   ~SAP();
   double GetPowerGeneration() const;
@@ -36,6 +38,7 @@ private:
   const double cell_efficiency_;
   const double transmission_efficiency_; //各種損失を考慮したPCUへの伝達効率
   const SRPEnvironment* const srp_;
+  const LocalCelestialInformation* local_celes_info_;
   double voltage_; //[V]
   double power_generation_; //[W]
   /* 他にIV曲線を決めるために必要なパラメータなど

--- a/src/Environment/Global/CelestialInformation.h
+++ b/src/Environment/Global/CelestialInformation.h
@@ -28,9 +28,11 @@ public:
   // GET FUNCTIONS
   Vector<3> GetPosFromCenter_i(const int id) const;
   Vector<3> GetVelFromCenter_i(const int id) const;
+  Vector<3> GetRadii(const int id) const;
   Vector<3> GetPosFromCenter_i(const char* body_name) const;
   Vector<3> GetVelFromCenter_i(const char* body_name) const;
   double GetGravityConstant(const char* body_name) const;
+  Vector<3> GetRadii(const char* body_name) const;
   inline int GetNumBody(void) const{return num_of_selected_body_;}
   inline int* GetSelectedBody(void) const{return selected_body_;}
   int CalcBodyIdFromName(const char* body_name) const;
@@ -53,10 +55,11 @@ private:
   std::string center_obj_;         //center object. Default = "EARTH"
   RotationMode rotation_mode_;   //designation of dynamics model. Default = "Full"
 
-  // Global Information. POS:[m], VEL:[m/s], GRAVITY CONSTANT (G*M):[m^3/s^2]
+  // Global Information. POS:[m], VEL:[m/s], GRAVITY CONSTANT (G*M):[m^3/s^2], RADIUS:[m]
   double* celes_objects_pos_from_center_i_;
   double* celes_objects_vel_from_center_i_;
   double* celes_objects_gravity_constant_;
+  double* celes_objects_radius_m_;
 
   // Rotational Motion of each planets 
   CelestialRotation* EarthRotation_;

--- a/src/Environment/Global/CelestialInformation.h
+++ b/src/Environment/Global/CelestialInformation.h
@@ -32,7 +32,8 @@ public:
   Vector<3> GetPosFromCenter_i(const char* body_name) const;
   Vector<3> GetVelFromCenter_i(const char* body_name) const;
   double GetGravityConstant(const char* body_name) const;
-  Vector<3> GetRadii(const char* body_name) const;
+  Vector<3> GetRadiiFromName(const char* body_name) const;
+  double GetMeanRadiusFromName(const char* body_name) const;
   inline int GetNumBody(void) const{return num_of_selected_body_;}
   inline int* GetSelectedBody(void) const{return selected_body_;}
   int CalcBodyIdFromName(const char* body_name) const;
@@ -55,11 +56,17 @@ private:
   std::string center_obj_;         //center object. Default = "EARTH"
   RotationMode rotation_mode_;   //designation of dynamics model. Default = "Full"
 
-  // Global Information. POS:[m], VEL:[m/s], GRAVITY CONSTANT (G*M):[m^3/s^2], RADIUS:[m]
+  // Global Information. POS:[m], VEL:[m/s], GRAVITY CONSTANT (G*M):[m^3/s^2]
   double* celes_objects_pos_from_center_i_;
   double* celes_objects_vel_from_center_i_;
   double* celes_objects_gravity_constant_;
-  double* celes_objects_radius_m_;
+  // 3 axis planetographic radii.
+  // X-axis pass through the 0 degree latitude 0 degree longitude direction
+  // Z-axis pass through the 90 degree latitude direction
+  // Y-axis equal to the cross product of the unit Z-axis and X-axis vectors
+  double* celes_objects_planetographic_radii_m_;
+  // Mean radius: r = (rx * ry * rz)^(1/3)
+  double* celes_objects_mean_radius_m_;
 
   // Rotational Motion of each planets 
   CelestialRotation* EarthRotation_;

--- a/src/Environment/Local/LocalEnvironment.cpp
+++ b/src/Environment/Local/LocalEnvironment.cpp
@@ -27,9 +27,9 @@ void LocalEnvironment::Initialize(SimulationConfig* sim_config, const GlobalEnvi
   sim_config->main_logger_->CopyFileToLogDir(ini_fname);
   // Initialize
   mag_     = new MagEnvironment(InitMagEnvironment(ini_fname));
-  srp_        = new SRPEnvironment(InitSRPEnvironment(ini_fname));
   atmosphere_ = new Atmosphere(InitAtmosphere(ini_fname));
   celes_info_ = new LocalCelestialInformation(&(glo_env->GetCelesInfo()));
+  srp_ = new SRPEnvironment(InitSRPEnvironment(ini_fname, celes_info_));
   // Log setting for Local celestial information
   IniAccess conf = IniAccess(ini_fname);
   celes_info_->IsLogEnabled = conf.ReadEnable("LOCAL_CELESTIAL_INFORMATION", LOG_LABEL);
@@ -50,7 +50,7 @@ void LocalEnvironment::Update(const Dynamics* dynamics, const SimTime* sim_time)
   if (sim_time->GetOrbitPropagateFlag()) {
     Vector<3> v1 = celes_info_->GetPosFromSC_b("EARTH");
     Vector<3> v2 = celes_info_->GetPosFromSC_b("SUN");
-    srp_->UpdateAllStates(v1, v2);
+    srp_->UpdateAllStates();
     atmosphere_->CalcAirDensity(sim_time->GetCurrentDecyear(), sim_time->GetEndSec(), orbit.GetLatLonAlt());
   }  
 }

--- a/src/Environment/Local/SRPEnvironment.cpp
+++ b/src/Environment/Local/SRPEnvironment.cpp
@@ -83,7 +83,7 @@ string SRPEnvironment::GetLogValue() const
 
 void SRPEnvironment::CalcShadowCoefficient(string shadow_source_name)
 {
-  if (shadow_source_name.c_str() == "SUN")
+  if (shadow_source_name == "SUN")
   {
     shadow_coefficient_ = 1.0;
     return;

--- a/src/Environment/Local/SRPEnvironment.cpp
+++ b/src/Environment/Local/SRPEnvironment.cpp
@@ -73,15 +73,11 @@ string SRPEnvironment::GetLogValue() const
 
 void SRPEnvironment::CalcShadowFunction(const char* shadow_source_name)
 {
-  Vector<3> r_sc2sun_eci = local_celes_info_->GetPosFromSC_i("SUN");
-  Vector<3> r_sc2source_eci = local_celes_info_->GetPosFromSC_i(shadow_source_name);
+  const Vector<3> r_sc2sun_eci = local_celes_info_->GetPosFromSC_i("SUN");
+  const Vector<3> r_sc2source_eci = local_celes_info_->GetPosFromSC_i(shadow_source_name);
 
-  Vector<3> sun_radii_m = local_celes_info_->GetGlobalInfo().GetRadii("SUN");
-  Vector<3> source_radii_m = local_celes_info_->GetGlobalInfo().GetRadii(shadow_source_name);
-  // Convert 3D radii to a mean radius
-  double sun_radius_m = pow(sun_radii_m[0] * sun_radii_m[1] * sun_radii_m[2], 1.0 / 3.0);
-  double source_radius_m = pow(source_radii_m[0] * source_radii_m[1] * source_radii_m[2], 1.0 / 3.0);
-
+  const double sun_radius_m = local_celes_info_->GetGlobalInfo().GetMeanRadiusFromName("SUN");
+  const double source_radius_m = local_celes_info_->GetGlobalInfo().GetMeanRadiusFromName(shadow_source_name);
   double distance_sat_to_sun = norm(r_sc2sun_eci);
   pressure_ = solar_constant_ / c_ / pow(distance_sat_to_sun / astronomical_unit_, 2.0);
   double sd_sun = asin(sun_radius_m / distance_sat_to_sun);        //Apparent radius of the sun

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -18,8 +18,8 @@ public:
   double CalcPowerDensity() const;          //Get solar power per unit area considering eclipse [W/m^2]
   double GetPressure() const;               //Get solar pressure without eclipse effect [N/m^2]
   double GetSolarConstant() const;          //Get solar constant value [W/m^2]
-  double GetShadowFunction() const;         //Get Shadow function
-  inline bool GetIsEclipsed() const { return(shadow_function_ >= 1.0 ? false : true); } //Returns true if the shadow function is less than 1
+  double GetShadowCoefficient() const;         //Get Shadow function
+  inline bool GetIsEclipsed() const { return(shadow_coefficient_ >= 1.0 ? false : true); } //Returns true if the shadow function is less than 1
 
   virtual std::string GetLogHeader() const; //log of header
   virtual std::string GetLogValue() const;  //log of value
@@ -29,14 +29,13 @@ private:
   double astronomical_unit_;     //1AU [m]
   double c_;                     //speed of light [m/s]
   double solar_constant_;        //solar constant [W/m^2]
-  double shadow_function_ = 1.0; //shadow function
+  double shadow_coefficient_ = 1.0; //shadow function
   double sun_radius_m_;
-  double source_radius_m_;
   std::string shadow_source_name_;
 
   LocalCelestialInformation* local_celes_info_;
 
-  void CalcShadowFunction();
+  void CalcShadowCoefficient(std::string shadow_source_name);
 };
 
 #endif /* SRPEnvironment_h */

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -13,9 +13,9 @@ public:
 
   SRPEnvironment(LocalCelestialInformation* local_celes_info);   //Default constructor
   void UpdateAllStates();
-  double CalcTruePressure() const;          //Obtaining solar radiation pressure that takes into account eclipse
+  double CalcTruePressure() const;          //Obtaining solar radiation pressure that takes into account eclipse [N/m^2]
   double CalcPowerDensity() const;          //Get solar power per unit area considering eclipse [W/m^2]
-  double GetPressure() const;               //Get pressure_(for debug)
+  double GetPressure() const;               //Get solar pressure without eclipse effect [N/m^2]
   double GetSolarConstant() const;          //Get solar constant value [W/m^2]
   double GetShadowFunction() const;         //Get Shadow function
   inline bool GetIsEclipsed() const { return(shadow_function_ >= 1.0 ? false : true); } //Returns true if the shadow function is less than 1

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -34,7 +34,7 @@ private:
 
   LocalCelestialInformation* local_celes_info_;
 
-  void CalcShadowFunction(double a, double b, double c, double x, double y);
+  void CalcShadowFunction(const char* shadow_source_name);
 };
 
 #endif /* SRPEnvironment_h */

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -11,7 +11,7 @@ class SRPEnvironment : public ILoggable
 public:
   bool IsCalcEnabled = true;
 
-  SRPEnvironment(LocalCelestialInformation* local_celes_info);   //Default constructor
+  SRPEnvironment(LocalCelestialInformation* local_celes_info, std::string shadow_source_name);   //Default constructor
   void UpdateAllStates();
   void UpdatePressure();
   double CalcTruePressure() const;          //Obtaining solar radiation pressure that takes into account eclipse [N/m^2]
@@ -30,10 +30,13 @@ private:
   double c_;                     //speed of light [m/s]
   double solar_constant_;        //solar constant [W/m^2]
   double shadow_function_ = 1.0; //shadow function
+  double sun_radius_m_;
+  double source_radius_m_;
+  std::string shadow_source_name_;
 
   LocalCelestialInformation* local_celes_info_;
 
-  void CalcShadowFunction(const char* shadow_source_name);
+  void CalcShadowFunction();
 };
 
 #endif /* SRPEnvironment_h */

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -2,6 +2,8 @@
 #define __SRPEnvironment_h__
 #include <Library/math/Vector.hpp>
 #include <Interface/LogOutput/ILoggable.h>
+#include <Environment/Local/LocalCelestialInformation.h>
+
 using libra::Vector;
 
 class SRPEnvironment : public ILoggable
@@ -9,28 +11,28 @@ class SRPEnvironment : public ILoggable
 public:
   bool IsCalcEnabled = true;
 
-  SRPEnvironment();																//デフォルトコンストラクタ
-  void UpdateAllStates(Vector<3>& earth_position_b, Vector<3>& sun_position_b);	//状態を更新、引数は地球中心までのベクトルと太陽中心までのベクトル、単位はm
-  double CalcTruePressure() const;														//蝕も考慮した太陽輻射圧を取得
-  double CalcPowerDensity() const;                  //Get solar power per unit area considering eclipse [W/m^2]
-  double GetPressure() const;															//pressure_を取得(デバッグ用)
-  double GetSolarConstant() const;                  //Get solar constant value [W/m^2]
+  SRPEnvironment();                //Default constructor
+  void UpdateAllStates(Vector<3>& earth_position_b, Vector<3>& sun_position_b);
+  double CalcTruePressure() const;          //Obtaining solar radiation pressure that takes into account eclipse
+  double CalcPowerDensity() const;          //Get solar power per unit area considering eclipse [W/m^2]
+  double GetPressure() const;               //Get pressure_(for debug)
+  double GetSolarConstant() const;          //Get solar constant value [W/m^2]
   inline Vector<3> GetSunDirectionFromSC_b() const{return d_sc2sun_b_;}
   double GetShadowFunction() const;                 //Get Shadow function
   inline bool GetIsEclipsed() const { return(shadow_function_ >= 1.0 ? false : true); } //Returns true if the shadow function is less than 1
 
-  virtual std::string GetLogHeader() const;													//ログofヘッダー
-  virtual std::string GetLogValue() const;														//ログof値
+  virtual std::string GetLogHeader() const; //log of header
+  virtual std::string GetLogValue() const;  //log of value
 
 private:
-  double pressure_;																//太陽輻射定数、単位はN/m^2
-  double astronomical_unit_;														//1天文単位、単位はm
-  double c_;																		//光速、単位はm/s
-  double solar_constant_;															//太陽定数、単位はW/m^2
-  double r_earth_;																//地球半径、単位はm
-  double r_sun_;																	//太陽半径、単位はm
-  Vector<3> d_sc2sun_b_;  //Direction Vector from SC to Sun in the body frame
-  double shadow_function_ = 1.0;                                     //shadow function
+  double pressure_;              //solar radiation constant [N/m^2]
+  double astronomical_unit_;     //1AU [m]
+  double c_;                     //speed of light [m/s]
+  double solar_constant_;        //solar constant [W/m^2]
+  double r_earth_;               //radius of earth [m]
+  double r_sun_;                 //radius of sun [m]
+  Vector<3> d_sc2sun_b_;         //Direction Vector from SC to Sun in the body frame
+  double shadow_function_ = 1.0; //shadow function
 
   void CalcShadowFunction(double a, double b, double c, double x, double y);
 };

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -28,8 +28,6 @@ private:
   double astronomical_unit_;     //1AU [m]
   double c_;                     //speed of light [m/s]
   double solar_constant_;        //solar constant [W/m^2]
-  double r_earth_;               //radius of earth [m]
-  double r_sun_;                 //radius of sun [m]
   double shadow_function_ = 1.0; //shadow function
 
   LocalCelestialInformation* local_celes_info_;

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -11,14 +11,13 @@ class SRPEnvironment : public ILoggable
 public:
   bool IsCalcEnabled = true;
 
-  SRPEnvironment();                //Default constructor
-  void UpdateAllStates(Vector<3>& earth_position_b, Vector<3>& sun_position_b);
+  SRPEnvironment(LocalCelestialInformation* local_celes_info);   //Default constructor
+  void UpdateAllStates();
   double CalcTruePressure() const;          //Obtaining solar radiation pressure that takes into account eclipse
   double CalcPowerDensity() const;          //Get solar power per unit area considering eclipse [W/m^2]
   double GetPressure() const;               //Get pressure_(for debug)
   double GetSolarConstant() const;          //Get solar constant value [W/m^2]
-  inline Vector<3> GetSunDirectionFromSC_b() const{return d_sc2sun_b_;}
-  double GetShadowFunction() const;                 //Get Shadow function
+  double GetShadowFunction() const;         //Get Shadow function
   inline bool GetIsEclipsed() const { return(shadow_function_ >= 1.0 ? false : true); } //Returns true if the shadow function is less than 1
 
   virtual std::string GetLogHeader() const; //log of header
@@ -31,8 +30,9 @@ private:
   double solar_constant_;        //solar constant [W/m^2]
   double r_earth_;               //radius of earth [m]
   double r_sun_;                 //radius of sun [m]
-  Vector<3> d_sc2sun_b_;         //Direction Vector from SC to Sun in the body frame
   double shadow_function_ = 1.0; //shadow function
+
+  LocalCelestialInformation* local_celes_info_;
 
   void CalcShadowFunction(double a, double b, double c, double x, double y);
 };

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -11,7 +11,7 @@ class SRPEnvironment : public ILoggable
 public:
   bool IsCalcEnabled = true;
 
-  SRPEnvironment(LocalCelestialInformation* local_celes_info, std::string shadow_source_name);   //Default constructor
+  SRPEnvironment(LocalCelestialInformation* local_celes_info);   //Default constructor
   void UpdateAllStates();
   void UpdatePressure();
   double CalcTruePressure() const;          //Obtaining solar radiation pressure that takes into account eclipse [N/m^2]

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -13,6 +13,7 @@ public:
 
   SRPEnvironment(LocalCelestialInformation* local_celes_info);   //Default constructor
   void UpdateAllStates();
+  void UpdatePressure();
   double CalcTruePressure() const;          //Obtaining solar radiation pressure that takes into account eclipse [N/m^2]
   double CalcPowerDensity() const;          //Get solar power per unit area considering eclipse [W/m^2]
   double GetPressure() const;               //Get solar pressure without eclipse effect [N/m^2]

--- a/src/Interface/InitInput/InitComponent/InitSAP.cpp
+++ b/src/Interface/InitInput/InitComponent/InitSAP.cpp
@@ -3,7 +3,7 @@
 #include "../Initialize.h"
 #include <Component/Power/SAP.h>
 
-SAP InitSAP(ClockGenerator* clock_gen, int sap_id, const std::string fname, const SRPEnvironment* srp) {
+SAP InitSAP(ClockGenerator* clock_gen, int sap_id, const std::string fname, const SRPEnvironment* srp, const LocalCelestialInformation* local_celes_info) {
 
   IniAccess sap_conf(fname);
 
@@ -31,7 +31,7 @@ SAP InitSAP(ClockGenerator* clock_gen, int sap_id, const std::string fname, cons
   double transmission_efficiency;
   transmission_efficiency = sap_conf.ReadDouble(Section, "transmission_efficiency");
 
-  SAP sap(clock_gen, sap_id, number_of_series, number_of_parallel, cell_area, normal_vector, cell_efficiency, transmission_efficiency, srp);
+  SAP sap(clock_gen, sap_id, number_of_series, number_of_parallel, cell_area, normal_vector, cell_efficiency, transmission_efficiency, srp, local_celes_info);
 
   return sap;
 }

--- a/src/Interface/InitInput/InitComponent/InitSunSensor.cpp
+++ b/src/Interface/InitInput/InitComponent/InitSunSensor.cpp
@@ -2,7 +2,7 @@
 #include "../Initialize.h"
 #include <Component/AOCS/SunSensor.h>
 
-SunSensor InitSunSensor(ClockGenerator* clock_gen, int ss_id, std::string file_name, const SRPEnvironment* srp)
+SunSensor InitSunSensor(ClockGenerator* clock_gen, int ss_id, std::string file_name, const SRPEnvironment* srp, const LocalCelestialInformation* local_celes_info)
 {
   IniAccess ss_conf(file_name);
   const std::string st_ss_id = std::to_string(static_cast<long long>(ss_id));
@@ -31,11 +31,11 @@ SunSensor InitSunSensor(ClockGenerator* clock_gen, int ss_id, std::string file_n
   double intensity_lower_threshold_percent;
   intensity_lower_threshold_percent = ss_conf.ReadDouble(Section, "intensity_lower_threshold_percent");
 
-  SunSensor ss(prescaler, clock_gen, ss_id, q_b2c, detectable_angle_rad, nr_stddev, nr_bias_stddev, intensity_lower_threshold_percent, srp);
+  SunSensor ss(prescaler, clock_gen, ss_id, q_b2c, detectable_angle_rad, nr_stddev, nr_bias_stddev, intensity_lower_threshold_percent, srp, local_celes_info);
   return ss;
 }
 
-SunSensor InitSunSensor(ClockGenerator* clock_gen, PowerPort* power_port, int ss_id, std::string file_name, const SRPEnvironment* srp)
+SunSensor InitSunSensor(ClockGenerator* clock_gen, PowerPort* power_port, int ss_id, std::string file_name, const SRPEnvironment* srp, const LocalCelestialInformation* local_celes_info)
 {
   IniAccess ss_conf(file_name);
   const std::string st_ss_id = std::to_string(static_cast<long long>(ss_id));
@@ -64,6 +64,6 @@ SunSensor InitSunSensor(ClockGenerator* clock_gen, PowerPort* power_port, int ss
   double intensity_lower_threshold_percent;
   intensity_lower_threshold_percent = ss_conf.ReadDouble(Section, "intensity_lower_threshold_percent");
 
-  SunSensor ss(prescaler, clock_gen, power_port, ss_id, q_b2c, detectable_angle_rad, nr_stddev, nr_bias_stddev, intensity_lower_threshold_percent, srp);
+  SunSensor ss(prescaler, clock_gen, power_port, ss_id, q_b2c, detectable_angle_rad, nr_stddev, nr_bias_stddev, intensity_lower_threshold_percent, srp, local_celes_info);
   return ss;
 }

--- a/src/Interface/InitInput/Init_Environment.cpp
+++ b/src/Interface/InitInput/Init_Environment.cpp
@@ -27,9 +27,8 @@ SRPEnvironment InitSRPEnvironment(std::string ini_path, LocalCelestialInformatio
 {
   auto conf = IniAccess(ini_path);
   const char* section = "SRP";
-  std::string shadow_source_name = conf.ReadString(section, "shadow_source_name");
 
-  SRPEnvironment srp_env(local_celes_info, shadow_source_name);
+  SRPEnvironment srp_env(local_celes_info);
   srp_env.IsCalcEnabled = conf.ReadEnable(section, CALC_LABEL);
   srp_env.IsLogEnabled = conf.ReadEnable(section, LOG_LABEL);
 

--- a/src/Interface/InitInput/Init_Environment.cpp
+++ b/src/Interface/InitInput/Init_Environment.cpp
@@ -27,8 +27,9 @@ SRPEnvironment InitSRPEnvironment(std::string ini_path, LocalCelestialInformatio
 {
   auto conf = IniAccess(ini_path);
   const char* section = "SRP";
+  std::string shadow_source_name = conf.ReadString(section, "shadow_source_name");
 
-  SRPEnvironment srp_env(local_celes_info);
+  SRPEnvironment srp_env(local_celes_info, shadow_source_name);
   srp_env.IsCalcEnabled = conf.ReadEnable(section, CALC_LABEL);
   srp_env.IsLogEnabled = conf.ReadEnable(section, LOG_LABEL);
 

--- a/src/Interface/InitInput/Init_Environment.cpp
+++ b/src/Interface/InitInput/Init_Environment.cpp
@@ -23,12 +23,12 @@ MagEnvironment InitMagEnvironment(std::string ini_path)
   return mag_env;
 }
 
-SRPEnvironment InitSRPEnvironment(std::string ini_path)
+SRPEnvironment InitSRPEnvironment(std::string ini_path, LocalCelestialInformation* local_celes_info)
 {
   auto conf = IniAccess(ini_path);
   const char* section = "SRP";
 
-  SRPEnvironment srp_env;
+  SRPEnvironment srp_env(local_celes_info);
   srp_env.IsCalcEnabled = conf.ReadEnable(section, CALC_LABEL);
   srp_env.IsLogEnabled = conf.ReadEnable(section, LOG_LABEL);
 

--- a/src/Interface/InitInput/Initialize.h
+++ b/src/Interface/InitInput/Initialize.h
@@ -53,7 +53,7 @@ class Atmosphere;
 class LocalCelestialInformation;
 class LocalEnvironment;
 MagEnvironment InitMagEnvironment(std::string ini_path);
-SRPEnvironment InitSRPEnvironment(std::string ini_path);
+SRPEnvironment InitSRPEnvironment(std::string ini_path, LocalCelestialInformation* local_celes_info);
 Atmosphere InitAtmosphere(std::string ini_path);
 
 //Dynamics
@@ -109,15 +109,15 @@ RWModel InitRWModel(ClockGenerator* clock_gen, int actuator_id, std::string file
 RWModel InitRWModel(ClockGenerator* clock_gen, PowerPort* power_port, int actuator_id, std::string file_name, double prop_step, double compo_update_step);
 STT InitSTT(ClockGenerator* clock_gen, int sensor_id, const std::string fname, double compo_step_time, const Dynamics *dynamics, const LocalEnvironment* local_env);
 STT InitSTT(ClockGenerator* clock_gen, PowerPort* power_port, int sensor_id, const std::string fname, double compo_step_time, const Dynamics *dynamics, const LocalEnvironment* local_env);
-SunSensor InitSunSensor(ClockGenerator* clock_gen, int sensor_id, const std::string fname, const SRPEnvironment* srp);
-SunSensor InitSunSensor(ClockGenerator* clock_gen, PowerPort* power_port, int sensor_id, const std::string fname, const SRPEnvironment* srp);
+SunSensor InitSunSensor(ClockGenerator* clock_gen, int sensor_id, const std::string fname, const SRPEnvironment* srp, const LocalCelestialInformation* local_celes_info);
+SunSensor InitSunSensor(ClockGenerator* clock_gen, PowerPort* power_port, int sensor_id, const std::string fname, const SRPEnvironment* srp, const LocalCelestialInformation* local_celes_info);
 GNSSReceiver InitGNSSReceiver(ClockGenerator* clock_gen, int id, const std::string fname, const Dynamics* dynamics, const GnssSatellites* gnss_satellites, const SimTime* simtime);
 GNSSReceiver InitGNSSReceiver(ClockGenerator* clock_gen, PowerPort* power_port, int id, const std::string fname, const Dynamics* dynamics, const GnssSatellites* gnss_satellites, const SimTime* simtime);
 SimpleThruster InitSimpleThruster(ClockGenerator* clock_gen, int thruster_id, const std::string fname, const Structure* structure, const Dynamics* dynamics);
 SimpleThruster InitSimpleThruster(ClockGenerator* clock_gen, PowerPort* power_port, int thruster_id, const std::string fname, const Structure* structure, const Dynamics* dynamics);
 
 BAT InitBAT(ClockGenerator* clock_gen, int bat_id, const std::string fname);
-SAP InitSAP(ClockGenerator* clock_gen, int sap_id, const std::string fname, const SRPEnvironment* srp);
+SAP InitSAP(ClockGenerator* clock_gen, int sap_id, const std::string fname, const SRPEnvironment* srp, const LocalCelestialInformation* local_celes_info);
 EMDS InitEMDS(int actuator_id);
 UWBSensor InitUWBSensor(int sensor_id);
 ANT InitANT(int ant_id, const std::string fname);

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
@@ -38,7 +38,7 @@ SampleComponents::SampleComponents(
   // SunSensor
   ini_path = iniAccess.ReadString("COMPONENTS_FILE", "ss_file");
   config_->main_logger_->CopyFileToLogDir(ini_path);
-  sun_sensor_ = new SunSensor(InitSunSensor(clock_gen, pcu_->GetPowerPort(2), 1, ini_path, &(local_env_->GetSrp())));
+  sun_sensor_ = new SunSensor(InitSunSensor(clock_gen, pcu_->GetPowerPort(2), 1, ini_path, &(local_env_->GetSrp()), &(local_env_->GetCelesInfo())));
   // GNSS-R
   ini_path = iniAccess.ReadString("COMPONENTS_FILE", "gnss_file");
   config_->main_logger_->CopyFileToLogDir(ini_path);


### PR DESCRIPTION
## Overview
In the `UpdateAll` function of the `SRPEnvironment` class, the position of each object is handled in the inertial frame instead of the body frame.

## Issue
- https://github.com/ut-issl/s2e-core/issues/25

## Details
The dependency on the `Attitude` class was reduced because the `SRPEnvironment` calculation does not need the information of attitude.

##  Validation results
- Simulation Condition
  + Simulation time: 5400sec
  + Orbit: ISS Orbit
  + Otherwise, the default ini file was used.
- Test results before the change
  + SRP force
![image](https://user-images.githubusercontent.com/93800108/152940714-b92132d3-3458-4a29-b66a-2d9ec8a35af7.png)
  
  + Sun direction detected by the sun sensor
![image](https://user-images.githubusercontent.com/93800108/152940852-f2e90803-8033-4b88-9612-ecc531d7668f.png)
 
  + SAP power generation
![image](https://user-images.githubusercontent.com/93800108/152940948-b1d219b0-56cf-41b4-94d6-96e22ce9dec2.png)

- Test results after the change
  + SRP force
![image](https://user-images.githubusercontent.com/93800108/152940714-b92132d3-3458-4a29-b66a-2d9ec8a35af7.png)
  
  + Sun direction detected by the sun sensor
![image](https://user-images.githubusercontent.com/93800108/152940852-f2e90803-8033-4b88-9612-ecc531d7668f.png)
 
  + SAP power generation
![image](https://user-images.githubusercontent.com/93800108/152940948-b1d219b0-56cf-41b4-94d6-96e22ce9dec2.png)

confirmed that this change did not change the behavior of the simulation.

## Scope of influence
Not only the `SRPEnvironment` code, but also the sun sensor and SAP code that depends on it will be changed. This does not change their behavior.

## Supplement

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
