### PR TITLE
Fix windows ver from `windows-latest` to `windows-2019` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ on:
 jobs:
   build_s2e_win:
     name: Build on Windows
-    runs-on: windows-latest
+    # VS2019 を使うため
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Overview
Fix windows ver from `windows-latest` to `windows-2019` in CI

## Issue
NA

## Details
- We are using VS2019, but the version of windows-latest is being migrated to window 2022 with VS2022
  - ref. https://github.blog/changelog/2021-11-16-github-actions-windows-server-2022-with-visual-studio-2022-is-now-generally-available-on-github-hosted-runners/

##  Validation results
NA
