### PR TITLE
Remove I2C HILS example

### DIFF
--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
@@ -89,9 +89,9 @@ SampleComponents::SampleComponents(const Dynamics* dynamics,
   // obc_, 4, 9600, hils_port_manager_, 0);
   // I2C tutorial. Comment out when not in use.
   // exp_hils_i2c_controller_ = new ExpHilsI2cController(
-  //    30, clock_gen, 5, 115200, 256, 256, hils_port_manager_);
+  // 30, clock_gen, 5, 115200, 256, 256, hils_port_manager_);
   // exp_hils_i2c_target_ =
-  //    new ExpHilsI2cTarget(1, clock_gen, 0, 0x44, obc_, 6, hils_port_manager_);
+  // new ExpHilsI2cTarget(1, clock_gen, 0, 0x44, obc_, 6, hils_port_manager_);
 
   // actuator debug output
   libra::Vector<kMtqDim> mag_moment_c{0.01};

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
@@ -88,10 +88,10 @@ SampleComponents::SampleComponents(const Dynamics* dynamics,
   // hils_port_manager_, 1); exp_hils_uart_sender_ = new ExpHils(clock_gen, 0,
   // obc_, 4, 9600, hils_port_manager_, 0);
   // I2C tutorial. Comment out when not in use.
-  exp_hils_i2c_controller_ = new ExpHilsI2cController(
-      30, clock_gen, 5, 115200, 256, 256, hils_port_manager_);
-  exp_hils_i2c_target_ =
-      new ExpHilsI2cTarget(1, clock_gen, 0, 0x44, obc_, 6, hils_port_manager_);
+  // exp_hils_i2c_controller_ = new ExpHilsI2cController(
+  //    30, clock_gen, 5, 115200, 256, 256, hils_port_manager_);
+  // exp_hils_i2c_target_ =
+  //    new ExpHilsI2cTarget(1, clock_gen, 0, 0x44, obc_, 6, hils_port_manager_);
 
   // actuator debug output
   libra::Vector<kMtqDim> mag_moment_c{0.01};
@@ -113,8 +113,8 @@ SampleComponents::~SampleComponents() {
   delete pcu_;
   // delete exp_hils_uart_responder_;
   // delete exp_hils_uart_sender_;
-  delete exp_hils_i2c_controller_;
-  delete exp_hils_i2c_target_;
+  // delete exp_hils_i2c_controller_;
+  // delete exp_hils_i2c_target_;
   delete obc_;
   delete hils_port_manager_;  // delete after exp_hils
 }

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.h
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.h
@@ -56,8 +56,8 @@ class SampleComponents {
   SimpleThruster* thruster_;
   // ExpHils* exp_hils_uart_responder_;
   // ExpHils* exp_hils_uart_sender_;
-  ExpHilsI2cController* exp_hils_i2c_controller_;
-  ExpHilsI2cTarget* exp_hils_i2c_target_;
+  // ExpHilsI2cController* exp_hils_i2c_controller_;
+  // ExpHilsI2cTarget* exp_hils_i2c_target_;
 
   const SimulationConfig* config_;
   const Dynamics* dynamics_;


### PR DESCRIPTION
## Overview
Remove I2C HILS example

## Issue
NA

## Details
Instances of I2C HILS examples remain and generate many outputs to the console.  
The examples are commented out since the example and outputs are unnecessary for many users.

##  Validation results
I confirmed that the console output is stopped.

## Scope of influence
Small

## Supplement
NA

## Note
NA