### PR TITLE
Fix port closing in CommunicationBase

### DIFF
--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -75,21 +75,21 @@ ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
       break;
     case OBC_COM_UART_MODE::SILS:
       ret = obc_->I2cCloseComPort(sils_port_id_);
+      if(ret != 0) {
       // TODO: Add a flag to select whether to show or hide warnings
-      // if(ret != 0) {
       //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
       //                "CloseComPort ID:"
       //             << sils_port_id_ << "\n";
-      // }
+      }
       break;
     case OBC_COM_UART_MODE::HILS:
       ret = hils_port_manager_->I2cTargetCloseComPort(hils_port_id_);
+      if (ret != 0) {
       // TODO: Add a flag to select whether to show or hide warnings
-      // if (ret != 0) {
       //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
       //                "CloseComPort ID:"
       //             << hils_port_id_ << "\n";
-      // }
+      }
       break;
     default:
       // NOT REACHED

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -75,20 +75,20 @@ ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
       break;
     case OBC_COM_UART_MODE::SILS:
       ret = obc_->I2cCloseComPort(sils_port_id_);
-      if(ret != 0) {
+      if (ret != 0) {
         // TODO: Add a flag to select whether to show or hide warnings
-        //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
-        //                "CloseComPort ID:"
-        //             << sils_port_id_ << "\n";
+        // std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+        //              "CloseComPort ID:"
+        //           << sils_port_id_ << "\n";
       }
       break;
     case OBC_COM_UART_MODE::HILS:
       ret = hils_port_manager_->I2cTargetCloseComPort(hils_port_id_);
       if (ret != 0) {
         // TODO: Add a flag to select whether to show or hide warnings
-        //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
-        //                "CloseComPort ID:"
-        //             << hils_port_id_ << "\n";
+        // std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+        //              "CloseComPort ID:"
+        //           << hils_port_id_ << "\n";
       }
       break;
     default:

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -76,14 +76,16 @@ ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
     case OBC_COM_UART_MODE::SILS:
       ret = obc_->I2cCloseComPort(sils_port_id_);
       if (ret != 0) {
-        std::cout << "Already closed or not used: ObcI2cTargetCommunication CloseComPort ID:"
+        std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+                     "CloseComPort ID:"
                   << sils_port_id_ << "\n";
       }
       break;
     case OBC_COM_UART_MODE::HILS:
       ret = hils_port_manager_->I2cTargetCloseComPort(hils_port_id_);
       if (ret != 0) {
-        std::cout << "Already closed or not used: ObcI2cTargetCommunication CloseComPort ID:"
+        std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+                     "CloseComPort ID:"
                   << hils_port_id_ << "\n";
       }
       break;

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -11,6 +11,7 @@ ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
 #else
   sim_mode_ = OBC_COM_UART_MODE::SILS;
   obc_->I2cConnectPort(sils_port_id_, i2c_address_);
+  std::cout << "default constructor is called" << sils_port_id_ << "\n";
 #endif
 }
 
@@ -52,14 +53,40 @@ ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
   obc_->I2cConnectPort(sils_port_id_, i2c_address_);
 #endif
 }
+/*
+ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
+    const ObcI2cTargetCommunicationBase& obj) {
+  sils_port_id_ = obj.sils_port_id_;
+  hils_port_id_ = obj.hils_port_id_;
+  i2c_address_ = obj.i2c_address_;
+  obc_ = obj.obc_;
+  hils_port_manager_ = obj.hils_port_manager_;
+  std::cout << "copy constructor is called" << sils_port_id_ << "\n";
+}
+*/
+ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
+    ObcI2cTargetCommunicationBase&& obj) noexcept
+    : sils_port_id_(obj.sils_port_id_),
+      hils_port_id_(obj.hils_port_id_),
+      i2c_address_(obj.i2c_address_),
+      obc_(obj.obc_),
+      hils_port_manager_(obj.hils_port_manager_) {
+  obj.is_moved_ = true;
+  std::cout << "move constructor is called" << sils_port_id_ << "\n";
+}
 
 ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
+  if (is_moved_ == true) {
+    std::cout << "keep open" << sils_port_id_ << "\n";
+    return;
+  }
+  std::cout << "close port" << sils_port_id_ << "\n";
   int ret;
   switch (sim_mode_) {
     case OBC_COM_UART_MODE::MODE_ERROR:
       break;
     case OBC_COM_UART_MODE::SILS:
-      ret = obc_->CloseComPort(sils_port_id_);
+      ret = obc_->I2cCloseComPort(sils_port_id_);
       if (ret != 0) {
         std::cout << "Error: ObcI2cTargetCommunication CloseComPort ID:"
                   << sils_port_id_ << "\n";

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -11,7 +11,6 @@ ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
 #else
   sim_mode_ = OBC_COM_UART_MODE::SILS;
   obc_->I2cConnectPort(sils_port_id_, i2c_address_);
-  std::cout << "default constructor is called" << sils_port_id_ << "\n";
 #endif
 }
 
@@ -53,34 +52,23 @@ ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
   obc_->I2cConnectPort(sils_port_id_, i2c_address_);
 #endif
 }
-/*
-ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
-    const ObcI2cTargetCommunicationBase& obj) {
-  sils_port_id_ = obj.sils_port_id_;
-  hils_port_id_ = obj.hils_port_id_;
-  i2c_address_ = obj.i2c_address_;
-  obc_ = obj.obc_;
-  hils_port_manager_ = obj.hils_port_manager_;
-  std::cout << "copy constructor is called" << sils_port_id_ << "\n";
-}
-*/
+
 ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
     ObcI2cTargetCommunicationBase&& obj) noexcept
     : sils_port_id_(obj.sils_port_id_),
       hils_port_id_(obj.hils_port_id_),
       i2c_address_(obj.i2c_address_),
       obc_(obj.obc_),
-      hils_port_manager_(obj.hils_port_manager_) {
+      hils_port_manager_(obj.hils_port_manager_),
+      sim_mode_(obj.sim_mode_) {
   obj.is_moved_ = true;
-  std::cout << "move constructor is called" << sils_port_id_ << "\n";
+  obj.obc_ = nullptr;
+  obj.hils_port_manager_ = nullptr;
 }
 
 ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
-  if (is_moved_ == true) {
-    std::cout << "keep open" << sils_port_id_ << "\n";
-    return;
-  }
-  std::cout << "close port" << sils_port_id_ << "\n";
+  if (is_moved_ == true) return; // prevent double freeing of memory
+
   int ret;
   switch (sim_mode_) {
     case OBC_COM_UART_MODE::MODE_ERROR:

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -75,19 +75,21 @@ ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
       break;
     case OBC_COM_UART_MODE::SILS:
       ret = obc_->I2cCloseComPort(sils_port_id_);
-      if (ret != 0) {
-        std::cout << "Already closed or not used: ObcI2cTargetCommunication "
-                     "CloseComPort ID:"
-                  << sils_port_id_ << "\n";
-      }
+      // TODO: Add a flag to select whether to show or hide warnings
+      // if(ret != 0) {
+      //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+      //                "CloseComPort ID:"
+      //             << sils_port_id_ << "\n";
+      // }
       break;
     case OBC_COM_UART_MODE::HILS:
       ret = hils_port_manager_->I2cTargetCloseComPort(hils_port_id_);
-      if (ret != 0) {
-        std::cout << "Already closed or not used: ObcI2cTargetCommunication "
-                     "CloseComPort ID:"
-                  << hils_port_id_ << "\n";
-      }
+      // TODO: Add a flag to select whether to show or hide warnings
+      // if (ret != 0) {
+      //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+      //                "CloseComPort ID:"
+      //             << hils_port_id_ << "\n";
+      // }
       break;
     default:
       // NOT REACHED

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -67,7 +67,7 @@ ObcI2cTargetCommunicationBase::ObcI2cTargetCommunicationBase(
 }
 
 ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
-  if (is_moved_ == true) return; // prevent double freeing of memory
+  if (is_moved_ == true) return;  // prevent double freeing of memory
 
   int ret;
   switch (sim_mode_) {

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -76,14 +76,14 @@ ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
     case OBC_COM_UART_MODE::SILS:
       ret = obc_->I2cCloseComPort(sils_port_id_);
       if (ret != 0) {
-        std::cout << "Error: ObcI2cTargetCommunication CloseComPort ID:"
+        std::cout << "Already closed or not used: ObcI2cTargetCommunication CloseComPort ID:"
                   << sils_port_id_ << "\n";
       }
       break;
     case OBC_COM_UART_MODE::HILS:
       ret = hils_port_manager_->I2cTargetCloseComPort(hils_port_id_);
       if (ret != 0) {
-        std::cout << "Error: ObcI2cTargetCommunication CloseComPort ID:"
+        std::cout << "Already closed or not used: ObcI2cTargetCommunication CloseComPort ID:"
                   << hils_port_id_ << "\n";
       }
       break;

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -76,19 +76,19 @@ ObcI2cTargetCommunicationBase::~ObcI2cTargetCommunicationBase() {
     case OBC_COM_UART_MODE::SILS:
       ret = obc_->I2cCloseComPort(sils_port_id_);
       if(ret != 0) {
-      // TODO: Add a flag to select whether to show or hide warnings
-      //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
-      //                "CloseComPort ID:"
-      //             << sils_port_id_ << "\n";
+        // TODO: Add a flag to select whether to show or hide warnings
+        //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+        //                "CloseComPort ID:"
+        //             << sils_port_id_ << "\n";
       }
       break;
     case OBC_COM_UART_MODE::HILS:
       ret = hils_port_manager_->I2cTargetCloseComPort(hils_port_id_);
       if (ret != 0) {
-      // TODO: Add a flag to select whether to show or hide warnings
-      //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
-      //                "CloseComPort ID:"
-      //             << hils_port_id_ << "\n";
+        // TODO: Add a flag to select whether to show or hide warnings
+        //   std::cout << "Already closed or not used: ObcI2cTargetCommunication "
+        //                "CloseComPort ID:"
+        //             << hils_port_id_ << "\n";
       }
       break;
     default:

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
@@ -14,8 +14,8 @@ class ObcI2cTargetCommunicationBase {
                                 const unsigned int hils_port_id,
                                 const unsigned char i2c_address, OBC* obc,
                                 HilsPortManager* hils_port_manager);
-  //ObcI2cTargetCommunicationBase(const ObcI2cTargetCommunicationBase& obj); // copy constructor
-  ObcI2cTargetCommunicationBase(ObcI2cTargetCommunicationBase&& obj) noexcept; // move constructor
+  // prevent double freeing of memory when this class is copied
+  ObcI2cTargetCommunicationBase(ObcI2cTargetCommunicationBase&& obj) noexcept;
   ~ObcI2cTargetCommunicationBase();
 
  protected:

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
@@ -14,6 +14,8 @@ class ObcI2cTargetCommunicationBase {
                                 const unsigned int hils_port_id,
                                 const unsigned char i2c_address, OBC* obc,
                                 HilsPortManager* hils_port_manager);
+  //ObcI2cTargetCommunicationBase(const ObcI2cTargetCommunicationBase& obj); // copy constructor
+  ObcI2cTargetCommunicationBase(ObcI2cTargetCommunicationBase&& obj) noexcept; // move constructor
   ~ObcI2cTargetCommunicationBase();
 
  protected:
@@ -30,6 +32,7 @@ class ObcI2cTargetCommunicationBase {
   unsigned int sils_port_id_;
   unsigned int hils_port_id_;
   unsigned char i2c_address_;
+  bool is_moved_ = false;
   OBC_COM_UART_MODE sim_mode_ = OBC_COM_UART_MODE::MODE_ERROR;
 
   OBC* obc_;


### PR DESCRIPTION
## Overview
1.  The SILS port of the I2C emulated components is not closed properly.
2. If the CommunicationBase class is copied, double freeing of memory can occur.

## Issue
https://github.com/ut-issl/s2e-core/issues/66

## Details
### Description
1. In the destructor of ObcI2cTargetCommunicationBase for SILS test, the function `CloseComPort` for UART is used when the function `I2cCloseComPort` for I2C should be used.
2. In UART and I2C CommunicationBase, memory is freed in the destructor. If CommunicationBase class is copied, double freeing of memory can occur.

##  Validation results
Link to tests or validation results.

## Scope of influence
The behavior of CommunicationBase will be change.

## Supplement
NA

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
