### PR TITLE
Add StoreTelemetry function for hils test

### DIFF
--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -150,8 +150,8 @@ int ObcI2cTargetCommunicationBase::GetStoredFrameCounter() {
   return hils_port_manager_->I2cTargetGetStoredFrameCounter(hils_port_id_);
 }
 
-int ObcI2cTargetCommunicationBase::StoreTelemetry(const unsigned int stored_frame_num,
-                                                  const unsigned int tlm_size) {
+int ObcI2cTargetCommunicationBase::StoreTelemetry(
+    const unsigned int stored_frame_num, const unsigned int tlm_size) {
   if (sim_mode_ != OBC_COM_UART_MODE::HILS) return -1;
   int additional_frame_num = stored_frame_num - GetStoredFrameCounter();
   if (additional_frame_num <= 0) return -1;

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.cpp
@@ -149,3 +149,16 @@ int ObcI2cTargetCommunicationBase::GetStoredFrameCounter() {
   if (sim_mode_ != OBC_COM_UART_MODE::HILS) return -1;
   return hils_port_manager_->I2cTargetGetStoredFrameCounter(hils_port_id_);
 }
+
+int ObcI2cTargetCommunicationBase::StoreTelemetry(const unsigned int stored_frame_num,
+                                                  const unsigned int tlm_size) {
+  if (sim_mode_ != OBC_COM_UART_MODE::HILS) return -1;
+  int additional_frame_num = stored_frame_num - GetStoredFrameCounter();
+  if (additional_frame_num <= 0) return -1;
+
+  // store telemetry in converter up to stored_frame_num
+  for (int i = 0; i < additional_frame_num; i++) {
+    SendTelemetry(tlm_size);
+  }
+  return 0;
+}

--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
@@ -25,6 +25,8 @@ class ObcI2cTargetCommunicationBase {
   int ReceiveCommand();
   int SendTelemetry(const unsigned char len);
   int GetStoredFrameCounter();
+  int StoreTelemetry(const unsigned int stored_frame_num,
+                     const unsigned int tlm_size);
 
  private:
   unsigned int sils_port_id_;


### PR DESCRIPTION
## Overview
Add StoreTelemetry function for I2C HILS test.

## Issue
- Related issues

## Details
In order to store some frames of telemetry in the USB-I2C target converter in advance, StoreTelemetry function is added.

##  Validation results
Link to tests or validation results.

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
This function may be useful for users when they perform I2C HILS test.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
