### PR TITLE
Reduce cspice build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: ./ExtLibraries
         run: |
           ls cspice
-          ls cspice/cspice_msvs
+          ls cspice/cspice_msvs/lib
           ls cspice/include
           ls cspice/generic_kernels
           ls nrlmsise00

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -11,7 +11,7 @@ set(GENERIC_KERNEL_URL_BASE https://naif.jpl.nasa.gov/pub/naif/generic_kernels)
 if(WIN32)
   set(CSPICE_URL http://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Windows_VisualC_32bit/packages/cspice.zip)
   set(CSPICE_SHA256 "bc566e6a975c888fc5fd89d76554329501446bda88c8bab937c0725faead170f")
-  set(CSPICE_BUILD_COMMAND cd src/cspice COMMAND mkprodct.bat)
+  set(CSPICE_BUILD_COMMAND "")
 else()
   # Linux
   set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_32bit/packages/cspice.tar.Z)

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -11,7 +11,7 @@ set(GENERIC_KERNEL_URL_BASE https://naif.jpl.nasa.gov/pub/naif/generic_kernels)
 if(WIN32)
   set(CSPICE_URL http://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Windows_VisualC_32bit/packages/cspice.zip)
   set(CSPICE_SHA256 "bc566e6a975c888fc5fd89d76554329501446bda88c8bab937c0725faead170f")
-  set(CSPICE_BUILD_COMMAND makeall.bat)
+  set(CSPICE_BUILD_COMMAND cd src/cspice COMMAND mkprodct.bat)
 else()
   # Linux
   set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_32bit/packages/cspice.tar.Z)


### PR DESCRIPTION
## Overview
Reduce unneeded build of `ExtLibraries/cspice` for speed up ExtLibraries build.

## Issue
- Related issues

## Details
Write in detail.

##  Validation results
Link to tests or validation results.

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
