### PR TITLE
Fix ExtLibraries cache-hit rule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,6 @@ jobs:
         uses: actions/cache@v3
         with:
           key: extlib-${{ runner.os }}-${{ hashFiles('./ExtLibraries/**') }}
-          restore-keys: |
-            extlib-${{ runner.os }}-
           path: ./ExtLibraries
 
       - name: build extlib
@@ -108,8 +106,6 @@ jobs:
         uses: actions/cache@v3
         with:
           key: extlib-${{ runner.os }}-${{ hashFiles('./ExtLibraries/**') }}
-          restore-keys: |
-            extlib-${{ runner.os }}-
           path: ExtLibraries
 
       - name: build extlib


### PR DESCRIPTION
## Overview
Fix #74 

## Issue
- #74 

## Details
ExtLibraries build cache should be restored on completely same `./ExtLibraries`.

##  Validation results
Link to tests or validation results.

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
