### PR TITLE
Modify physical constants management

### DIFF
--- a/src/Component/AOCS/GNSSReceiver.cpp
+++ b/src/Component/AOCS/GNSSReceiver.cpp
@@ -1,6 +1,7 @@
 #include "GNSSReceiver.h"
 
 #include <Library/math/GlobalRand.h>
+#include <Environment/Global/PhysicalConstants.hpp>
 
 #include <string>
 
@@ -117,7 +118,7 @@ void GNSSReceiver::CheckAntennaCone(const Vector<3> pos_true_eci_, Quaternion q_
     ant2gnss_i_n = normalizer * ant2gnss_i;
 
     // check gnss sats are visible from antenna
-    double Re = 6378137.0;  // radius of earth [m]
+    double Re = libra::earth_equatorial_radius_m;
     double inner1 = inner_product(ant_pos_i, gnss_sat_pos_i);
     int is_visible_ant2gnss = 0;
     if (inner1 > 0)

--- a/src/Component/AOCS/GNSSReceiver.cpp
+++ b/src/Component/AOCS/GNSSReceiver.cpp
@@ -134,7 +134,7 @@ void GNSSReceiver::CheckAntennaCone(const Vector<3> pos_true_eci_, Quaternion q_
     }
 
     double inner2 = inner_product(antenna_direction_i, ant2gnss_i_n);
-    if (inner2 > cos(half_width_ * DEG2RAD) && is_visible_ant2gnss) {
+    if (inner2 > cos(half_width_ * libra::deg_to_rad) && is_visible_ant2gnss) {
       // is visible
       gnss_sats_visible_num_++;
       SetGnssInfo(ant2gnss_i, q_i2b, id_tmp);

--- a/src/Component/AOCS/GNSSReceiver.cpp
+++ b/src/Component/AOCS/GNSSReceiver.cpp
@@ -1,8 +1,8 @@
 #include "GNSSReceiver.h"
 
 #include <Library/math/GlobalRand.h>
-#include <Environment/Global/PhysicalConstants.hpp>
 
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <string>
 
 GNSSReceiver::GNSSReceiver(const int prescaler, ClockGenerator* clock_gen, const int id, const std::string gnss_id, const int ch_max,

--- a/src/Component/AOCS/GNSSReceiver.cpp
+++ b/src/Component/AOCS/GNSSReceiver.cpp
@@ -118,7 +118,7 @@ void GNSSReceiver::CheckAntennaCone(const Vector<3> pos_true_eci_, Quaternion q_
     ant2gnss_i_n = normalizer * ant2gnss_i;
 
     // check gnss sats are visible from antenna
-    double Re = libra::earth_equatorial_radius_m;
+    double Re = environment::earth_equatorial_radius_m;
     double inner1 = inner_product(ant_pos_i, gnss_sat_pos_i);
     int is_visible_ant2gnss = 0;
     if (inner1 > 0)

--- a/src/Component/AOCS/GNSSReceiver.h
+++ b/src/Component/AOCS/GNSSReceiver.h
@@ -10,8 +10,6 @@
 
 #include "../Abstract/ComponentBase.h"
 
-#define DEG2RAD 0.017453292519943295769  // PI/180
-
 using libra::Vector;
 
 enum AntennaModel {

--- a/src/Component/AOCS/STT.cpp
+++ b/src/Component/AOCS/STT.cpp
@@ -2,14 +2,11 @@
 
 #include <Interface/LogOutput/LogUtility.h>
 #include <Library/math/GlobalRand.h>
-
 #include <Library/math/Constant.hpp>
 #include <Library/math/Matrix.hpp>
-#include <string>
+#include <Environment/Global/PhysicalConstants.hpp>
 
-#ifndef RE
-#define RE 6378136.30  // Earth radius [m]
-#endif
+#include <string>
 
 using namespace std;
 using namespace libra;
@@ -145,7 +142,7 @@ int STT::SunJudgement(const libra::Vector<3>& sun_b) {
 int STT::EarthJudgement(const libra::Vector<3>& earth_b) {
   Quaternion q_c2b = q_b2c_.conjugate();
   Vector<3> sight_b = q_c2b.frame_conv(sight_);
-  double earth_size_rad = atan2(RE,
+  double earth_size_rad = atan2(libra::earth_equatorial_radius_m,
                                 norm(earth_b));                           // angles between sat<->earth_center & sat<->earth_edge
   double earth_center_angle_rad = CalAngleVect_rad(earth_b, sight_b);     // angles between sat<->earth_center & sat_sight
   double earth_edge_angle_rad = earth_center_angle_rad - earth_size_rad;  // angles between sat<->earth_edge & sat_sight

--- a/src/Component/AOCS/STT.cpp
+++ b/src/Component/AOCS/STT.cpp
@@ -2,10 +2,10 @@
 
 #include <Interface/LogOutput/LogUtility.h>
 #include <Library/math/GlobalRand.h>
+
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <Library/math/Constant.hpp>
 #include <Library/math/Matrix.hpp>
-#include <Environment/Global/PhysicalConstants.hpp>
-
 #include <string>
 
 using namespace std;

--- a/src/Component/AOCS/STT.cpp
+++ b/src/Component/AOCS/STT.cpp
@@ -142,7 +142,7 @@ int STT::SunJudgement(const libra::Vector<3>& sun_b) {
 int STT::EarthJudgement(const libra::Vector<3>& earth_b) {
   Quaternion q_c2b = q_b2c_.conjugate();
   Vector<3> sight_b = q_c2b.frame_conv(sight_);
-  double earth_size_rad = atan2(libra::earth_equatorial_radius_m,
+  double earth_size_rad = atan2(environment::earth_equatorial_radius_m,
                                 norm(earth_b));                           // angles between sat<->earth_center & sat<->earth_edge
   double earth_center_angle_rad = CalAngleVect_rad(earth_b, sight_b);     // angles between sat<->earth_center & sat_sight
   double earth_edge_angle_rad = earth_center_angle_rad - earth_size_rad;  // angles between sat<->earth_edge & sat_sight

--- a/src/Component/CommGS/GScalculator.cpp
+++ b/src/Component/CommGS/GScalculator.cpp
@@ -90,7 +90,7 @@ double GScalculator::CalcMaxBitrate(const Dynamics& dynamics, const ANT& sc_ant,
   double gs_boresight_angle = 0;  // 地上局アンテナは追尾を行うとして，最大ゲインを適用できると考える
 
   double CN0 = sc_ant.GetTxEIRP(sc_boresight_angle) + loss_space + loss_polarization_ + loss_atmosphere_ + loss_rainfall_ + loss_others_ +
-               gs_ant.GetRxGT(gs_boresight_angle) - 10 * log10(libra::boltzmann_constant_J_K);  //[dBHz]
+               gs_ant.GetRxGT(gs_boresight_angle) - 10 * log10(environment::boltzmann_constant_J_K);  //[dBHz]
 
   double margin_for_bitrate = CN0 - (EbN0_ + hardware_deterioration_ + coding_gain_) - margin_req_;  //[dB]
 

--- a/src/Component/CommGS/GScalculator.cpp
+++ b/src/Component/CommGS/GScalculator.cpp
@@ -8,7 +8,8 @@
 #include "GScalculator.h"
 
 #include <Library/math/Constant.hpp>
-#define Kb 1.38064852E-23                // Boltzmann constant
+#include <Environment/Global/PhysicalConstants.hpp>
+
 #define DEG2RAD 0.017453292519943295769  // PI/180
 
 GScalculator::GScalculator(double loss_polarization, double loss_atmosphere, double loss_rainfall, double loss_others, double EbN0,
@@ -91,7 +92,7 @@ double GScalculator::CalcMaxBitrate(const Dynamics& dynamics, const ANT& sc_ant,
   double gs_boresight_angle = 0;  // 地上局アンテナは追尾を行うとして，最大ゲインを適用できると考える
 
   double CN0 = sc_ant.GetTxEIRP(sc_boresight_angle) + loss_space + loss_polarization_ + loss_atmosphere_ + loss_rainfall_ + loss_others_ +
-               gs_ant.GetRxGT(gs_boresight_angle) - 10 * log10(Kb);  //[dBHz]
+               gs_ant.GetRxGT(gs_boresight_angle) - 10 * log10(libra::boltzmann_constant_J_K);  //[dBHz]
 
   double margin_for_bitrate = CN0 - (EbN0_ + hardware_deterioration_ + coding_gain_) - margin_req_;  //[dB]
 

--- a/src/Component/CommGS/GScalculator.cpp
+++ b/src/Component/CommGS/GScalculator.cpp
@@ -7,8 +7,8 @@
 
 #include "GScalculator.h"
 
-#include <Library/math/Constant.hpp>
 #include <Environment/Global/PhysicalConstants.hpp>
+#include <Library/math/Constant.hpp>
 
 GScalculator::GScalculator(double loss_polarization, double loss_atmosphere, double loss_rainfall, double loss_others, double EbN0,
                            double hardware_deterioration, double coding_gain, double margin_req)

--- a/src/Component/CommGS/GScalculator.cpp
+++ b/src/Component/CommGS/GScalculator.cpp
@@ -10,8 +10,6 @@
 #include <Library/math/Constant.hpp>
 #include <Environment/Global/PhysicalConstants.hpp>
 
-#define DEG2RAD 0.017453292519943295769  // PI/180
-
 GScalculator::GScalculator(double loss_polarization, double loss_atmosphere, double loss_rainfall, double loss_others, double EbN0,
                            double hardware_deterioration, double coding_gain, double margin_req)
     : loss_polarization_(loss_polarization),
@@ -46,8 +44,8 @@ bool GScalculator::IsVisible(const Dynamics& dynamics, const GroundStation& grou
   Matrix<3, 3> DCM_ecei_ecef = dynamics.GetOrbit().GetTransECItoECEF();
   Vector<3> gs_pos_ecef = DCM_ecei_ecef * gs_pos_i;
 
-  double lat = groundstation.latitude_ * DEG2RAD;   //[rad]
-  double lon = groundstation.longitude_ * DEG2RAD;  //[rad]
+  double lat = groundstation.latitude_ * libra::deg_to_rad;   //[rad]
+  double lon = groundstation.longitude_ * libra::deg_to_rad;  //[rad]
 
   Matrix<3, 3> trans_mat;  // 地上局におけるECEF2LTC変換行列の回転部分
   trans_mat[0][0] = -sin(lon);
@@ -67,9 +65,9 @@ bool GScalculator::IsVisible(const Dynamics& dynamics, const GroundStation& grou
   dir_GS_to_zenith[2] = 1;
 
   // 地上局の最低可視仰角をクリアしているかを判定
-  if (dot(sc_pos_ltc, dir_GS_to_zenith) > norm(sc_pos_ltc) * sin(groundstation.elevation_angle_ * DEG2RAD)) {
+  if (dot(sc_pos_ltc, dir_GS_to_zenith) > norm(sc_pos_ltc) * sin(groundstation.elevation_angle_ * libra::deg_to_rad)) {
     // std::cout << std::asin(dot(sc_pos_ltc, dir_GS_to_zenith) /
-    // norm(sc_pos_ltc)) / DEG2RAD << std::endl;
+    // norm(sc_pos_ltc)) / libra::deg_to_rad << std::endl;
     return true;
   } else {
     return false;

--- a/src/Component/CommGS/GScalculator.h
+++ b/src/Component/CommGS/GScalculator.h
@@ -24,10 +24,6 @@ using libra::Vector;
 #include <Library/sgp4/sgp4ext.h>
 #include <Library/sgp4/sgp4io.h>
 #include <Library/sgp4/sgp4unit.h>
-// using namespace std;
-// #define DEG2RAD 0.017453292519943295769  // PI/180
-// static gravconsttype whichconst;
-//↑
 
 class GScalculator : public ILoggable {
  public:

--- a/src/Disturbance/AirDrag.cpp
+++ b/src/Disturbance/AirDrag.cpp
@@ -1,7 +1,7 @@
 #include "AirDrag.h"
 
-#include <Library/math/Constant.hpp>
 #include <Environment/Global/PhysicalConstants.hpp>
+#include <Library/math/Constant.hpp>
 #include <cmath>
 #include <iostream>
 

--- a/src/Disturbance/AirDrag.cpp
+++ b/src/Disturbance/AirDrag.cpp
@@ -61,7 +61,7 @@ void AirDrag::CalCnCt(Vector<3>& vel_b) {
   Vector<3> vel_b_normal(vel_b);
   normalize(vel_b_normal);
   // Re-emitting speed
-  S = sqrt(M_ * vel_b_norm_m * vel_b_norm_m / (2.0 * libra::boltzmann_constant_J_K * Tw_));
+  S = sqrt(M_ * vel_b_norm_m * vel_b_norm_m / (2.0 * environment::boltzmann_constant_J_K * Tw_));
   // CalcTheta(vel_b);
   for (size_t i = 0; i < surfaces_.size(); i++) {
     double Sn = S * cosX[i];

--- a/src/Disturbance/AirDrag.cpp
+++ b/src/Disturbance/AirDrag.cpp
@@ -1,6 +1,7 @@
 #include "AirDrag.h"
 
 #include <Library/math/Constant.hpp>
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <cmath>
 #include <iostream>
 
@@ -60,7 +61,7 @@ void AirDrag::CalCnCt(Vector<3>& vel_b) {
   Vector<3> vel_b_normal(vel_b);
   normalize(vel_b_normal);
   // Re-emitting speed
-  S = sqrt(M_ * vel_b_norm_m * vel_b_norm_m / (2.0 * K * Tw_));
+  S = sqrt(M_ * vel_b_norm_m * vel_b_norm_m / (2.0 * libra::boltzmann_constant_J_K * Tw_));
   // CalcTheta(vel_b);
   for (size_t i = 0; i < surfaces_.size(); i++) {
     double Sn = S * cosX[i];

--- a/src/Disturbance/AirDrag.h
+++ b/src/Disturbance/AirDrag.h
@@ -12,8 +12,6 @@
 using libra::Quaternion;
 using libra::Vector;
 
-#define K 1.38064852E-23 /* Boltzmann constant */
-
 #pragma once
 class AirDrag : public SurfaceForce {
  public:

--- a/src/Disturbance/GGDist.cpp
+++ b/src/Disturbance/GGDist.cpp
@@ -5,10 +5,11 @@
 #include <iostream>
 
 #include "../Interface/LogOutput/LogUtility.h"
+#include <Environment/Global/PhysicalConstants.hpp>
 
 using namespace std;
 
-GGDist::GGDist() : GGDist(3.986004418 * pow(10.0, 14.0)) {  //デフォルトコンストラクタ
+GGDist::GGDist() : GGDist(libra::earth_gravitational_constant_m3_s2) {  //デフォルトコンストラクタ
 }
 
 GGDist::GGDist(const double mu_e_input) {  //コンストラクタ

--- a/src/Disturbance/GGDist.cpp
+++ b/src/Disturbance/GGDist.cpp
@@ -1,11 +1,11 @@
 #include "GGDist.h"
 
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <cmath>
 #include <fstream>
 #include <iostream>
 
 #include "../Interface/LogOutput/LogUtility.h"
-#include <Environment/Global/PhysicalConstants.hpp>
 
 using namespace std;
 

--- a/src/Disturbance/GGDist.cpp
+++ b/src/Disturbance/GGDist.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-GGDist::GGDist() : GGDist(libra::earth_gravitational_constant_m3_s2) {  //デフォルトコンストラクタ
+GGDist::GGDist() : GGDist(environment::earth_gravitational_constant_m3_s2) {  //デフォルトコンストラクタ
 }
 
 GGDist::GGDist(const double mu_e_input) {  //コンストラクタ

--- a/src/Disturbance/GeoPotential.cpp
+++ b/src/Disturbance/GeoPotential.cpp
@@ -88,7 +88,7 @@ void GeoPotential::CalcAccelerationECEF(const Vector<3> &position_ecef) {
   vector<vector<double>> v(degree_vw + 1, vector<double>(degree_vw + 1, 0.0));
   vector<vector<double>> w(degree_vw + 1, vector<double>(degree_vw + 1, 0.0));
   // n=m=0
-  v[0][0] = libra::earth_equatorial_radius_m / r;
+  v[0][0] = environment::earth_equatorial_radius_m / r;
   w[0][0] = 0.0;
   m = 0;
 
@@ -135,7 +135,7 @@ void GeoPotential::CalcAccelerationECEF(const Vector<3> &position_ecef) {
       acc_ecef_[2] += (n_d - m_d + 1.0) * (-c_[n][m] * v[n + 1][m] - s_[n][m] * w[n + 1][m]) * normalize_z;
     }
   }
-  acc_ecef_ *= libra::earth_gravitational_constant_m3_s2 / (libra::earth_equatorial_radius_m * libra::earth_equatorial_radius_m);
+  acc_ecef_ *= environment::earth_gravitational_constant_m3_s2 / (environment::earth_equatorial_radius_m * environment::earth_equatorial_radius_m);
 
   return;
 }
@@ -145,7 +145,7 @@ void GeoPotential::v_w_nn_update(double *v_nn, double *w_nn, const double v_prev
 
   double n_d = (double)n;
 
-  double tmp = libra::earth_equatorial_radius_m / (r * r);
+  double tmp = environment::earth_equatorial_radius_m / (r * r);
   double x_tmp = x * tmp;
   double y_tmp = y * tmp;
   double c_normalize;
@@ -165,9 +165,9 @@ void GeoPotential::v_w_nm_update(double *v_nm, double *w_nm, const double v_prev
   double m_d = (double)m;
   double n_d = (double)n;
 
-  double tmp = libra::earth_equatorial_radius_m / (r * r);
+  double tmp = environment::earth_equatorial_radius_m / (r * r);
   double z_tmp = z * tmp;
-  double re_tmp = libra::earth_equatorial_radius_m * tmp;
+  double re_tmp = environment::earth_equatorial_radius_m * tmp;
   double c1 = (2.0 * n_d - 1.0) / (n_d - m_d);
   double c2 = (n_d + m_d - 1.0) / (n_d - m_d);
   double c_normalize, c2_normalize;

--- a/src/Disturbance/GeoPotential.cpp
+++ b/src/Disturbance/GeoPotential.cpp
@@ -1,5 +1,6 @@
 #include "GeoPotential.h"
 
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <chrono>
 #include <cmath>
 #include <fstream>
@@ -10,9 +11,6 @@
 //#define DEBUG_GEOPOTENTIAL
 
 using namespace std;
-
-#define RE 6378136.30                            // m
-#define MU (3.986004415 * std::pow(10.0, 14.0))  // m3/s2
 
 GeoPotential::GeoPotential(const int degree, const string file_path) : degree_(degree) {
   // Initialize
@@ -90,7 +88,7 @@ void GeoPotential::CalcAccelerationECEF(const Vector<3> &position_ecef) {
   vector<vector<double>> v(degree_vw + 1, vector<double>(degree_vw + 1, 0.0));
   vector<vector<double>> w(degree_vw + 1, vector<double>(degree_vw + 1, 0.0));
   // n=m=0
-  v[0][0] = RE / r;
+  v[0][0] = libra::earth_equatorial_radius_m / r;
   w[0][0] = 0.0;
   m = 0;
 
@@ -137,7 +135,7 @@ void GeoPotential::CalcAccelerationECEF(const Vector<3> &position_ecef) {
       acc_ecef_[2] += (n_d - m_d + 1.0) * (-c_[n][m] * v[n + 1][m] - s_[n][m] * w[n + 1][m]) * normalize_z;
     }
   }
-  acc_ecef_ *= MU / (RE * RE);
+  acc_ecef_ *= libra::earth_gravitational_constant_m3_s2 / (libra::earth_equatorial_radius_m * libra::earth_equatorial_radius_m);
 
   return;
 }
@@ -147,7 +145,7 @@ void GeoPotential::v_w_nn_update(double *v_nn, double *w_nn, const double v_prev
 
   double n_d = (double)n;
 
-  double tmp = RE / (r * r);
+  double tmp = libra::earth_equatorial_radius_m / (r * r);
   double x_tmp = x * tmp;
   double y_tmp = y * tmp;
   double c_normalize;
@@ -167,9 +165,9 @@ void GeoPotential::v_w_nm_update(double *v_nm, double *w_nm, const double v_prev
   double m_d = (double)m;
   double n_d = (double)n;
 
-  double tmp = RE / (r * r);
+  double tmp = libra::earth_equatorial_radius_m / (r * r);
   double z_tmp = z * tmp;
-  double re_tmp = RE * tmp;
+  double re_tmp = libra::earth_equatorial_radius_m * tmp;
   double c1 = (2.0 * n_d - 1.0) / (n_d - m_d);
   double c2 = (n_d + m_d - 1.0) / (n_d - m_d);
   double c_normalize, c2_normalize;

--- a/src/Dynamics/Orbit/EarthCenteredOrbit.cpp
+++ b/src/Dynamics/Orbit/EarthCenteredOrbit.cpp
@@ -53,7 +53,7 @@ void EarthCenteredOrbit::Propagate(double endtime, double current_jd) {
 
   // convert velocity vector in ECI to the vector in ECEF
   Vector<3> OmegaE{0.0};
-  OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
+  OmegaE[2] = environment::earth_mean_angular_velocity_rad_s;
   Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
   Vector<3> V_wExr = sat_velocity_i_ - wExr;
   sat_velocity_ecef_ = trans_eci2ecef_ * V_wExr;

--- a/src/Dynamics/Orbit/EarthCenteredOrbit.cpp
+++ b/src/Dynamics/Orbit/EarthCenteredOrbit.cpp
@@ -53,7 +53,7 @@ void EarthCenteredOrbit::Propagate(double endtime, double current_jd) {
 
   // convert velocity vector in ECI to the vector in ECEF
   Vector<3> OmegaE{0.0};
-  OmegaE[2] = OmegaEarth;
+  OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
   Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
   Vector<3> V_wExr = sat_velocity_i_ - wExr;
   sat_velocity_ecef_ = trans_eci2ecef_ * V_wExr;

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -12,6 +12,7 @@ using libra::Quaternion;
 using libra::Vector;
 
 #include <Interface/LogOutput/ILoggable.h>
+
 #include <Environment/Global/PhysicalConstants.hpp>
 
 // For ECI to GEO calculation

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -18,9 +18,6 @@ using libra::Vector;
 #include <Library/sgp4/sgp4io.h>
 #include <Library/sgp4/sgp4unit.h>
 
-//#define PIO2		1.57079632679489656		/* Pi/2 */
-//#define TWOPI		6.28318530717958623		/* 2*Pi  */
-#define DEG2RAD 0.017453292519943295769  // PI/180
 #define OmegaEarth \
   7.29211514670698e-05  // Earth Rotational rate (not considering
                         // Nutation/Precession)

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -91,7 +91,7 @@ class Orbit : public ILoggable {
 
     // convert velocity vector in ECI to the vector in ECEF
     Vector<3> OmegaE{0.0};
-    OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
+    OmegaE[2] = environment::earth_mean_angular_velocity_rad_s;
     Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
     Vector<3> V_wExr = sat_velocity_i_ - wExr;
     sat_velocity_ecef_ = trans_mat * V_wExr;

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -12,15 +12,12 @@ using libra::Quaternion;
 using libra::Vector;
 
 #include <Interface/LogOutput/ILoggable.h>
+#include <Environment/Global/PhysicalConstants.hpp>
 
 // For ECI to GEO calculation
 #include <Library/sgp4/sgp4ext.h>
 #include <Library/sgp4/sgp4io.h>
 #include <Library/sgp4/sgp4unit.h>
-
-#define OmegaEarth \
-  7.29211514670698e-05  // Earth Rotational rate (not considering
-                        // Nutation/Precession)
 
 class Orbit : public ILoggable {
  public:
@@ -93,7 +90,7 @@ class Orbit : public ILoggable {
 
     // convert velocity vector in ECI to the vector in ECEF
     Vector<3> OmegaE{0.0};
-    OmegaE[2] = OmegaEarth;
+    OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
     Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
     Vector<3> V_wExr = sat_velocity_i_ - wExr;
     sat_velocity_ecef_ = trans_mat * V_wExr;

--- a/src/Dynamics/Orbit/SimpleCircularOrbit.cpp
+++ b/src/Dynamics/Orbit/SimpleCircularOrbit.cpp
@@ -69,7 +69,7 @@ void SimpleCircularOrbit::Initialize(Vector<3> init_position, Vector<3> init_vel
 
   // convert velocity vector in ECI to the vector in ECEF
   Vector<3> OmegaE{0.0};
-  OmegaE[2] = OmegaEarth;
+  OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
   Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
   Vector<3> V_wExr = sat_velocity_i_ - wExr;
   sat_velocity_ecef_ = trans_eci2ecef_ * V_wExr;
@@ -102,7 +102,7 @@ void SimpleCircularOrbit::Propagate(double endtime, double current_jd) {
 
   // convert velocity vector in ECI to the vector in ECEF
   Vector<3> OmegaE{0.0};
-  OmegaE[2] = OmegaEarth;
+  OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
   Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
   Vector<3> V_wExr = sat_velocity_i_ - wExr;
   sat_velocity_ecef_ = trans_eci2ecef_ * V_wExr;

--- a/src/Dynamics/Orbit/SimpleCircularOrbit.cpp
+++ b/src/Dynamics/Orbit/SimpleCircularOrbit.cpp
@@ -69,7 +69,7 @@ void SimpleCircularOrbit::Initialize(Vector<3> init_position, Vector<3> init_vel
 
   // convert velocity vector in ECI to the vector in ECEF
   Vector<3> OmegaE{0.0};
-  OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
+  OmegaE[2] = environment::earth_mean_angular_velocity_rad_s;
   Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
   Vector<3> V_wExr = sat_velocity_i_ - wExr;
   sat_velocity_ecef_ = trans_eci2ecef_ * V_wExr;
@@ -102,7 +102,7 @@ void SimpleCircularOrbit::Propagate(double endtime, double current_jd) {
 
   // convert velocity vector in ECI to the vector in ECEF
   Vector<3> OmegaE{0.0};
-  OmegaE[2] = libra::earth_mean_angular_velocity_rad_s;
+  OmegaE[2] = environment::earth_mean_angular_velocity_rad_s;
   Vector<3> wExr = outer_product(OmegaE, sat_position_i_);
   Vector<3> V_wExr = sat_velocity_i_ - wExr;
   sat_velocity_ecef_ = trans_eci2ecef_ * V_wExr;

--- a/src/Dynamics/Thermal/Node.cpp
+++ b/src/Dynamics/Thermal/Node.cpp
@@ -1,6 +1,7 @@
 #include "Node.h"
 
 #include <cmath>
+#include <Environment/Global/PhysicalConstants.hpp>
 
 using namespace std;
 using namespace libra;
@@ -22,7 +23,7 @@ Node::Node(const int node_id, const string node_label, const int heater_node_id,
 Node::~Node() {}
 
 double Node::K2deg(double kelvin) const {
-  double temp = kelvin - 273;
+  double temp = kelvin + libra::absolute_zero_degC;
   return temp;
 }
 
@@ -52,6 +53,7 @@ void Node::SetInternalHeat(double heat_power) {
 }
 
 double Node::CalcSolarRadiation(Vector<3> sun_direction) {
+  // FIXME: constants
   double R = 6.96E+8;                              // Distance from sun
   double T = 5778;                                 // sun surface temperature [K]
   double sigma = 5.67E-8;                          // stephan-boltzman constant

--- a/src/Dynamics/Thermal/Node.cpp
+++ b/src/Dynamics/Thermal/Node.cpp
@@ -23,7 +23,7 @@ Node::Node(const int node_id, const string node_label, const int heater_node_id,
 Node::~Node() {}
 
 double Node::K2deg(double kelvin) const {
-  double temp = kelvin + libra::absolute_zero_degC;
+  double temp = kelvin + environment::absolute_zero_degC;
   return temp;
 }
 

--- a/src/Dynamics/Thermal/Node.cpp
+++ b/src/Dynamics/Thermal/Node.cpp
@@ -1,7 +1,7 @@
 #include "Node.h"
 
-#include <cmath>
 #include <Environment/Global/PhysicalConstants.hpp>
+#include <cmath>
 
 using namespace std;
 using namespace libra;

--- a/src/Environment/Global/CelestialRotation.cpp
+++ b/src/Environment/Global/CelestialRotation.cpp
@@ -2,8 +2,8 @@
 
 #include <Library/sgp4/sgp4ext.h>   //for jday()
 #include <Library/sgp4/sgp4unit.h>  //for gstime()
-#include <Library/math/Constant.hpp>
 
+#include <Library/math/Constant.hpp>
 #include <iostream>
 #include <sstream>
 

--- a/src/Environment/Global/CelestialRotation.cpp
+++ b/src/Environment/Global/CelestialRotation.cpp
@@ -2,14 +2,12 @@
 
 #include <Library/sgp4/sgp4ext.h>   //for jday()
 #include <Library/sgp4/sgp4unit.h>  //for gstime()
+#include <Library/math/Constant.hpp>
 
 #include <iostream>
 #include <sstream>
 
 using namespace std;
-
-#define DEG2RAD 0.017453292519943295769  // PI/180
-#define ASEC2RAD DEG2RAD / 3600.0
 
 // default constructor
 CelestialRotation::CelestialRotation(const RotationMode rotation_mode, const string center_obj) {
@@ -38,91 +36,91 @@ void CelestialRotation::Init_CelestialRotation_As_Earth(const RotationMode rotat
       // coefficients for computing mean obliquity of the ecliptic
       // the actual unit of c_epsi_rad_ is [rad/century^i], i is the index of
       // the array
-      c_epsi_rad_[0] = 23.4392911 * DEG2RAD;    // [rad]
-      c_epsi_rad_[1] = -46.8150000 * ASEC2RAD;  // [rad/century]
-      c_epsi_rad_[2] = -5.9000e-4 * ASEC2RAD;   // [rad/century^2]
-      c_epsi_rad_[3] = 1.8130e-3 * ASEC2RAD;    // [rad/century^3]
+      c_epsi_rad_[0] = 23.4392911 * libra::deg_to_rad;      // [rad]
+      c_epsi_rad_[1] = -46.8150000 * libra::arcsec_to_rad;  // [rad/century]
+      c_epsi_rad_[2] = -5.9000e-4 * libra::arcsec_to_rad;   // [rad/century^2]
+      c_epsi_rad_[3] = 1.8130e-3 * libra::arcsec_to_rad;    // [rad/century^3]
 
       // coefficients for computing five delauney angles(l=lm,l'=ls,F,D,Ω=O)
       // lm means mean anomaly of the moon
       // the actual unit of c_lm_rad_ is [rad/century^i], i is the index of the
       // array
-      c_lm_rad_[0] = 134.96340251 * DEG2RAD;          // [rad]
-      c_lm_rad_[1] = 1717915923.21780000 * ASEC2RAD;  // [rad/century]
-      c_lm_rad_[2] = 31.87920000 * ASEC2RAD;          // [rad/century^2]
-      c_lm_rad_[3] = 0.05163500 * ASEC2RAD;           // [rad/century^3]
-      c_lm_rad_[4] = -0.00024470 * ASEC2RAD;          // [rad/century^4]
+      c_lm_rad_[0] = 134.96340251 * libra::deg_to_rad;            // [rad]
+      c_lm_rad_[1] = 1717915923.21780000 * libra::arcsec_to_rad;  // [rad/century]
+      c_lm_rad_[2] = 31.87920000 * libra::arcsec_to_rad;          // [rad/century^2]
+      c_lm_rad_[3] = 0.05163500 * libra::arcsec_to_rad;           // [rad/century^3]
+      c_lm_rad_[4] = -0.00024470 * libra::arcsec_to_rad;          // [rad/century^4]
       // ls means mean anomaly of the sun
       // the actual unit of c_ls_rad_ is [rad/century^i], i is the index of the
       // array
-      c_ls_rad_[0] = 357.52910918 * DEG2RAD;         // [rad]
-      c_ls_rad_[1] = 129596581.04810000 * ASEC2RAD;  // [rad/century]
-      c_ls_rad_[2] = -0.55320000 * ASEC2RAD;         // [rad/century^2]
-      c_ls_rad_[3] = 0.00013600 * ASEC2RAD;          // [rad/century^3]
-      c_ls_rad_[4] = -0.00001149 * ASEC2RAD;         // [rad/century^4]
+      c_ls_rad_[0] = 357.52910918 * libra::deg_to_rad;           // [rad]
+      c_ls_rad_[1] = 129596581.04810000 * libra::arcsec_to_rad;  // [rad/century]
+      c_ls_rad_[2] = -0.55320000 * libra::arcsec_to_rad;         // [rad/century^2]
+      c_ls_rad_[3] = 0.00013600 * libra::arcsec_to_rad;          // [rad/century^3]
+      c_ls_rad_[4] = -0.00001149 * libra::arcsec_to_rad;         // [rad/century^4]
       // F means mean longitude of the moon - mean longitude of ascending node
       // of the moon the actual unit of c_F_rad_ is [rad/century^i], i is the
       // index of the array
-      c_F_rad_[0] = 93.27209062 * DEG2RAD;           // [rad]
-      c_F_rad_[1] = 1739527262.84780000 * ASEC2RAD;  // [rad/century]
-      c_F_rad_[2] = -12.75120000 * ASEC2RAD;         // [rad/century^2]
-      c_F_rad_[3] = -0.00103700 * ASEC2RAD;          // [rad/century^3]
-      c_F_rad_[4] = 0.00000417 * ASEC2RAD;           // [rad/century^4]
+      c_F_rad_[0] = 93.27209062 * libra::deg_to_rad;             // [rad]
+      c_F_rad_[1] = 1739527262.84780000 * libra::arcsec_to_rad;  // [rad/century]
+      c_F_rad_[2] = -12.75120000 * libra::arcsec_to_rad;         // [rad/century^2]
+      c_F_rad_[3] = -0.00103700 * libra::arcsec_to_rad;          // [rad/century^3]
+      c_F_rad_[4] = 0.00000417 * libra::arcsec_to_rad;           // [rad/century^4]
       // D means mean elogation of the moon from the sun
       // the actual unit of c_D_rad_ is [rad/century^i], i is the index of the
       // array
-      c_D_rad_[0] = 297.85019547 * DEG2RAD;          // [rad]
-      c_D_rad_[1] = 1602961601.20900000 * ASEC2RAD;  // [rad/century]
-      c_D_rad_[2] = -6.37060000 * ASEC2RAD;          // [rad/century^2]
-      c_D_rad_[3] = 0.00659300 * ASEC2RAD;           // [rad/century^3]
-      c_D_rad_[4] = -0.00003169 * ASEC2RAD;          // [rad/century^4]
+      c_D_rad_[0] = 297.85019547 * libra::deg_to_rad;            // [rad]
+      c_D_rad_[1] = 1602961601.20900000 * libra::arcsec_to_rad;  // [rad/century]
+      c_D_rad_[2] = -6.37060000 * libra::arcsec_to_rad;          // [rad/century^2]
+      c_D_rad_[3] = 0.00659300 * libra::arcsec_to_rad;           // [rad/century^3]
+      c_D_rad_[4] = -0.00003169 * libra::arcsec_to_rad;          // [rad/century^4]
       // O means mean longitude of ascending node of the moon
       // the actual unit of c_O_rad_ is [rad/century^i], i is the index of the
       // array
-      c_O_rad_[0] = 125.04455501 * DEG2RAD;        // [rad]
-      c_O_rad_[1] = -6962890.54310000 * ASEC2RAD;  // [rad/century]
-      c_O_rad_[2] = 7.47220000 * ASEC2RAD;         // [rad/century^2]
-      c_O_rad_[3] = 0.00770200 * ASEC2RAD;         // [rad/century^3]
-      c_O_rad_[4] = -0.00005939 * ASEC2RAD;        // [rad/century^4]
+      c_O_rad_[0] = 125.04455501 * libra::deg_to_rad;          // [rad]
+      c_O_rad_[1] = -6962890.54310000 * libra::arcsec_to_rad;  // [rad/century]
+      c_O_rad_[2] = 7.47220000 * libra::arcsec_to_rad;         // [rad/century^2]
+      c_O_rad_[3] = 0.00770200 * libra::arcsec_to_rad;         // [rad/century^3]
+      c_O_rad_[4] = -0.00005939 * libra::arcsec_to_rad;        // [rad/century^4]
 
       // coefficients for computing nutation angles
       // delta epsilon
-      c_depsilon_rad_[0] = 9.2050 * ASEC2RAD;   // [rad]
-      c_depsilon_rad_[1] = 0.5730 * ASEC2RAD;   // [rad]
-      c_depsilon_rad_[2] = -0.0900 * ASEC2RAD;  // [rad]
-      c_depsilon_rad_[3] = 0.0980 * ASEC2RAD;   // [rad]
-      c_depsilon_rad_[4] = 0.0070 * ASEC2RAD;   // [rad]
-      c_depsilon_rad_[5] = -0.0010 * ASEC2RAD;  // [rad]
-      c_depsilon_rad_[6] = 0.0220 * ASEC2RAD;   // [rad]
-      c_depsilon_rad_[7] = 0.0130 * ASEC2RAD;   // [rad]
-      c_depsilon_rad_[8] = -0.0100 * ASEC2RAD;  // [rad]
+      c_depsilon_rad_[0] = 9.2050 * libra::arcsec_to_rad;   // [rad]
+      c_depsilon_rad_[1] = 0.5730 * libra::arcsec_to_rad;   // [rad]
+      c_depsilon_rad_[2] = -0.0900 * libra::arcsec_to_rad;  // [rad]
+      c_depsilon_rad_[3] = 0.0980 * libra::arcsec_to_rad;   // [rad]
+      c_depsilon_rad_[4] = 0.0070 * libra::arcsec_to_rad;   // [rad]
+      c_depsilon_rad_[5] = -0.0010 * libra::arcsec_to_rad;  // [rad]
+      c_depsilon_rad_[6] = 0.0220 * libra::arcsec_to_rad;   // [rad]
+      c_depsilon_rad_[7] = 0.0130 * libra::arcsec_to_rad;   // [rad]
+      c_depsilon_rad_[8] = -0.0100 * libra::arcsec_to_rad;  // [rad]
       // delta psi
-      c_dpsi_rad_[0] = -17.2060 * ASEC2RAD;  // [rad]
-      c_dpsi_rad_[1] = -1.3170 * ASEC2RAD;   // [rad]
-      c_dpsi_rad_[2] = 0.2070 * ASEC2RAD;    // [rad]
-      c_dpsi_rad_[3] = -0.2280 * ASEC2RAD;   // [rad]
-      c_dpsi_rad_[4] = 0.1480 * ASEC2RAD;    // [rad]
-      c_dpsi_rad_[5] = 0.0710 * ASEC2RAD;    // [rad]
-      c_dpsi_rad_[6] = -0.0520 * ASEC2RAD;   // [rad]
-      c_dpsi_rad_[7] = -0.0300 * ASEC2RAD;   // [rad]
-      c_dpsi_rad_[8] = 0.0220 * ASEC2RAD;    // [rad]
+      c_dpsi_rad_[0] = -17.2060 * libra::arcsec_to_rad;  // [rad]
+      c_dpsi_rad_[1] = -1.3170 * libra::arcsec_to_rad;   // [rad]
+      c_dpsi_rad_[2] = 0.2070 * libra::arcsec_to_rad;    // [rad]
+      c_dpsi_rad_[3] = -0.2280 * libra::arcsec_to_rad;   // [rad]
+      c_dpsi_rad_[4] = 0.1480 * libra::arcsec_to_rad;    // [rad]
+      c_dpsi_rad_[5] = 0.0710 * libra::arcsec_to_rad;    // [rad]
+      c_dpsi_rad_[6] = -0.0520 * libra::arcsec_to_rad;   // [rad]
+      c_dpsi_rad_[7] = -0.0300 * libra::arcsec_to_rad;   // [rad]
+      c_dpsi_rad_[8] = 0.0220 * libra::arcsec_to_rad;    // [rad]
 
       // coefficients for computing precession angles(zeta, theta, z)
       // the actual unit of c_zeta_rad_ is [rad/century^(i+1)], i is the index
       // of the array
-      c_zeta_rad_[0] = 2306.218100 * ASEC2RAD;  // [rad/century]
-      c_zeta_rad_[1] = 0.301880 * ASEC2RAD;     // [rad/century^2]
-      c_zeta_rad_[2] = 0.017998 * ASEC2RAD;     // [rad/century^3]
+      c_zeta_rad_[0] = 2306.218100 * libra::arcsec_to_rad;  // [rad/century]
+      c_zeta_rad_[1] = 0.301880 * libra::arcsec_to_rad;     // [rad/century^2]
+      c_zeta_rad_[2] = 0.017998 * libra::arcsec_to_rad;     // [rad/century^3]
       // the actual unit of c_theta_rad_ is [rad/century^(i+1)], i is the index
       // of the array
-      c_theta_rad_[0] = 2004.310900 * ASEC2RAD;  // [rad/century]
-      c_theta_rad_[1] = -0.426650 * ASEC2RAD;    // [rad/century^2]
-      c_theta_rad_[2] = -0.041833 * ASEC2RAD;    // [rad/century^3]
+      c_theta_rad_[0] = 2004.310900 * libra::arcsec_to_rad;  // [rad/century]
+      c_theta_rad_[1] = -0.426650 * libra::arcsec_to_rad;    // [rad/century^2]
+      c_theta_rad_[2] = -0.041833 * libra::arcsec_to_rad;    // [rad/century^3]
       // the actual unit of c_z_rad_ is [rad/century^(i+1)], i is the index of
       // the array
-      c_z_rad_[0] = 2306.218100 * ASEC2RAD;  // [rad/century]
-      c_z_rad_[1] = 1.094680 * ASEC2RAD;     // [rad/century^2]
-      c_z_rad_[2] = 0.018203 * ASEC2RAD;     // [rad/century^3]
+      c_z_rad_[0] = 2306.218100 * libra::arcsec_to_rad;  // [rad/century]
+      c_z_rad_[1] = 1.094680 * libra::arcsec_to_rad;     // [rad/century^2]
+      c_z_rad_[2] = 0.018203 * libra::arcsec_to_rad;     // [rad/century^3]
     } else {
       // if the rotation mode is neither Simple nor Full, disable the rotation
       // calculation and make the DCM a unit matrix

--- a/src/Environment/Global/GnssSatellites.cpp
+++ b/src/Environment/Global/GnssSatellites.cpp
@@ -3,9 +3,9 @@
 #include <Interface/LogOutput/LogUtility.h>
 #include <Library/sgp4/sgp4ext.h>   //for jday()
 #include <Library/sgp4/sgp4unit.h>  //for gstime()
-#include <Library/math/Constant.hpp>
-#include <Environment/Global/PhysicalConstants.hpp>
 
+#include <Environment/Global/PhysicalConstants.hpp>
+#include <Library/math/Constant.hpp>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -614,7 +614,7 @@ void GnssSat_clock::Init(vector<vector<string>>& file, string file_extension, in
 
         int sat_id = GetIndexFromID(s.at(1));
         double clock_bias = stod(s.at(9)) * libra::speed_of_light_m_s;  // [s] -> [m]
-        if (start_unix_time - unix_time > 1e-4) continue;        // for the numerical error
+        if (start_unix_time - unix_time > 1e-4) continue;               // for the numerical error
         if (end_unix_time - unix_time < 1e-4) break;
         if (!unixtime_vector_.at(sat_id).empty() && std::abs(unix_time - unixtime_vector_.at(sat_id).back()) < 1e-4) {  // for the numerical error
           unixtime_vector_.at(sat_id).back() = unix_time;

--- a/src/Environment/Global/GnssSatellites.cpp
+++ b/src/Environment/Global/GnssSatellites.cpp
@@ -3,14 +3,14 @@
 #include <Interface/LogOutput/LogUtility.h>
 #include <Library/sgp4/sgp4ext.h>   //for jday()
 #include <Library/sgp4/sgp4unit.h>  //for gstime()
-
 #include <Library/math/Constant.hpp>
+#include <Environment/Global/PhysicalConstants.hpp>
+
 #include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <vector>
 
-const double speed_of_light_m_s = 299792458.0;  //[m/s] in vacuum
 const double nan99 = 999999.999999;
 
 const int gps_sat_num_ = 32;
@@ -557,7 +557,7 @@ void GnssSat_clock::Init(vector<vector<string>>& file, string file_extension, in
 
           // in the file, clock bias is expressed in [micro second], so by
           // multiplying by the speed_of_light & 1e-6, they are converted to [m]
-          clock *= (speed_of_light_m_s * 1e-6);
+          clock *= (libra::speed_of_light_m_s * 1e-6);
           if (!unixtime_vector_.at(sat_id).empty() && std::abs(unix_time - unixtime_vector_.at(sat_id).back()) < 1.0) {
             unixtime_vector_.at(sat_id).back() = unix_time;
             gnss_sat_clock_table_.at(sat_id).back() = clock;
@@ -613,7 +613,7 @@ void GnssSat_clock::Init(vector<vector<string>>& file, string file_extension, in
         std::free(time_tm);
 
         int sat_id = GetIndexFromID(s.at(1));
-        double clock_bias = stod(s.at(9)) * speed_of_light_m_s;  // [s] -> [m]
+        double clock_bias = stod(s.at(9)) * libra::speed_of_light_m_s;  // [s] -> [m]
         if (start_unix_time - unix_time > 1e-4) continue;        // for the numerical error
         if (end_unix_time - unix_time < 1e-4) break;
         if (!unixtime_vector_.at(sat_id).empty() && std::abs(unix_time - unixtime_vector_.at(sat_id).back()) < 1e-4) {  // for the numerical error
@@ -992,7 +992,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseECEF(const int sat_id, libra
 
   // wavelength
   // frequency is thought to be given by MHz
-  double lambda = speed_of_light_m_s * 1e-6 / frequency;
+  double lambda = libra::speed_of_light_m_s * 1e-6 / frequency;
   double cycle = res / lambda;
 
   double bias = floor(cycle);
@@ -1023,7 +1023,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseECI(const int sat_id, libra:
 
   // wavelength
   // frequency is thought to be given by MHz
-  double lambda = speed_of_light_m_s * 1e-6 / frequency;
+  double lambda = libra::speed_of_light_m_s * 1e-6 / frequency;
   double cycle = res / lambda;
 
   double bias = floor(cycle);

--- a/src/Environment/Global/GnssSatellites.cpp
+++ b/src/Environment/Global/GnssSatellites.cpp
@@ -557,7 +557,7 @@ void GnssSat_clock::Init(vector<vector<string>>& file, string file_extension, in
 
           // in the file, clock bias is expressed in [micro second], so by
           // multiplying by the speed_of_light & 1e-6, they are converted to [m]
-          clock *= (libra::speed_of_light_m_s * 1e-6);
+          clock *= (environment::speed_of_light_m_s * 1e-6);
           if (!unixtime_vector_.at(sat_id).empty() && std::abs(unix_time - unixtime_vector_.at(sat_id).back()) < 1.0) {
             unixtime_vector_.at(sat_id).back() = unix_time;
             gnss_sat_clock_table_.at(sat_id).back() = clock;
@@ -613,8 +613,8 @@ void GnssSat_clock::Init(vector<vector<string>>& file, string file_extension, in
         std::free(time_tm);
 
         int sat_id = GetIndexFromID(s.at(1));
-        double clock_bias = stod(s.at(9)) * libra::speed_of_light_m_s;  // [s] -> [m]
-        if (start_unix_time - unix_time > 1e-4) continue;               // for the numerical error
+        double clock_bias = stod(s.at(9)) * environment::speed_of_light_m_s;  // [s] -> [m]
+        if (start_unix_time - unix_time > 1e-4) continue;                     // for the numerical error
         if (end_unix_time - unix_time < 1e-4) break;
         if (!unixtime_vector_.at(sat_id).empty() && std::abs(unix_time - unixtime_vector_.at(sat_id).back()) < 1e-4) {  // for the numerical error
           unixtime_vector_.at(sat_id).back() = unix_time;
@@ -992,7 +992,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseECEF(const int sat_id, libra
 
   // wavelength
   // frequency is thought to be given by MHz
-  double lambda = libra::speed_of_light_m_s * 1e-6 / frequency;
+  double lambda = environment::speed_of_light_m_s * 1e-6 / frequency;
   double cycle = res / lambda;
 
   double bias = floor(cycle);
@@ -1023,7 +1023,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseECI(const int sat_id, libra:
 
   // wavelength
   // frequency is thought to be given by MHz
-  double lambda = libra::speed_of_light_m_s * 1e-6 / frequency;
+  double lambda = environment::speed_of_light_m_s * 1e-6 / frequency;
   double cycle = res / lambda;
 
   double bias = floor(cycle);

--- a/src/Environment/Global/GnssSatellites.h
+++ b/src/Environment/Global/GnssSatellites.h
@@ -13,7 +13,6 @@
 
 #include "SimTime.h"
 
-extern const double speed_of_light;  //[m/s] in vacuum
 extern const double nan99;
 
 #define ECEF 0

--- a/src/Environment/Global/PhysicalConstants.hpp
+++ b/src/Environment/Global/PhysicalConstants.hpp
@@ -22,18 +22,17 @@ using enable_if_float = std::enable_if_t<std::is_floating_point_v<T>, T>;
 
 // TODO: Is the unit information needed in variable names?
 // Physics
-DEFINE_PHYSICAL_CONSTANT(speed_of_light_m_s, 299792458.0L);              /* in vacuum m/s */
-DEFINE_PHYSICAL_CONSTANT(boltzmann_constant_J_K, 1.380649e-23L);         /* J/K */
-DEFINE_PHYSICAL_CONSTANT(absolute_zero_degC, -273.15L);                  /* degC */
+DEFINE_PHYSICAL_CONSTANT(speed_of_light_m_s, 299792458.0L);      /* in vacuum m/s */
+DEFINE_PHYSICAL_CONSTANT(boltzmann_constant_J_K, 1.380649e-23L); /* J/K */
+DEFINE_PHYSICAL_CONSTANT(absolute_zero_degC, -273.15L);          /* degC */
 
 // Astronomy Ref: https://iau-a3.gitlab.io/NSFA/
-DEFINE_PHYSICAL_CONSTANT(astronomical_unit_m, 1.49597870700e11L);               /* fixed m */
-DEFINE_PHYSICAL_CONSTANT(gravitational_constant_Nm2_kg2, 6.67428e-11L);         /* best estimates Nm2/kg2 */
-DEFINE_PHYSICAL_CONSTANT(earth_equatorial_radius_m, 6378136.6L);                /* best estimates m */
-DEFINE_PHYSICAL_CONSTANT(earth_polar_radius_m, 6378136.6L);                     /* best estimates m */
-DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14L);  /* best estimates, TT m3/s2 */
-DEFINE_PHYSICAL_CONSTANT(earth_mean_angular_velocity_rad_s, 7.292115e-5L);      /* best estimates, TT rad/s */
-
+DEFINE_PHYSICAL_CONSTANT(astronomical_unit_m, 1.49597870700e11L);              /* fixed m */
+DEFINE_PHYSICAL_CONSTANT(gravitational_constant_Nm2_kg2, 6.67428e-11L);        /* best estimates Nm2/kg2 */
+DEFINE_PHYSICAL_CONSTANT(earth_equatorial_radius_m, 6378136.6L);               /* best estimates m */
+DEFINE_PHYSICAL_CONSTANT(earth_polar_radius_m, 6378136.6L);                    /* best estimates m */
+DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14L); /* best estimates, TT m3/s2 */
+DEFINE_PHYSICAL_CONSTANT(earth_mean_angular_velocity_rad_s, 7.292115e-5L);     /* best estimates, TT rad/s */
 
 #undef DEFINE_PHYSICAL_CONSTANT
 }  // namespace numbers

--- a/src/Environment/Global/PhysicalConstants.hpp
+++ b/src/Environment/Global/PhysicalConstants.hpp
@@ -31,7 +31,7 @@ DEFINE_PHYSICAL_CONSTANT(astronomical_unit_m, 1.49597870700e11L);               
 DEFINE_PHYSICAL_CONSTANT(gravitational_constant_Nm2_kg2, 6.67428e-11L);         /* best estimates Nm2/kg2 */
 DEFINE_PHYSICAL_CONSTANT(earth_equatorial_radius_m, 6378136.6L);                /* best estimates m */
 DEFINE_PHYSICAL_CONSTANT(earth_polar_radius_m, 6378136.6L);                     /* best estimates m */
-DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14 L); /* best estimates, TT m3/s2 */
+DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14L);  /* best estimates, TT m3/s2 */
 
 
 #undef DEFINE_PHYSICAL_CONSTANT

--- a/src/Environment/Global/PhysicalConstants.hpp
+++ b/src/Environment/Global/PhysicalConstants.hpp
@@ -32,6 +32,7 @@ DEFINE_PHYSICAL_CONSTANT(gravitational_constant_Nm2_kg2, 6.67428e-11L);         
 DEFINE_PHYSICAL_CONSTANT(earth_equatorial_radius_m, 6378136.6L);                /* best estimates m */
 DEFINE_PHYSICAL_CONSTANT(earth_polar_radius_m, 6378136.6L);                     /* best estimates m */
 DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14L);  /* best estimates, TT m3/s2 */
+DEFINE_PHYSICAL_CONSTANT(earth_mean_angular_velocity_rad_s, 7.292115e-5L);      /* best estimates, TT rad/s */
 
 
 #undef DEFINE_PHYSICAL_CONSTANT

--- a/src/Environment/Global/PhysicalConstants.hpp
+++ b/src/Environment/Global/PhysicalConstants.hpp
@@ -8,10 +8,8 @@
 
 #include <type_traits>  // std::is_floating_point_v
 
-namespace libra {
+namespace environment {
 
-// instead of C++20 std::numbers
-inline namespace numbers {
 template <typename T>
 using enable_if_float = std::enable_if_t<std::is_floating_point_v<T>, T>;
 
@@ -20,23 +18,24 @@ using enable_if_float = std::enable_if_t<std::is_floating_point_v<T>, T>;
   inline constexpr T name##_v = enable_if_float<T>(value); \
   inline constexpr double name = name##_v<double>;
 
-// TODO: Is the unit information needed in variable names?
-// Physics
+inline namespace physics {
 DEFINE_PHYSICAL_CONSTANT(speed_of_light_m_s, 299792458.0L);      /* in vacuum m/s */
 DEFINE_PHYSICAL_CONSTANT(boltzmann_constant_J_K, 1.380649e-23L); /* J/K */
 DEFINE_PHYSICAL_CONSTANT(absolute_zero_degC, -273.15L);          /* degC */
+}  // namespace physics
 
-// Astronomy Ref: https://iau-a3.gitlab.io/NSFA/
+inline namespace astronomy {
+// Ref: https://iau-a3.gitlab.io/NSFA/
 DEFINE_PHYSICAL_CONSTANT(astronomical_unit_m, 1.49597870700e11L);              /* fixed m */
 DEFINE_PHYSICAL_CONSTANT(gravitational_constant_Nm2_kg2, 6.67428e-11L);        /* best estimates Nm2/kg2 */
 DEFINE_PHYSICAL_CONSTANT(earth_equatorial_radius_m, 6378136.6L);               /* best estimates m */
 DEFINE_PHYSICAL_CONSTANT(earth_polar_radius_m, 6378136.6L);                    /* best estimates m */
 DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14L); /* best estimates, TT m3/s2 */
 DEFINE_PHYSICAL_CONSTANT(earth_mean_angular_velocity_rad_s, 7.292115e-5L);     /* best estimates, TT rad/s */
+}  // namespace astronomy
 
 #undef DEFINE_PHYSICAL_CONSTANT
-}  // namespace numbers
 
-}  // namespace libra
+}  // namespace environment
 
 #endif  // PHYSICAL_CONSTANT_HPP_

--- a/src/Environment/Global/PhysicalConstants.hpp
+++ b/src/Environment/Global/PhysicalConstants.hpp
@@ -1,0 +1,42 @@
+/**
+ * @file
+ * @brief header for physical constant values
+ */
+
+#ifndef PHYSICAL_CONSTANT_HPP_
+#define PHYSICAL_CONSTANT_HPP_
+
+#include <type_traits>  // std::is_floating_point_v
+
+namespace libra {
+
+// instead of C++20 std::numbers
+inline namespace numbers {
+template <typename T>
+using enable_if_float = std::enable_if_t<std::is_floating_point_v<T>, T>;
+
+#define DEFINE_PHYSICAL_CONSTANT(name, value)              \
+  template <typename T>                                    \
+  inline constexpr T name##_v = enable_if_float<T>(value); \
+  inline constexpr double name = name##_v<double>;
+
+// TODO: Is the unit information needed in variable names?
+// Physics
+DEFINE_PHYSICAL_CONSTANT(speed_of_light_m_s, 299792458.0L);              /* in vacuum m/s */
+DEFINE_PHYSICAL_CONSTANT(boltzmann_constant_J_K, 1.380649e-23L);         /* J/K */
+DEFINE_PHYSICAL_CONSTANT(absolute_zero_degC, -273.15L);                  /* degC */
+
+// Astronomy Ref: https://iau-a3.gitlab.io/NSFA/
+DEFINE_PHYSICAL_CONSTANT(astronomical_unit_m, 1.49597870700e11L);               /* fixed m */
+DEFINE_PHYSICAL_CONSTANT(gravitational_constant_Nm2_kg2, 6.67428e-11L);         /* best estimates Nm2/kg2 */
+DEFINE_PHYSICAL_CONSTANT(earth_equatorial_radius_m, 6378136.6L);                /* best estimates m */
+DEFINE_PHYSICAL_CONSTANT(earth_polar_radius_m, 6378136.6L);                     /* best estimates m */
+DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14 L); /* best estimates, TT m3/s2 */
+
+
+#undef DEFINE_PHYSICAL_CONSTANT
+}  // namespace numbers
+
+}  // namespace libra
+
+#endif  // PHYSICAL_CONSTANT_HPP_

--- a/src/Environment/Local/SRPEnvironment.cpp
+++ b/src/Environment/Local/SRPEnvironment.cpp
@@ -2,10 +2,9 @@
 
 #include <Interface/LogOutput/LogUtility.h>
 
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <Library/math/Constant.hpp>
 #include <Library/math/Vector.hpp>
-#include <Environment/Global/PhysicalConstants.hpp>
-
 #include <algorithm>
 #include <cassert>
 #include <fstream>
@@ -14,8 +13,8 @@ using libra::Vector;
 using namespace std;
 
 SRPEnvironment::SRPEnvironment(LocalCelestialInformation* local_celes_info) : local_celes_info_(local_celes_info) {
-  solar_constant_ = 1366.0;  // [W/m2]
-  pressure_ = solar_constant_ / libra::speed_of_light_m_s; // [N/m2]
+  solar_constant_ = 1366.0;                                 // [W/m2]
+  pressure_ = solar_constant_ / libra::speed_of_light_m_s;  // [N/m2]
   shadow_source_name_ = local_celes_info_->GetGlobalInfo().GetCenterBodyName();
   sun_radius_m_ = local_celes_info_->GetGlobalInfo().GetMeanRadiusFromName("SUN");
 }

--- a/src/Environment/Local/SRPEnvironment.cpp
+++ b/src/Environment/Local/SRPEnvironment.cpp
@@ -4,6 +4,8 @@
 
 #include <Library/math/Constant.hpp>
 #include <Library/math/Vector.hpp>
+#include <Environment/Global/PhysicalConstants.hpp>
+
 #include <algorithm>
 #include <cassert>
 #include <fstream>
@@ -12,10 +14,8 @@ using libra::Vector;
 using namespace std;
 
 SRPEnvironment::SRPEnvironment(LocalCelestialInformation* local_celes_info) : local_celes_info_(local_celes_info) {
-  astronomical_unit_ = 149597870700.0;  //[m]
-  c_ = 299792458.0;                     //[m/s]
-  solar_constant_ = 1366.0;             //[W/m2]
-  pressure_ = solar_constant_ / c_;     //[N/m2]
+  solar_constant_ = 1366.0;  // TODO: move to constant[W/m2]
+  pressure_ = solar_constant_ / libra::speed_of_light_m_s; //[N/m2]
   shadow_source_name_ = local_celes_info_->GetGlobalInfo().GetCenterBodyName();
   sun_radius_m_ = local_celes_info_->GetGlobalInfo().GetMeanRadiusFromName("SUN");
 }
@@ -30,12 +30,12 @@ void SRPEnvironment::UpdateAllStates() {
 void SRPEnvironment::UpdatePressure() {
   const Vector<3> r_sc2sun_eci = local_celes_info_->GetPosFromSC_i("SUN");
   const double distance_sat_to_sun = norm(r_sc2sun_eci);
-  pressure_ = solar_constant_ / c_ / pow(distance_sat_to_sun / astronomical_unit_, 2.0);
+  pressure_ = solar_constant_ / libra::speed_of_light_m_s / pow(distance_sat_to_sun / libra::astronomical_unit_m, 2.0);
 }
 
 double SRPEnvironment::CalcTruePressure() const { return pressure_ * shadow_coefficient_; }
 
-double SRPEnvironment::CalcPowerDensity() const { return pressure_ * c_ * shadow_coefficient_; }
+double SRPEnvironment::CalcPowerDensity() const { return pressure_ * libra::speed_of_light_m_s * shadow_coefficient_; }
 
 double SRPEnvironment::GetPressure() const { return pressure_; }
 

--- a/src/Environment/Local/SRPEnvironment.cpp
+++ b/src/Environment/Local/SRPEnvironment.cpp
@@ -13,8 +13,8 @@ using libra::Vector;
 using namespace std;
 
 SRPEnvironment::SRPEnvironment(LocalCelestialInformation* local_celes_info) : local_celes_info_(local_celes_info) {
-  solar_constant_ = 1366.0;                                 // [W/m2]
-  pressure_ = solar_constant_ / libra::speed_of_light_m_s;  // [N/m2]
+  solar_constant_ = 1366.0;                                       // [W/m2]
+  pressure_ = solar_constant_ / environment::speed_of_light_m_s;  // [N/m2]
   shadow_source_name_ = local_celes_info_->GetGlobalInfo().GetCenterBodyName();
   sun_radius_m_ = local_celes_info_->GetGlobalInfo().GetMeanRadiusFromName("SUN");
 }
@@ -29,12 +29,12 @@ void SRPEnvironment::UpdateAllStates() {
 void SRPEnvironment::UpdatePressure() {
   const Vector<3> r_sc2sun_eci = local_celes_info_->GetPosFromSC_i("SUN");
   const double distance_sat_to_sun = norm(r_sc2sun_eci);
-  pressure_ = solar_constant_ / libra::speed_of_light_m_s / pow(distance_sat_to_sun / libra::astronomical_unit_m, 2.0);
+  pressure_ = solar_constant_ / environment::speed_of_light_m_s / pow(distance_sat_to_sun / environment::astronomical_unit_m, 2.0);
 }
 
 double SRPEnvironment::CalcTruePressure() const { return pressure_ * shadow_coefficient_; }
 
-double SRPEnvironment::CalcPowerDensity() const { return pressure_ * libra::speed_of_light_m_s * shadow_coefficient_; }
+double SRPEnvironment::CalcPowerDensity() const { return pressure_ * environment::speed_of_light_m_s * shadow_coefficient_; }
 
 double SRPEnvironment::GetPressure() const { return pressure_; }
 

--- a/src/Environment/Local/SRPEnvironment.cpp
+++ b/src/Environment/Local/SRPEnvironment.cpp
@@ -14,8 +14,8 @@ using libra::Vector;
 using namespace std;
 
 SRPEnvironment::SRPEnvironment(LocalCelestialInformation* local_celes_info) : local_celes_info_(local_celes_info) {
-  solar_constant_ = 1366.0;  // TODO: move to constant[W/m2]
-  pressure_ = solar_constant_ / libra::speed_of_light_m_s; //[N/m2]
+  solar_constant_ = 1366.0;  // [W/m2]
+  pressure_ = solar_constant_ / libra::speed_of_light_m_s; // [N/m2]
   shadow_source_name_ = local_celes_info_->GetGlobalInfo().GetCenterBodyName();
   sun_radius_m_ = local_celes_info_->GetGlobalInfo().GetMeanRadiusFromName("SUN");
 }

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -26,8 +26,9 @@ class SRPEnvironment : public ILoggable {
   virtual std::string GetLogValue() const;   // log of value
 
  private:
-  double pressure_;                  // solar radiation constant [N/m^2]
+  double pressure_;                  // solar radiation pressure [N/m^2]
   double solar_constant_;            // solar constant [W/m^2]
+                                     // TODO: This value is not a constant value in real. We need to change the value depends on sun activity.
   double shadow_coefficient_ = 1.0;  // shadow function
   double sun_radius_m_;
   std::string shadow_source_name_;

--- a/src/Environment/Local/SRPEnvironment.h
+++ b/src/Environment/Local/SRPEnvironment.h
@@ -27,8 +27,6 @@ class SRPEnvironment : public ILoggable {
 
  private:
   double pressure_;                  // solar radiation constant [N/m^2]
-  double astronomical_unit_;         // 1AU [m]
-  double c_;                         // speed of light [m/s]
   double solar_constant_;            // solar constant [W/m^2]
   double shadow_coefficient_ = 1.0;  // shadow function
   double sun_radius_m_;

--- a/src/Library/igrf/igrf.cpp
+++ b/src/Library/igrf/igrf.cpp
@@ -60,6 +60,8 @@ double testglobal[3];
 /*   Basic Routines   */
 /*--------------------*/
 
+// TODO: Consider how to fix the following constant values in this library copied from outside
+
 #define MxOD 19
 #define URAD (180. / 3.14159265359)
 

--- a/src/Library/math/Constant.hpp
+++ b/src/Library/math/Constant.hpp
@@ -35,6 +35,10 @@ DEFINE_MATH_CONSTANT(tau, 6.283185307179586476925286766559005768L);        /* pi
 
 static_assert(3.14 < pi && pi < 3.15, "pi");
 
+// angle conversion
+DEFINE_MATH_CONSTANT(deg_to_rad, pi/180.0L);              /* degree to radian */
+DEFINE_MATH_CONSTANT(arcsec_to_rad, deg_to_rad/3600.0L);  /* arcsecond to radian */
+
 #undef DEFINE_MATH_CONSTANT
 }  // namespace numbers
 

--- a/src/Library/math/Constant.hpp
+++ b/src/Library/math/Constant.hpp
@@ -37,6 +37,7 @@ static_assert(3.14 < pi && pi < 3.15, "pi");
 
 // angle conversion
 DEFINE_MATH_CONSTANT(deg_to_rad, pi/180.0L);              /* degree to radian */
+DEFINE_MATH_CONSTANT(rad_to_deg, 180.0L/pi);              /* radian to degree */
 DEFINE_MATH_CONSTANT(arcsec_to_rad, deg_to_rad/3600.0L);  /* arcsecond to radian */
 
 #undef DEFINE_MATH_CONSTANT

--- a/src/Library/math/Constant.hpp
+++ b/src/Library/math/Constant.hpp
@@ -36,9 +36,9 @@ DEFINE_MATH_CONSTANT(tau, 6.283185307179586476925286766559005768L);        /* pi
 static_assert(3.14 < pi && pi < 3.15, "pi");
 
 // angle conversion
-DEFINE_MATH_CONSTANT(deg_to_rad, pi/180.0L);              /* degree to radian */
-DEFINE_MATH_CONSTANT(rad_to_deg, 180.0L/pi);              /* radian to degree */
-DEFINE_MATH_CONSTANT(arcsec_to_rad, deg_to_rad/3600.0L);  /* arcsecond to radian */
+DEFINE_MATH_CONSTANT(deg_to_rad, pi / 180.0L);             /* degree to radian */
+DEFINE_MATH_CONSTANT(rad_to_deg, 180.0L / pi);             /* radian to degree */
+DEFINE_MATH_CONSTANT(arcsec_to_rad, deg_to_rad / 3600.0L); /* arcsecond to radian */
 
 #undef DEFINE_MATH_CONSTANT
 }  // namespace numbers

--- a/src/Library/nrlmsise00/Wrapper_nrlmsise00.cpp
+++ b/src/Library/nrlmsise00/Wrapper_nrlmsise00.cpp
@@ -9,6 +9,7 @@ extern "C" {
 #include <stdlib.h> /* for malloc/free */
 
 #include <Library/math/Constant.hpp>
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <algorithm>
 #include <cctype>
 #include <cmath> /* maths functions */
@@ -21,8 +22,6 @@ using namespace std;
 /* ------------------------------------------------------------------- */
 /* ------------------------------ DEFINES ---------------------------- */
 /* ------------------------------------------------------------------- */
-
-#define RAD2DEG (180 / libra::pi)
 
 static double decyear_monthly;
 
@@ -185,9 +184,9 @@ double CalcNRLMSISE00(double decyear, double latrad, double lonrad, double alt, 
   input.year = 0; /* without effect */
   input.sec = date[3] * 60.0 * 60.0 + date[4] * 60.0 + date[5];
   input.alt = alt / 1000.0;
-  input.g_lat = latrad * RAD2DEG;
-  input.g_long = lonrad * RAD2DEG;
-  input.lst = input.sec / 3600.0 + lonrad * RAD2DEG / 15.0;
+  input.g_lat = latrad * libra::rad_to_deg;
+  input.g_long = lonrad * libra::rad_to_deg;
+  input.lst = input.sec / 3600.0 + lonrad * libra::rad_to_deg / 15.0;
 
   if (is_manual_param) {
     input.f107 = manual_f107;

--- a/src/Library/nrlmsise00/Wrapper_nrlmsise00.cpp
+++ b/src/Library/nrlmsise00/Wrapper_nrlmsise00.cpp
@@ -8,8 +8,8 @@ extern "C" {
 }
 #include <stdlib.h> /* for malloc/free */
 
-#include <Library/math/Constant.hpp>
 #include <Environment/Global/PhysicalConstants.hpp>
+#include <Library/math/Constant.hpp>
 #include <algorithm>
 #include <cctype>
 #include <cmath> /* maths functions */

--- a/src/Simulation/GroundStation/GroundStation.cpp
+++ b/src/Simulation/GroundStation/GroundStation.cpp
@@ -2,6 +2,7 @@
 
 #include <Interface/LogOutput/LogUtility.h>
 #include <Interface/LogOutput/Logger.h>
+#include <Environment/Global/PhysicalConstants.hpp>
 
 #include <cmath>
 #include <string>
@@ -31,19 +32,19 @@ void GroundStation::LogSetup(Logger& logger) {}
 void GroundStation::Update(const double& current_jd)  // 慣性系での地上局位置を更新する
 {
   double current_side = gstime(current_jd);
-  double theta = FMod2p(longitude_ * DEG2RAD + current_side);  //[rad]
+  double theta = FMod2p(longitude_ * libra::deg_to_rad + current_side);  //[rad]
 
   double radiusearthkm;
   double f;
   getwgsconst(whichconst_gs, radiusearthkm, f);
 
   double e2 = f * (2 - f);
-  double c = 1 / sqrt(1 - e2 * sin(latitude_ * DEG2RAD) * sin(latitude_ * DEG2RAD));
+  double c = 1 / sqrt(1 - e2 * sin(latitude_ * libra::deg_to_rad) * sin(latitude_ * libra::deg_to_rad));
   double N = c * radiusearthkm * 1000.0;  //[metre]
 
-  double x = (N + height_) * cos(latitude_ * DEG2RAD) * cos(theta);  //[metre]
-  double y = (N + height_) * cos(latitude_ * DEG2RAD) * sin(theta);  //[metre]
-  double z = (N * (1 - e2) + height_) * sin(latitude_ * DEG2RAD);    //[metre]
+  double x = (N + height_) * cos(latitude_ * libra::deg_to_rad) * cos(theta);  //[metre]
+  double y = (N + height_) * cos(latitude_ * libra::deg_to_rad) * sin(theta);  //[metre]
+  double z = (N * (1 - e2) + height_) * sin(latitude_ * libra::deg_to_rad);    //[metre]
 
   gs_position_i_(0) = x;
   gs_position_i_(1) = y;

--- a/src/Simulation/GroundStation/GroundStation.cpp
+++ b/src/Simulation/GroundStation/GroundStation.cpp
@@ -2,8 +2,8 @@
 
 #include <Interface/LogOutput/LogUtility.h>
 #include <Interface/LogOutput/Logger.h>
-#include <Environment/Global/PhysicalConstants.hpp>
 
+#include <Environment/Global/PhysicalConstants.hpp>
 #include <cmath>
 #include <string>
 

--- a/src/Simulation/GroundStation/GroundStation.h
+++ b/src/Simulation/GroundStation/GroundStation.h
@@ -13,7 +13,6 @@
 #include <Library/sgp4/sgp4io.h>
 #include <Library/sgp4/sgp4unit.h>
 
-#define DEG2RAD 0.017453292519943295769  // PI/180
 static gravconsttype whichconst_gs;
 //↑
 


### PR DESCRIPTION
## Overview
Modify physical constants management.

## Issue
- #7 

## Details
Physical constants are defined in `Environment/Global/physical_constants.hpp`.   
All codes refer to the values from there.  
Angular conversion constants are also defined in `Library/math/constant.hpp`.

##  Validation results
I confirmed the output log file is similar between before and after this modification.

## Scope of influence
large

## Supplement
Some codes from outside still have several constant values, but I didn't focus on them in this PR. 

## Note
- NA
