### PR TITLE
Fix log output bug

### DIFF
--- a/src/Simulation/Case/SimulationCase.cpp
+++ b/src/Simulation/Case/SimulationCase.cpp
@@ -32,7 +32,4 @@ SimulationCase::SimulationCase(std::string ini_base, const MCSimExecutor& mc_sim
   // Global Environment
   glo_env_ = new GlobalEnvironment(&sim_config_);
 }
-SimulationCase::~SimulationCase() {
-  delete glo_env_;
-  delete sim_config_.main_logger_;
-}
+SimulationCase::~SimulationCase() { delete glo_env_; }

--- a/src/Simulation/Case/SimulationCase.cpp
+++ b/src/Simulation/Case/SimulationCase.cpp
@@ -32,4 +32,7 @@ SimulationCase::SimulationCase(std::string ini_base, const MCSimExecutor& mc_sim
   // Global Environment
   glo_env_ = new GlobalEnvironment(&sim_config_);
 }
-SimulationCase::~SimulationCase() { delete glo_env_; }
+SimulationCase::~SimulationCase() {
+  delete glo_env_;
+  delete sim_config_.main_logger_;
+}

--- a/src/Simulation/SimulationConfig.h
+++ b/src/Simulation/SimulationConfig.h
@@ -12,4 +12,6 @@ struct SimulationConfig {
   std::string gs_file_;
   std::string inter_sat_comm_file_;
   std::string gnss_file_;
+
+  ~SimulationConfig() { delete main_logger_; }
 };


### PR DESCRIPTION
## Overview
Fix log output bug.

## Issue
NA

## Details
The previous code cannot output results of last several seconds in the CSV file because the file closing process is not executed.  
I fixed it.

##  Validation results
I confirmed the S2E can output all results.

## Scope of influence
Only for log output.

## Supplement
This bug is occurred in Linux environment but not in Windows.

## Note
NA