### PR TITLE
Add Kepler and Encke orbit propagation method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ add_subdirectory(src/Library/sgp4)
 add_subdirectory(src/Library/utils)
 add_subdirectory(src/Library/optics)
 add_subdirectory(src/Library/RelativeOrbit)
+add_subdirectory(src/Library/Orbit)
 
 set(SOURCE_FILES
   src/S2E.cpp
@@ -136,7 +137,7 @@ endif()
 
 ## Linking libraries
 set(S2E_LIBRARIES
-  IGRF WRAPPER_NRLMSISE00 INIH MATH SGP4 UTIL OPTICS RELATIVE_ORBIT_MODELS
+  IGRF WRAPPER_NRLMSISE00 INIH SGP4 UTIL OPTICS RELATIVE_ORBIT_MODELS ORBIT_MODELS MATH
 )
 # Initialize link
 target_link_libraries(COMPONENT INTERFACE INI_IN DYNAMICS GLOBAL_ENVIRONMENT LOCAL_ENVIRONMENT SC_IO RELATIVE_INFO ${S2E_LIBRARIES})

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -51,31 +51,34 @@ pointing_sub_t_b(2) = 1.0
 calculation = ENABLE
 logging = ENABLE
 
+// World Geodetic System
+wgs = 2 // 0: wgs72old, 1: wgs72, 2: wgs84
+
 // Orbit propagation mode
 // 0: RK4 with initial position and velocity
 // 1: SGP4 with TLE
 // 2: Relative dynamics (for formation flying simulation)
 // 3: Kepler Orbit Propagation
-propagate_mode = 3
+// 4: Encke Orbit Propagation
+propagate_mode = 0
 
 // TLE definition for SGP4 ///////////////////////////////////////////////
 // ISS
 tle1=1 25544U 98067A   20076.51604214  .00016717  00000-0  10270-3 0  9005
 tle2=2 25544  51.6412  86.9962 0006063  30.9353 329.2153 15.49228202 17647
-wgs = 2 // 0: wgs72old, 1: wgs72, 2: wgs84
 //////////////////////////////////////////////////////////////////////////
 
 // Initial value definition for RK4 //////////////////////////////////////
 // ＊The coordinate system is defined in PlanetSelect.ini
 // Initial satellite position[m] 
-init_position(0) = 4.2164140100E+07  // radius of GEO
-init_position(1) = 0
-init_position(2) = 0
+init_position(0) = 2882338.197
+init_position(1) = -3601791.324
+init_position(2) = -5002582.63
 
 //initial satellite velocity[m/s]
-init_velocity(0) = 0
-init_velocity(1) = 3.074661E+03  // Speed of a spacecraft in GEO
-init_velocity(2) = 0
+init_velocity(0) = 6877.224962
+init_velocity(1) = 2613.068629
+init_velocity(2) = 2084.426745
 ///////////////////////////////////////////////////////////////////////////
 
 
@@ -113,6 +116,12 @@ inclination_rad = 0.9012
 raan_rad = 0.1411
 arg_perigee_rad = 1.7952
 epoch_jday = 2.458940966402607e6
+///////////////////////////////////////////////////////////////////////////////
+
+
+// Information used for orbital propagation by the Encke Formulation ///////////
+error_tolerance = 0.01
+// initialize position and vector are same with RK4 setting
 ///////////////////////////////////////////////////////////////////////////////
 
 

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -55,7 +55,8 @@ logging = ENABLE
 // 0: RK4 with initial position and velocity
 // 1: SGP4 with TLE
 // 2: Relative dynamics (for formation flying simulation)
-propagate_mode = 1
+// 3: Kepler Orbit Propagation
+propagate_mode = 3
 
 // TLE definition for SGP4 ///////////////////////////////////////////////
 // ISS
@@ -98,6 +99,20 @@ init_relative_velocity_lvlh(1) = 0.0
 init_relative_velocity_lvlh(2) = 0.0
 // information of reference satellite
 reference_sat_id = 1
+///////////////////////////////////////////////////////////////////////////////
+
+
+// Information used for orbital propagation by the Kepler Motion ///////////
+// initialize mode for kepler motion
+init_mode_kepler = 1
+// 0 : initialize with position and velocity defined for RK4
+// 1 : initialize with the following orbital elements
+semi_major_axis_m = 6794500.0
+eccentricity = 0.0015
+inclination_rad = 0.9012
+raan_rad = 0.1411
+arg_perigee_rad = 1.7952
+epoch_jday = 2.458940966402607e6
 ///////////////////////////////////////////////////////////////////////////////
 
 

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -55,12 +55,12 @@ logging = ENABLE
 wgs = 2 // 0: wgs72old, 1: wgs72, 2: wgs84
 
 // Orbit propagation mode
-// RK4: use RK4 propagation with initial position and velocity with thruster maneuver
-// SGP4: Use SGP4 with TLE without thruster maneuver
-// RELATIVE: Relative dynamics (for formation flying simulation)
-// KEPLER: Kepler Orbit Propagation without disturbances and thruster maneuver
-// ENCKE: Encke Orbit Propagation
-propagate_mode = ENCKE
+// RK4      : RK4 propagation with disturbances and thruster maneuver
+// SGP4     : SGP4 propagation using TLE without thruster maneuver
+// RELATIVE : Relative dynamics (for formation flying simulation)
+// KEPLER   : Kepler orbit propagation without disturbances and thruster maneuver
+// ENCKE    : Encke orbit propagation with disturbances and thruster maneuver
+propagate_mode = RK4
 
 // TLE definition for SGP4 ///////////////////////////////////////////////
 // ISS
@@ -71,14 +71,14 @@ tle2=2 25544  51.6412  86.9962 0006063  30.9353 329.2153 15.49228202 17647
 // Initial value definition for RK4 //////////////////////////////////////
 // ＊The coordinate system is defined in PlanetSelect.ini
 // Initial satellite position[m] 
-init_position(0) = 2882338.197
-init_position(1) = -3601791.324
-init_position(2) = -5002582.63
+init_position(0) = 4.2164140100E+07  // radius of GEO
+init_position(1) = 0
+init_position(2) = 0
 
 //initial satellite velocity[m/s]
-init_velocity(0) = 6877.224962
-init_velocity(1) = 2613.068629
-init_velocity(2) = 2084.426745
+init_velocity(0) = 0
+init_velocity(1) = 3.074661E+03  // Speed of a spacecraft in GEO
+init_velocity(2) = 0
 ///////////////////////////////////////////////////////////////////////////
 
 

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -107,9 +107,10 @@ reference_sat_id = 1
 
 // Information used for orbital propagation by the Kepler Motion ///////////
 // initialize mode for kepler motion
-init_mode_kepler = 1
-// 0 : initialize with position and velocity defined for RK4
-// 1 : initialize with the following orbital elements
+// INIT_POSVEL : initialize with position and velocity defined for RK4
+// INIT_OE : initialize with the following orbital elements
+init_mode_kepler = INIT_POSVEL
+// Orbital Elements for INIT_OE
 semi_major_axis_m = 6794500.0
 eccentricity = 0.0015
 inclination_rad = 0.9012
@@ -120,7 +121,7 @@ epoch_jday = 2.458940966402607e6
 
 
 // Information used for orbital propagation by the Encke Formulation ///////////
-error_tolerance = 0.01
+error_tolerance = 0.0001
 // initialize position and vector are same with RK4 setting
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -55,12 +55,12 @@ logging = ENABLE
 wgs = 2 // 0: wgs72old, 1: wgs72, 2: wgs84
 
 // Orbit propagation mode
-// 0: RK4 with initial position and velocity
-// 1: SGP4 with TLE
-// 2: Relative dynamics (for formation flying simulation)
-// 3: Kepler Orbit Propagation
-// 4: Encke Orbit Propagation
-propagate_mode = 0
+// RK4: use RK4 propagation with initial position and velocity with thruster maneuver
+// SGP4: Use SGP4 with TLE without thruster maneuver
+// RELATIVE: Relative dynamics (for formation flying simulation)
+// KEPLER: Kepler Orbit Propagation without disturbances and thruster maneuver
+// ENCKE: Encke Orbit Propagation
+propagate_mode = ENCKE
 
 // TLE definition for SGP4 ///////////////////////////////////////////////
 // ISS

--- a/src/Dynamics/CMakeLists.txt
+++ b/src/Dynamics/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${PROJECT_NAME} STATIC
   Orbit/EarthCenteredOrbit.cpp
   Orbit/SimpleCircularOrbit.cpp
   Orbit/RelativeOrbit.cpp
+  Orbit/KeplerOrbitPropagation.cpp
   Thermal/Node.cpp
   Thermal/Temperature.cpp
   Attitude/AttitudeRK4.cpp

--- a/src/Dynamics/CMakeLists.txt
+++ b/src/Dynamics/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(${PROJECT_NAME} STATIC
   Orbit/SimpleCircularOrbit.cpp
   Orbit/RelativeOrbit.cpp
   Orbit/KeplerOrbitPropagation.cpp
+  Orbit/EnckeOrbitPropagation.cpp
   Thermal/Node.cpp
   Thermal/Temperature.cpp
   Attitude/AttitudeRK4.cpp

--- a/src/Dynamics/Orbit/EnckeOrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/EnckeOrbitPropagation.cpp
@@ -1,0 +1,157 @@
+#include "EnckeOrbitPropagation.h"
+#include "../../Library/Orbit/OrbitalElements.h"
+
+EnckeOrbitPropagation::EnckeOrbitPropagation(
+  const double mu_m3_s2,
+  const double prop_step_s,
+  const double current_jd,
+  const Vector<3> init_position_i_m, 
+  const Vector<3> init_velocity_i_m_s,
+  const double error_tolerance,
+  const int wgs
+):mu_m3_s2_(mu_m3_s2), error_tolerance_(error_tolerance), prop_step_s_(prop_step_s), libra::ODE<6>(prop_step_s)
+{
+  // TODO whichconst周りを整理する
+  if (wgs == 0) { whichconst = wgs72old; }
+  else if (wgs == 1) { whichconst = wgs72; }
+  else if (wgs == 2) { whichconst = wgs84; }
+
+  prop_time_s_ = 0.0;
+  Initialize(current_jd, init_position_i_m, init_velocity_i_m_s);
+}
+
+EnckeOrbitPropagation::~EnckeOrbitPropagation()
+{
+}
+
+// Functions for Orbit
+void EnckeOrbitPropagation::Propagate(double endtime, double current_jd)
+{
+  if (!IsCalcEnabled) return;
+
+  // Rectification
+  double norm_sat_position_m = norm(sat_position_i_);
+  double norm_diff_position_m = norm(diff_position_i_m_);
+  if (norm_diff_position_m/norm_sat_position_m > error_tolerance_)
+  {
+    Initialize(current_jd, sat_position_i_, sat_velocity_i_);
+  }
+
+  // Update reference orbit
+  ref_kepler_orbit.CalcPosVel(current_jd);
+  ref_position_i_m_ = ref_kepler_orbit.GetPosition_i_m();
+  ref_velocity_i_m_s_ = ref_kepler_orbit.GetVelocity_i_m_s();
+
+  // Propagate difference orbit
+  setStepWidth(prop_step_s_); //Re-set propagation Δt
+  while (endtime - prop_time_s_ - prop_step_s_ > 1.0e-6) 
+  {
+    Update(); // Propagation methods of the ODE class
+    prop_time_s_ += prop_step_s_;
+  }
+  setStepWidth(endtime - prop_time_s_); //Adjust the last propagation Δt
+  Update();
+  prop_time_s_ = endtime;
+  
+  acc_i_ *= 0.0; //Reset disturbance acceleration
+  diff_position_i_m_[0]   = state()[0];
+  diff_position_i_m_[1]   = state()[1];
+  diff_position_i_m_[2]   = state()[2];
+  diff_velocity_i_m_s_[0] = state()[3];
+  diff_velocity_i_m_s_[1] = state()[4];
+  diff_velocity_i_m_s_[2] = state()[5];
+
+  UpdateSatOrbit(current_jd);
+}
+
+std::string EnckeOrbitPropagation::GetLogHeader() const
+{
+  std::string str_tmp = "";
+
+  str_tmp += WriteVector("sat_position", "i", "m", 3);
+  str_tmp += WriteVector("sat_velocity", "i", "m/s", 3);
+  str_tmp += WriteVector("sat_acc", "i", "m/s^2", 3);
+
+  return str_tmp;
+}
+
+std::string EnckeOrbitPropagation::GetLogValue() const
+{
+  std::string str_tmp = "";
+
+  str_tmp += WriteVector(sat_position_i_, 16);
+  str_tmp += WriteVector(sat_velocity_i_, 10);
+  str_tmp += WriteVector(acc_i_, 10);
+
+  return str_tmp;
+}
+
+// Functions for ODE
+void EnckeOrbitPropagation::RHS(double t, const Vector<6>& state, Vector<6>& rhs)
+{
+  Vector<3> diff_pos_i_m, diff_acc_i_m_s2;
+  for (int i=0;i<3;i++)
+  {
+    diff_pos_i_m[i] = state[i];
+  }
+  
+  double q_func = CalcQFunction(diff_pos_i_m);
+  double r_m = norm(ref_position_i_m_);
+  double r_m3 = pow(r_m, 3.0);
+
+  diff_acc_i_m_s2 = - (mu_m3_s2_ / r_m3) *(q_func * sat_position_i_ + diff_pos_i_m) + acc_i_;
+
+  rhs[0] = state[3]; 
+  rhs[1] = state[4];
+  rhs[2] = state[5];
+  rhs[3] = diff_acc_i_m_s2[0];
+  rhs[4] = diff_acc_i_m_s2[1];
+  rhs[5] = diff_acc_i_m_s2[2];
+}
+
+// Private Functions
+void EnckeOrbitPropagation::Initialize(
+  double current_jd,
+  Vector<3> init_ref_position_i_m, 
+  Vector<3> init_ref_velocity_i_m_s)
+{
+  // General
+  fill_up(acc_i_, 0.0);
+
+  // reference orbit
+  ref_position_i_m_ = init_ref_position_i_m;
+  ref_velocity_i_m_s_ = init_ref_velocity_i_m_s;
+  OrbitalElements oe_ref(mu_m3_s2_, current_jd, init_ref_position_i_m, init_ref_velocity_i_m_s);
+  ref_kepler_orbit = KeplerOrbit(mu_m3_s2_, current_jd, oe_ref);
+
+  // difference orbit
+  fill_up(diff_position_i_m_, 0.0);
+  fill_up(diff_velocity_i_m_s_, 0.0);
+
+  UpdateSatOrbit(current_jd);
+}
+
+void EnckeOrbitPropagation::UpdateSatOrbit(double current_jd)
+{
+  sat_position_i_ = ref_position_i_m_ + diff_position_i_m_;
+  sat_velocity_i_ = ref_velocity_i_m_s_ + diff_velocity_i_m_s_;
+  
+  // ECI->ECEF
+  TransECIToGeo(current_jd);
+  TransECIToECEF(current_jd);
+}
+
+double EnckeOrbitPropagation::CalcQFunction(Vector<3> diff_pos_i)
+{
+  double r2;
+  r2 = inner_product(sat_position_i_, sat_position_i_);
+  
+  Vector<3> dr_2r;
+  dr_2r = diff_pos_i - 2.0 * sat_position_i_;
+
+  double q = inner_product(diff_pos_i, dr_2r) / r2;
+
+  double q_func = q*(q*q + 3.0*q + 3.0)/(pow(1.0+q, 1.5)+1.0);
+
+  return q_func;
+}

--- a/src/Dynamics/Orbit/EnckeOrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/EnckeOrbitPropagation.cpp
@@ -128,6 +128,9 @@ void EnckeOrbitPropagation::Initialize(
   fill_up(diff_position_i_m_, 0.0);
   fill_up(diff_velocity_i_m_s_, 0.0);
 
+  Vector<6> zero(0.0f);
+  setup(0.0, zero);
+
   UpdateSatOrbit(current_jd);
 }
 

--- a/src/Dynamics/Orbit/EnckeOrbitPropagation.h
+++ b/src/Dynamics/Orbit/EnckeOrbitPropagation.h
@@ -1,20 +1,12 @@
 #pragma once
-#include "Orbit.h"
-#include "../../Library/math/ODE.hpp"
 #include "../../Library/Orbit/KeplerOrbit.h"
+#include "../../Library/math/ODE.hpp"
+#include "Orbit.h"
 
-class EnckeOrbitPropagation : public Orbit, public libra::ODE<6>
-{
-public:
-  EnckeOrbitPropagation(
-    const double mu_m3_s2,
-    const double prop_step_s,
-    const double current_jd,
-    const Vector<3> init_position_i_m, 
-    const Vector<3> init_velocity_i_m_s,
-    const double error_tolerance,
-    const int wgs
-  );
+class EnckeOrbitPropagation : public Orbit, public libra::ODE<6> {
+ public:
+  EnckeOrbitPropagation(const double mu_m3_s2, const double prop_step_s, const double current_jd, const Vector<3> init_position_i_m,
+                        const Vector<3> init_velocity_i_m_s, const double error_tolerance, const int wgs);
   ~EnckeOrbitPropagation();
 
   // Orbit class
@@ -25,12 +17,12 @@ public:
   // ODE class
   virtual void RHS(double t, const Vector<6>& state, Vector<6>& rhs);
 
-private:
+ private:
   // General
   const double mu_m3_s2_;
   const double error_tolerance_;  // error ratio
-  double prop_step_s_; //Δt for RK4 
-  double prop_time_s_; //Simulation current time for numerical integration by RK4
+  double prop_step_s_;            //Δt for RK4
+  double prop_time_s_;            // Simulation current time for numerical integration by RK4
 
   // reference orbit
   Vector<3> ref_position_i_m_;
@@ -42,10 +34,7 @@ private:
   Vector<3> diff_velocity_i_m_s_;
 
   // functions
-  void Initialize(
-    double current_jd,
-    Vector<3> init_ref_position_i_m, 
-    Vector<3> init_ref_velocity_i_m_s);
+  void Initialize(double current_jd, Vector<3> init_ref_position_i_m, Vector<3> init_ref_velocity_i_m_s);
   void UpdateSatOrbit(double current_jd);
   double CalcQFunction(Vector<3> diff_pos_i);
 };

--- a/src/Dynamics/Orbit/EnckeOrbitPropagation.h
+++ b/src/Dynamics/Orbit/EnckeOrbitPropagation.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "Orbit.h"
+#include "../../Library/math/ODE.hpp"
+#include "../../Library/Orbit/KeplerOrbit.h"
+
+class EnckeOrbitPropagation : public Orbit, public libra::ODE<6>
+{
+public:
+  EnckeOrbitPropagation(
+    const double mu_m3_s2,
+    const double prop_step_s,
+    const double current_jd,
+    const Vector<3> init_position_i_m, 
+    const Vector<3> init_velocity_i_m_s,
+    const double error_tolerance,
+    const int wgs
+  );
+  ~EnckeOrbitPropagation();
+
+  // Orbit class
+  virtual void Propagate(double endtime, double current_jd);
+  virtual std::string GetLogHeader() const;
+  virtual std::string GetLogValue() const;
+
+  // ODE class
+  virtual void RHS(double t, const Vector<6>& state, Vector<6>& rhs);
+
+private:
+  // General
+  const double mu_m3_s2_;
+  const double error_tolerance_;  // error ratio
+  double prop_step_s_; //Δt for RK4 
+  double prop_time_s_; //Simulation current time for numerical integration by RK4
+
+  // reference orbit
+  Vector<3> ref_position_i_m_;
+  Vector<3> ref_velocity_i_m_s_;
+  KeplerOrbit ref_kepler_orbit;
+
+  // difference orbit
+  Vector<3> diff_position_i_m_;
+  Vector<3> diff_velocity_i_m_s_;
+
+  // functions
+  void Initialize(
+    double current_jd,
+    Vector<3> init_ref_position_i_m, 
+    Vector<3> init_ref_velocity_i_m_s);
+  void UpdateSatOrbit(double current_jd);
+  double CalcQFunction(Vector<3> diff_pos_i);
+};

--- a/src/Dynamics/Orbit/EnckeOrbitPropagation.h
+++ b/src/Dynamics/Orbit/EnckeOrbitPropagation.h
@@ -21,7 +21,7 @@ class EnckeOrbitPropagation : public Orbit, public libra::ODE<6> {
   // General
   const double mu_m3_s2_;
   const double error_tolerance_;  // error ratio
-  double prop_step_s_;            //Δt for RK4
+  double prop_step_s_;            // Δt for RK4
   double prop_time_s_;            // Simulation current time for numerical integration by RK4
 
   // reference orbit

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
@@ -4,7 +4,7 @@
 KeplerOrbitPropagation::KeplerOrbitPropagation(
   const double current_jd,
   KeplerOrbit kepler_orbit,
-  int wgs
+  const int wgs
 ):KeplerOrbit(kepler_orbit)
 {
   // TODO whichconst周りを整理する

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
@@ -1,33 +1,29 @@
 #include "KeplerOrbitPropagation.h"
+
 #include "../../Library/math/s2e_math.hpp"
 
-KeplerOrbitPropagation::KeplerOrbitPropagation(
-  const double current_jd,
-  KeplerOrbit kepler_orbit,
-  const int wgs
-):KeplerOrbit(kepler_orbit)
-{
+KeplerOrbitPropagation::KeplerOrbitPropagation(const double current_jd, KeplerOrbit kepler_orbit, const int wgs) : KeplerOrbit(kepler_orbit) {
   // TODO whichconst周りを整理する
-  if (wgs == 0) { whichconst = wgs72old; }
-  else if (wgs == 1) { whichconst = wgs72; }
-  else if (wgs == 2) { whichconst = wgs84; }
+  if (wgs == 0) {
+    whichconst = wgs72old;
+  } else if (wgs == 1) {
+    whichconst = wgs72;
+  } else if (wgs == 2) {
+    whichconst = wgs84;
+  }
 
   UpdateState(current_jd);
 }
 
-KeplerOrbitPropagation::~KeplerOrbitPropagation()
-{
-}
+KeplerOrbitPropagation::~KeplerOrbitPropagation() {}
 
-void KeplerOrbitPropagation::Propagate(double endtime, double current_jd)
-{
+void KeplerOrbitPropagation::Propagate(double endtime, double current_jd) {
   if (!IsCalcEnabled) return;
 
   UpdateState(current_jd);
 }
 
-std::string KeplerOrbitPropagation::GetLogHeader() const
-{
+std::string KeplerOrbitPropagation::GetLogHeader() const {
   std::string str_tmp = "";
 
   str_tmp += WriteVector("sat_position", "i", "m", 3);
@@ -41,8 +37,7 @@ std::string KeplerOrbitPropagation::GetLogHeader() const
   return str_tmp;
 }
 
-std::string KeplerOrbitPropagation::GetLogValue() const
-{
+std::string KeplerOrbitPropagation::GetLogValue() const {
   std::string str_tmp = "";
 
   str_tmp += WriteVector(sat_position_i_, 16);
@@ -57,8 +52,7 @@ std::string KeplerOrbitPropagation::GetLogValue() const
 }
 
 // Private Function
-void KeplerOrbitPropagation::UpdateState(const double current_jd)
-{
+void KeplerOrbitPropagation::UpdateState(const double current_jd) {
   CalcPosVel(current_jd);
   sat_position_i_ = position_i_m_;
   sat_velocity_i_ = velocity_i_m_s_;

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
@@ -1,0 +1,60 @@
+#include "KeplerOrbitPropagation.h"
+#include "../../Library/math/s2e_math.hpp"
+
+KeplerOrbitPropagation::KeplerOrbitPropagation(
+  const double current_jd,
+  KeplerOrbit kepler_orbit
+):KeplerOrbit(kepler_orbit)
+{
+  UpdateState(current_jd);
+}
+
+KeplerOrbitPropagation::~KeplerOrbitPropagation()
+{
+}
+
+void KeplerOrbitPropagation::Propagate(double endtime, double current_jd)
+{
+  if (!IsCalcEnabled) return;
+
+  UpdateState(current_jd);
+}
+
+std::string KeplerOrbitPropagation::GetLogHeader() const
+{
+  std::string str_tmp = "";
+
+  str_tmp += WriteVector("sat_position", "i", "m", 3);
+  str_tmp += WriteVector("sat_velocity", "i", "m/s", 3);
+  str_tmp += WriteVector("sat_velocity", "b", "m/s", 3);
+  str_tmp += WriteVector("sat_acc_i", "i", "m/s^2", 3);
+  str_tmp += WriteScalar("lat", "rad");
+  str_tmp += WriteScalar("lon", "rad");
+  str_tmp += WriteScalar("alt", "m");
+
+  return str_tmp;
+}
+
+std::string KeplerOrbitPropagation::GetLogValue() const
+{
+  std::string str_tmp = "";
+
+  str_tmp += WriteVector(sat_position_i_, 16);
+  str_tmp += WriteVector(sat_velocity_i_, 10);
+  str_tmp += WriteVector(sat_velocity_b_);
+  str_tmp += WriteVector(acc_i_, 10);
+  str_tmp += WriteScalar(lat_rad_);
+  str_tmp += WriteScalar(lon_rad_);
+  str_tmp += WriteScalar(alt_m_);
+
+  return str_tmp;
+}
+
+// Private Function
+void KeplerOrbitPropagation::UpdateState(const double current_jd)
+{
+  CalcPosVel(current_jd);
+  sat_position_i_ = position_i_m_;
+  sat_velocity_i_ = velocity_i_m_s_;
+  TransECIToGeo(current_jd);
+}

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.cpp
@@ -3,9 +3,15 @@
 
 KeplerOrbitPropagation::KeplerOrbitPropagation(
   const double current_jd,
-  KeplerOrbit kepler_orbit
+  KeplerOrbit kepler_orbit,
+  int wgs
 ):KeplerOrbit(kepler_orbit)
 {
+  // TODO whichconst周りを整理する
+  if (wgs == 0) { whichconst = wgs72old; }
+  else if (wgs == 1) { whichconst = wgs72; }
+  else if (wgs == 2) { whichconst = wgs84; }
+
   UpdateState(current_jd);
 }
 
@@ -57,4 +63,5 @@ void KeplerOrbitPropagation::UpdateState(const double current_jd)
   sat_position_i_ = position_i_m_;
   sat_velocity_i_ = velocity_i_m_s_;
   TransECIToGeo(current_jd);
+  TransECIToECEF(current_jd);
 }

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.h
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.h
@@ -1,16 +1,11 @@
 #pragma once
-#include "Orbit.h"
 #include "../../Library/Orbit/KeplerOrbit.h"
+#include "Orbit.h"
 
-class KeplerOrbitPropagation : public Orbit, public KeplerOrbit
-{
-public:
+class KeplerOrbitPropagation : public Orbit, public KeplerOrbit {
+ public:
   // Initialize with orbital elements
-  KeplerOrbitPropagation(
-    const double current_jd,
-    KeplerOrbit kepler_orbit,
-    const int wgs
-  );
+  KeplerOrbitPropagation(const double current_jd, KeplerOrbit kepler_orbit, const int wgs);
   ~KeplerOrbitPropagation();
 
   // Orbit class
@@ -18,6 +13,6 @@ public:
   virtual std::string GetLogHeader() const;
   virtual std::string GetLogValue() const;
 
-private:
+ private:
   void UpdateState(const double current_jd);
 };

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.h
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.h
@@ -9,7 +9,7 @@ public:
   KeplerOrbitPropagation(
     const double current_jd,
     KeplerOrbit kepler_orbit,
-    int wgs
+    const int wgs
   );
   ~KeplerOrbitPropagation();
 

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.h
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.h
@@ -8,7 +8,8 @@ public:
   // Initialize with orbital elements
   KeplerOrbitPropagation(
     const double current_jd,
-    KeplerOrbit kepler_orbit
+    KeplerOrbit kepler_orbit,
+    int wgs
   );
   ~KeplerOrbitPropagation();
 

--- a/src/Dynamics/Orbit/KeplerOrbitPropagation.h
+++ b/src/Dynamics/Orbit/KeplerOrbitPropagation.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "Orbit.h"
+#include "../../Library/Orbit/KeplerOrbit.h"
+
+class KeplerOrbitPropagation : public Orbit, public KeplerOrbit
+{
+public:
+  // Initialize with orbital elements
+  KeplerOrbitPropagation(
+    const double current_jd,
+    KeplerOrbit kepler_orbit
+  );
+  ~KeplerOrbitPropagation();
+
+  // Orbit class
+  virtual void Propagate(double endtime, double current_jd);
+  virtual std::string GetLogHeader() const;
+  virtual std::string GetLogValue() const;
+
+private:
+  void UpdateState(const double current_jd);
+};

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -23,7 +23,7 @@ using libra::Vector;
 
 class Orbit : public ILoggable {
  public:
-  enum class PROPAGATE_MODE { RK4 = 0, SGP4, RELATIVE_ORBIT, KEPLER };
+  enum class PROPAGATE_MODE { RK4 = 0, SGP4, RELATIVE_ORBIT, KEPLER, ENCKE };
 
   virtual ~Orbit() {}
 

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -12,19 +12,20 @@ using libra::Quaternion;
 using libra::Vector;
 
 #include <Interface/LogOutput/ILoggable.h>
+#include <math.h>
 
 #include <Environment/Global/PhysicalConstants.hpp>
 
 // For ECI to GEO calculation
-#include <Library/sgp4/sgp4ext.h>
-#include <Library/sgp4/sgp4io.h>
-#include <Library/sgp4/sgp4unit.h>
+#include "../../Library/sgp4/sgp4ext.h"
+#include "../../Library/sgp4/sgp4io.h"
+#include "../../Library/sgp4/sgp4unit.h"
 
 class Orbit : public ILoggable {
  public:
-  virtual ~Orbit() {}
+  enum class PROPAGATE_MODE { RK4 = 0, SGP4, RELATIVE_ORBIT, KEPLER };
 
-  enum class PROPAGATE_MODE { RK4 = 0, SGP4, RELATIVE_ORBIT };
+  virtual ~Orbit() {}
 
   inline PROPAGATE_MODE GetPropagateMode() const { return propagate_mode_; }
   inline Vector<3> GetSatPosition_i() const { return sat_position_i_; }

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -17,9 +17,9 @@ using libra::Vector;
 #include <Environment/Global/PhysicalConstants.hpp>
 
 // For ECI to GEO calculation
-#include "../../Library/sgp4/sgp4ext.h"
-#include "../../Library/sgp4/sgp4io.h"
-#include "../../Library/sgp4/sgp4unit.h"
+#include <Library/sgp4/sgp4ext.h>
+#include <Library/sgp4/sgp4io.h>
+#include <Library/sgp4/sgp4unit.h>
 
 class Orbit : public ILoggable {
  public:

--- a/src/Interface/InitInput/Init_Orbit.cpp
+++ b/src/Interface/InitInput/Init_Orbit.cpp
@@ -1,4 +1,5 @@
 #include <Dynamics/Orbit/EarthCenteredOrbit.h>
+#include <Dynamics/Orbit/EnckeOrbitPropagation.h>
 #include <Dynamics/Orbit/KeplerOrbitPropagation.h>
 #include <Dynamics/Orbit/Orbit.h>
 #include <Dynamics/Orbit/RelativeOrbit.h>
@@ -75,6 +76,13 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
     }
     KeplerOrbit kepler_orbit(mu_m3_s2, current_jd, oe);
     orbit = new KeplerOrbitPropagation(current_jd, kepler_orbit, wgs);
+  } else if (propagate_mode == (int)Orbit::PROPAGATE_MODE::ENCKE) {
+    Vector<3> init_pos_m;
+    conf.ReadVector<3>(section_, "init_position", init_pos_m);
+    Vector<3> init_vel_m_s;
+    conf.ReadVector<3>(section_, "init_velocity", init_vel_m_s);
+    double error_tolerance = conf.ReadDouble(section_, "error_tolerance");
+    orbit = new EnckeOrbitPropagation(gravity_constant, stepSec, current_jd, init_pos_m, init_vel_m_s, error_tolerance, wgs);
   } else  // initialize orbit for RK4 propagation
   {
     Vector<3> init_pos;

--- a/src/Interface/InitInput/Init_Orbit.cpp
+++ b/src/Interface/InitInput/Init_Orbit.cpp
@@ -23,6 +23,7 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
   Orbit* orbit;
 
   int propagate_mode = conf.ReadInt(section_, "propagate_mode");
+  int wgs = conf.ReadInt(section_, "wgs");
 
   // Initialize SGP4 orbit propagator
   if (propagate_mode == (int)Orbit::PROPAGATE_MODE::SGP4) {
@@ -30,11 +31,9 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
     conf.ReadChar(section_, "tle1", 80, tle1);
     conf.ReadChar(section_, "tle2", 80, tle2);
 
-    int wgs = conf.ReadInt(section_, "wgs");
     orbit = new EarthCenteredOrbit(celes_info, tle1, tle2, wgs, current_jd);
   } else if (propagate_mode == (int)Orbit::PROPAGATE_MODE::RELATIVE_ORBIT)  // initialize orbit for relative dynamics of formation flying
   {
-    int wgs = conf.ReadInt(section_, "wgs");
     RelativeOrbit::RelativeOrbitUpdateMethod update_method =
         (RelativeOrbit::RelativeOrbitUpdateMethod)(conf.ReadInt(section_, "relative_orbit_update_method"));
     RelativeOrbitModel relative_dynamics_model_type = (RelativeOrbitModel)(conf.ReadInt(section_, "relative_dynamics_model_type"));
@@ -75,10 +74,9 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
       oe = OrbitalElements(epoch_jday, semi_major_axis_m, eccentricity, inclination_rad, raan_rad, arg_perigee_rad);
     }
     KeplerOrbit kepler_orbit(mu_m3_s2, current_jd, oe);
-    orbit = new KeplerOrbitPropagation(current_jd, kepler_orbit);
+    orbit = new KeplerOrbitPropagation(current_jd, kepler_orbit, wgs);
   } else  // initialize orbit for RK4 propagation
   {
-    int wgs = conf.ReadInt(section_, "wgs");
     Vector<3> init_pos;
     conf.ReadVector<3>(section_, "init_position", init_pos);
     Vector<3> init_veloc;

--- a/src/Interface/InitInput/Init_Orbit.cpp
+++ b/src/Interface/InitInput/Init_Orbit.cpp
@@ -61,18 +61,20 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
     orbit = new RelativeOrbit(gravity_constant, stepSec, wgs, current_jd, reference_sat_id, init_relative_position_lvlh, init_relative_velocity_lvlh,
                               update_method, relative_dynamics_model_type, stm_model_type, rel_info);
   } else if (propagate_mode == "KEPLER") {
-    int init_mode_kepler = conf.ReadInt(section_, "init_mode_kepler");
+    std::string init_mode_kepler = conf.ReadString(section_, "init_mode_kepler");
     double mu_m3_s2 = gravity_constant;
     OrbitalElements oe;
-    if (init_mode_kepler == 0)  // initialize with position and velocity
+    if (init_mode_kepler == "INIT_POSVEL")
     {
+      // initialize with position and velocity
       Vector<3> init_pos_m;
       conf.ReadVector<3>(section_, "init_position", init_pos_m);
       Vector<3> init_vel_m_s;
       conf.ReadVector<3>(section_, "init_velocity", init_vel_m_s);
       oe = OrbitalElements(mu_m3_s2, current_jd, init_pos_m, init_vel_m_s);
-    } else  // initialize with orbital elements
+    } else if (init_mode_kepler == "INIT_OE")
     {
+      // initialize with orbital elements
       double semi_major_axis_m = conf.ReadDouble(section_, "semi_major_axis_m");
       double eccentricity = conf.ReadDouble(section_, "eccentricity");
       double inclination_rad = conf.ReadDouble(section_, "inclination_rad");
@@ -80,6 +82,9 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
       double arg_perigee_rad = conf.ReadDouble(section_, "arg_perigee_rad");
       double epoch_jday = conf.ReadDouble(section_, "epoch_jday");
       oe = OrbitalElements(epoch_jday, semi_major_axis_m, eccentricity, inclination_rad, raan_rad, arg_perigee_rad);
+    }
+    else {
+      std::cerr << "ERROR: Kepler orbit initialize mode: " << init_mode_kepler << " is not defined!" << std::endl;
     }
     KeplerOrbit kepler_orbit(mu_m3_s2, current_jd, oe);
     orbit = new KeplerOrbitPropagation(current_jd, kepler_orbit, wgs);

--- a/src/Library/Orbit/CMakeLists.txt
+++ b/src/Library/Orbit/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+project(ORBIT_MODELS)
+add_library(${PROJECT_NAME} STATIC
+  OrbitalElements.cpp
+  KeplerOrbit.cpp
+)
+# Compile option
+if(MSVC)
+  target_compile_options(${PROJECT_NAME} PUBLIC "/W4")
+  target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
+else()
+  target_compile_options(${PROJECT_NAME} PUBLIC "-Wall")
+  set(CMAKE_CXX_FLAGS "-m32 -rdynamic -Wall -g")
+  set(CMAKE_C_FLAGS "-m32 -rdynamic -Wall -g")
+endif()

--- a/src/Library/Orbit/CMakeLists.txt
+++ b/src/Library/Orbit/CMakeLists.txt
@@ -1,15 +1,9 @@
-cmake_minimum_required(VERSION 3.10)
 project(ORBIT_MODELS)
+cmake_minimum_required(VERSION 3.10)
+
 add_library(${PROJECT_NAME} STATIC
   OrbitalElements.cpp
   KeplerOrbit.cpp
 )
-# Compile option
-if(MSVC)
-  target_compile_options(${PROJECT_NAME} PUBLIC "/W4")
-  target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
-else()
-  target_compile_options(${PROJECT_NAME} PUBLIC "-Wall")
-  set(CMAKE_CXX_FLAGS "-m32 -rdynamic -Wall -g")
-  set(CMAKE_C_FLAGS "-m32 -rdynamic -Wall -g")
-endif()
+
+include(../../../common.cmake)

--- a/src/Library/Orbit/KeplerOrbit.cpp
+++ b/src/Library/Orbit/KeplerOrbit.cpp
@@ -1,0 +1,93 @@
+#include "KeplerOrbit.h"
+#include "../math/s2e_math.hpp"
+#include "../math/MatVec.hpp"
+
+KeplerOrbit::KeplerOrbit(){}
+// Initialize with orbital elements
+KeplerOrbit::KeplerOrbit(
+  const double mu_m3_s2,
+  const double current_jd,
+  const OrbitalElements oe
+):mu_m3_s2_(mu_m3_s2), oe_(oe)
+{
+  CalcConstKeplerMotion();
+}
+
+KeplerOrbit::~KeplerOrbit()
+{
+}
+
+// Private Functions
+void KeplerOrbit::CalcConstKeplerMotion()
+{
+  // mean motion
+  double a_m3 = pow(oe_.GetSemiMajor(), 3.0);
+  mean_motion_rad_s_ = sqrt(mu_m3_s2_ / a_m3);
+
+  // DCM
+  libra::Matrix<3, 3> dcm_arg_perigee = libra::rotz(-1.0 * oe_.GetArgPerigee());
+  libra::Matrix<3, 3> dcm_inclination = libra::rotx(-1.0 * oe_.GetInclination());
+  libra::Matrix<3, 3> dcm_raan = libra::rotz(-1.0 * oe_.GetRaan());
+  libra::Matrix<3, 3> dcm_inc_arg = dcm_inclination * dcm_arg_perigee;
+  dcm_inplane_to_eci_ = dcm_raan * dcm_inc_arg;
+}
+
+void KeplerOrbit::CalcPosVel(double time_jday)
+{
+  // replace to short name variables
+  double a_m = oe_.GetSemiMajor();
+  double e = oe_.GetEccentricity();
+  double n_rad_s = mean_motion_rad_s_;
+  double dt_s = (time_jday - oe_.GetEpoch()) * (24.0*60.0*60.0);
+
+  double mean_anomaly_rad = mean_motion_rad_s_ * dt_s;
+  double l_rad = libra::WrapTo2Pi(mean_anomaly_rad);
+
+  // Solve Kepler Equation
+  double eccentric_anomaly_rad;
+  eccentric_anomaly_rad = SolveKeplerFirstOrder(e, l_rad, 1.0e-5, 10);  // TODO: Implement Newton method
+  float u_rad = libra::WrapTo2Pi(eccentric_anomaly_rad);
+
+  // Calc position and velocity in the plane
+  double cos_u = cos(u_rad);
+  double sin_u = sin(u_rad);
+  double a_sqrt_e_m = a_m * sqrtf(1.0 - e * e);
+  double e_cos_u = 1.0 - e * cos_u;
+
+  libra::Vector<3> pos_inplane_m;
+  pos_inplane_m[0] = a_m * (cos_u - e);
+  pos_inplane_m[1] = a_sqrt_e_m * sin_u;
+  pos_inplane_m[2] = 0.0;
+
+  libra::Vector<3> vel_inplane_m_s;
+  vel_inplane_m_s[0] = -1.0 * a_m * n_rad_s * sin_u / e_cos_u;
+  vel_inplane_m_s[1] =  n_rad_s * a_sqrt_e_m * cos_u / e_cos_u;
+  vel_inplane_m_s[2] = 0.0;
+
+  // Transform to ECI
+  position_i_m_ = dcm_inplane_to_eci_ * pos_inplane_m;
+  velocity_i_m_s_ = dcm_inplane_to_eci_ * vel_inplane_m_s;
+}
+
+double KeplerOrbit::SolveKeplerFirstOrder(
+  const double eccentricity, 
+  const double mean_anomaly_rad, 
+  const double angle_limit_rad, 
+  const int iteration_limit)
+{
+  double u_prev_rad = mean_anomaly_rad;
+  double u_rad = 0.0;
+
+  for (int i = 0; i < iteration_limit; i++)
+  {
+    u_rad = mean_anomaly_rad + eccentricity * sin(u_prev_rad);
+
+    float diff_abs_rad;
+    diff_abs_rad = abs(u_rad - u_prev_rad);
+    if (diff_abs_rad < angle_limit_rad) break;
+
+    u_prev_rad = u_rad;
+  }
+
+  return u_rad;
+}

--- a/src/Library/Orbit/KeplerOrbit.cpp
+++ b/src/Library/Orbit/KeplerOrbit.cpp
@@ -38,7 +38,7 @@ void KeplerOrbit::CalcPosVel(double time_jday) {
   // Solve Kepler Equation
   double eccentric_anomaly_rad;
   eccentric_anomaly_rad = SolveKeplerFirstOrder(e, l_rad, 1.0e-5, 10);  // TODO: Implement Newton method
-  float u_rad = libra::WrapTo2Pi(eccentric_anomaly_rad);
+  double u_rad = libra::WrapTo2Pi(eccentric_anomaly_rad);
 
   // Calc position and velocity in the plane
   double cos_u = cos(u_rad);
@@ -69,8 +69,7 @@ double KeplerOrbit::SolveKeplerFirstOrder(const double eccentricity, const doubl
   for (int i = 0; i < iteration_limit; i++) {
     u_rad = mean_anomaly_rad + eccentricity * sin(u_prev_rad);
 
-    float diff_abs_rad;
-    diff_abs_rad = abs(u_rad - u_prev_rad);
+    double diff_abs_rad = std::abs(u_rad - u_prev_rad);
     if (diff_abs_rad < angle_limit_rad) break;
 
     u_prev_rad = u_rad;

--- a/src/Library/Orbit/KeplerOrbit.cpp
+++ b/src/Library/Orbit/KeplerOrbit.cpp
@@ -1,25 +1,18 @@
 #include "KeplerOrbit.h"
-#include "../math/s2e_math.hpp"
-#include "../math/MatVec.hpp"
 
-KeplerOrbit::KeplerOrbit(){}
+#include "../math/MatVec.hpp"
+#include "../math/s2e_math.hpp"
+
+KeplerOrbit::KeplerOrbit() {}
 // Initialize with orbital elements
-KeplerOrbit::KeplerOrbit(
-  const double mu_m3_s2,
-  const double current_jd,
-  const OrbitalElements oe
-):mu_m3_s2_(mu_m3_s2), oe_(oe)
-{
+KeplerOrbit::KeplerOrbit(const double mu_m3_s2, const double current_jd, const OrbitalElements oe) : mu_m3_s2_(mu_m3_s2), oe_(oe) {
   CalcConstKeplerMotion();
 }
 
-KeplerOrbit::~KeplerOrbit()
-{
-}
+KeplerOrbit::~KeplerOrbit() {}
 
 // Private Functions
-void KeplerOrbit::CalcConstKeplerMotion()
-{
+void KeplerOrbit::CalcConstKeplerMotion() {
   // mean motion
   double a_m3 = pow(oe_.GetSemiMajor(), 3.0);
   mean_motion_rad_s_ = sqrt(mu_m3_s2_ / a_m3);
@@ -32,13 +25,12 @@ void KeplerOrbit::CalcConstKeplerMotion()
   dcm_inplane_to_eci_ = dcm_raan * dcm_inc_arg;
 }
 
-void KeplerOrbit::CalcPosVel(double time_jday)
-{
+void KeplerOrbit::CalcPosVel(double time_jday) {
   // replace to short name variables
   double a_m = oe_.GetSemiMajor();
   double e = oe_.GetEccentricity();
   double n_rad_s = mean_motion_rad_s_;
-  double dt_s = (time_jday - oe_.GetEpoch()) * (24.0*60.0*60.0);
+  double dt_s = (time_jday - oe_.GetEpoch()) * (24.0 * 60.0 * 60.0);
 
   double mean_anomaly_rad = mean_motion_rad_s_ * dt_s;
   double l_rad = libra::WrapTo2Pi(mean_anomaly_rad);
@@ -61,7 +53,7 @@ void KeplerOrbit::CalcPosVel(double time_jday)
 
   libra::Vector<3> vel_inplane_m_s;
   vel_inplane_m_s[0] = -1.0 * a_m * n_rad_s * sin_u / e_cos_u;
-  vel_inplane_m_s[1] =  n_rad_s * a_sqrt_e_m * cos_u / e_cos_u;
+  vel_inplane_m_s[1] = n_rad_s * a_sqrt_e_m * cos_u / e_cos_u;
   vel_inplane_m_s[2] = 0.0;
 
   // Transform to ECI
@@ -69,17 +61,12 @@ void KeplerOrbit::CalcPosVel(double time_jday)
   velocity_i_m_s_ = dcm_inplane_to_eci_ * vel_inplane_m_s;
 }
 
-double KeplerOrbit::SolveKeplerFirstOrder(
-  const double eccentricity, 
-  const double mean_anomaly_rad, 
-  const double angle_limit_rad, 
-  const int iteration_limit)
-{
+double KeplerOrbit::SolveKeplerFirstOrder(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad,
+                                          const int iteration_limit) {
   double u_prev_rad = mean_anomaly_rad;
   double u_rad = 0.0;
 
-  for (int i = 0; i < iteration_limit; i++)
-  {
+  for (int i = 0; i < iteration_limit; i++) {
     u_rad = mean_anomaly_rad + eccentricity * sin(u_prev_rad);
 
     float diff_abs_rad;

--- a/src/Library/Orbit/KeplerOrbit.cpp
+++ b/src/Library/Orbit/KeplerOrbit.cpp
@@ -22,7 +22,7 @@ void KeplerOrbit::CalcConstKeplerMotion() {
   libra::Matrix<3, 3> dcm_inclination = libra::rotx(-1.0 * oe_.GetInclination());
   libra::Matrix<3, 3> dcm_raan = libra::rotz(-1.0 * oe_.GetRaan());
   libra::Matrix<3, 3> dcm_inc_arg = dcm_inclination * dcm_arg_perigee;
-  dcm_inplane_to_eci_ = dcm_raan * dcm_inc_arg;
+  dcm_inplane_to_i_ = dcm_raan * dcm_inc_arg;
 }
 
 void KeplerOrbit::CalcPosVel(double time_jday) {
@@ -57,8 +57,8 @@ void KeplerOrbit::CalcPosVel(double time_jday) {
   vel_inplane_m_s[2] = 0.0;
 
   // Transform to ECI
-  position_i_m_ = dcm_inplane_to_eci_ * pos_inplane_m;
-  velocity_i_m_s_ = dcm_inplane_to_eci_ * vel_inplane_m_s;
+  position_i_m_ = dcm_inplane_to_i_ * pos_inplane_m;
+  velocity_i_m_s_ = dcm_inplane_to_i_ * vel_inplane_m_s;
 }
 
 double KeplerOrbit::SolveKeplerFirstOrder(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad,

--- a/src/Library/Orbit/KeplerOrbit.h
+++ b/src/Library/Orbit/KeplerOrbit.h
@@ -1,42 +1,32 @@
 #pragma once
-#include "./OrbitalElements.h"
 #include "../math/Matrix.hpp"
 #include "../math/Vector.hpp"
+#include "./OrbitalElements.h"
 
-class KeplerOrbit
-{
-public:
+class KeplerOrbit {
+ public:
   KeplerOrbit();
   // Initialize with orbital elements
-  KeplerOrbit(
-    const double mu_m3_s2,
-    const double current_jd,
-    const OrbitalElements oe
-  );
+  KeplerOrbit(const double mu_m3_s2, const double current_jd, const OrbitalElements oe);
   ~KeplerOrbit();
 
-  void CalcPosVel(double time_jday); // Calculation of Position and Velocity from Orbital Elements
+  void CalcPosVel(double time_jday);  // Calculation of Position and Velocity from Orbital Elements
 
-  inline const libra::Vector<3> GetPosition_i_m() const {return position_i_m_;}
-  inline const libra::Vector<3> GetVelocity_i_m_s() const {return velocity_i_m_s_;}
+  inline const libra::Vector<3> GetPosition_i_m() const { return position_i_m_; }
+  inline const libra::Vector<3> GetVelocity_i_m_s() const { return velocity_i_m_s_; }
 
-protected:
+ protected:
   libra::Vector<3> position_i_m_;
   libra::Vector<3> velocity_i_m_s_;
 
-private:
+ private:
   double mu_m3_s2_;
-  OrbitalElements oe_; 
+  OrbitalElements oe_;
   double mean_motion_rad_s_;
   libra::Matrix<3, 3> dcm_inplane_to_eci_;
 
   // Calculation of constants for kepler motion calculation
   void CalcConstKeplerMotion();
   // Solve Kepler Equation
-  double SolveKeplerFirstOrder(
-    const double eccentricity, 
-    const double mean_anomaly_rad, 
-    const double angle_limit_rad, 
-    const int iteration_limit
-  );
+  double SolveKeplerFirstOrder(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad, const int iteration_limit);
 };

--- a/src/Library/Orbit/KeplerOrbit.h
+++ b/src/Library/Orbit/KeplerOrbit.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "./OrbitalElements.h"
+#include "../math/Matrix.hpp"
+#include "../math/Vector.hpp"
+
+class KeplerOrbit
+{
+public:
+  KeplerOrbit();
+  // Initialize with orbital elements
+  KeplerOrbit(
+    const double mu_m3_s2,
+    const double current_jd,
+    const OrbitalElements oe
+  );
+  ~KeplerOrbit();
+
+  void CalcPosVel(double time_jday); // Calculation of Position and Velocity from Orbital Elements
+
+  inline const libra::Vector<3> GetPosition_i_m() const {return position_i_m_;}
+  inline const libra::Vector<3> GetVelocity_i_m_s() const {return velocity_i_m_s_;}
+protected:
+  libra::Vector<3> position_i_m_;
+  libra::Vector<3> velocity_i_m_s_;
+
+private:
+  double mu_m3_s2_;
+  OrbitalElements oe_; 
+  double mean_motion_rad_s_;
+  libra::Matrix<3, 3> dcm_inplane_to_eci_;
+
+  // Calculation of constants for kepler motion calculation
+  void CalcConstKeplerMotion();
+  // Solve Kepler Equation
+  double SolveKeplerFirstOrder(
+    const double eccentricity, 
+    const double mean_anomaly_rad, 
+    const double angle_limit_rad, 
+    const int iteration_limit
+  );
+};

--- a/src/Library/Orbit/KeplerOrbit.h
+++ b/src/Library/Orbit/KeplerOrbit.h
@@ -19,6 +19,7 @@ public:
 
   inline const libra::Vector<3> GetPosition_i_m() const {return position_i_m_;}
   inline const libra::Vector<3> GetVelocity_i_m_s() const {return velocity_i_m_s_;}
+
 protected:
   libra::Vector<3> position_i_m_;
   libra::Vector<3> velocity_i_m_s_;

--- a/src/Library/Orbit/KeplerOrbit.h
+++ b/src/Library/Orbit/KeplerOrbit.h
@@ -23,7 +23,7 @@ class KeplerOrbit {
   double mu_m3_s2_;
   OrbitalElements oe_;
   double mean_motion_rad_s_;
-  libra::Matrix<3, 3> dcm_inplane_to_eci_;
+  libra::Matrix<3, 3> dcm_inplane_to_i_;
 
   // Calculation of constants for kepler motion calculation
   void CalcConstKeplerMotion();

--- a/src/Library/Orbit/OrbitalElements.cpp
+++ b/src/Library/Orbit/OrbitalElements.cpp
@@ -42,7 +42,7 @@ void OrbitalElements::CalcOeFromPosVel(
   const libra::Vector<3> r_i_m,
   const libra::Vector<3> v_i_m_s)
 {
-  // comman variables
+  // common variables
   double r_m = norm(r_i_m);
   double r2_m2 = inner_product(r_i_m, r_i_m);
   double v_m_s = norm(v_i_m_s);
@@ -78,14 +78,15 @@ void OrbitalElements::CalcOeFromPosVel(
   eccentricity_ = sqrt(t1*t1 + t2*t2);
 
   // arg perigee
-  arg_perigee_rad_ = acos(t1/eccentricity_);
+  arg_perigee_rad_ = atan2(t2, t1);
 
   // true anomaly f_rad and eccentric anomaly u_rad
-  double phi_rad = acos(x_p_m/r_m);
+  double phi_rad = atan2(y_p_m, x_p_m);
   double f_rad = phi_rad - arg_perigee_rad_;
   f_rad = libra::WrapTo2Pi(f_rad);
 
-  double u_rad = asin(r_m*sin(f_rad)/(semi_major_axis_m_ * sqrt(1.0 - eccentricity_*eccentricity_)));
+  double u_rad = atan2(r_m*sin(f_rad)/sqrt(1.0 - eccentricity_*eccentricity_),
+                       r_m*cos(f_rad) + semi_major_axis_m_ * eccentricity_);
   u_rad = libra::WrapTo2Pi(u_rad);
 
   // epoch t0

--- a/src/Library/Orbit/OrbitalElements.cpp
+++ b/src/Library/Orbit/OrbitalElements.cpp
@@ -1,0 +1,95 @@
+#include "OrbitalElements.h"
+#include "../math/s2e_math.hpp"
+
+OrbitalElements::OrbitalElements()
+{
+}
+
+// initialize with OE
+OrbitalElements::OrbitalElements(
+  const double epoch_jday,
+  const double semi_major_axis_m, 
+  const double eccentricity,
+  const double inclination_rad,
+  const double raan_rad,
+  const double arg_perigee_rad
+):semi_major_axis_m_(semi_major_axis_m), 
+  eccentricity_(eccentricity),
+  inclination_rad_(inclination_rad),
+  raan_rad_(raan_rad),
+  arg_perigee_rad_(arg_perigee_rad),
+  epoch_jday_(epoch_jday)
+{
+}
+  
+// initialize with position and velocity
+OrbitalElements::OrbitalElements(
+  const double mu_m3_s2,
+  const double time_jday,
+  const libra::Vector<3> position_i_m,
+  const libra::Vector<3> velocity_i_m_s
+)
+{
+  CalcOeFromPosVel(mu_m3_s2, time_jday, position_i_m, velocity_i_m_s);
+}
+
+OrbitalElements::~OrbitalElements(){}
+
+// Private Function
+void OrbitalElements::CalcOeFromPosVel(
+  const double mu_m3_s2,
+  const double time_jday,
+  const libra::Vector<3> r_i_m,
+  const libra::Vector<3> v_i_m_s)
+{
+  // comman variables
+  double r_m = norm(r_i_m);
+  double r2_m2 = inner_product(r_i_m, r_i_m);
+  double v_m_s = norm(v_i_m_s);
+  double v2_m2_s2 = inner_product(v_i_m_s, v_i_m_s);
+  libra::Vector<3> h;
+  h = outer_product(r_i_m, v_i_m_s);
+  double h_norm = norm(h);
+
+  // semi major axis
+  semi_major_axis_m_ = mu_m3_s2/(2.0*mu_m3_s2/r_m - v2_m2_s2);
+
+  // inclination
+  libra::Vector<3> h_direction = h;
+  h_direction = normalize(h_direction);
+  inclination_rad_ = acos(h_direction[2]);
+
+  // RAAN
+  raan_rad_ = asin(h[0]/sqrt(h[0]*h[0] + h[1]*h[1])); // TODO: 傾斜角0に対応できない
+
+  // position in plain
+  double x_p_m = r_i_m[0] * cos(raan_rad_) + r_i_m[1] * sin(raan_rad_);
+  double tmp_m =-r_i_m[0] * sin(raan_rad_) + r_i_m[1] * cos(raan_rad_);
+  double y_p_m = tmp_m * cos(inclination_rad_) + r_i_m[2] * sin(inclination_rad_);
+
+  // velocity in plain
+  double dx_p_m_s = v_i_m_s[0] * cos(raan_rad_) + v_i_m_s[1] * sin(raan_rad_);
+  double dtmp_m_s =-v_i_m_s[0] * sin(raan_rad_) + v_i_m_s[1] * cos(raan_rad_);
+  double dy_p_m_s = dtmp_m_s * cos(inclination_rad_) + v_i_m_s[2] * sin(inclination_rad_);
+ 
+  // eccentricity
+  double t1 = (h_norm/mu_m3_s2)*dy_p_m_s - x_p_m / r_m;
+  double t2 =-(h_norm/mu_m3_s2)*dx_p_m_s - y_p_m / r_m;
+  eccentricity_ = sqrt(t1*t1 + t2*t2);
+
+  // arg perigee
+  arg_perigee_rad_ = acos(t1/eccentricity_);
+
+  // true anomaly f_rad and eccentric anomaly u_rad
+  double phi_rad = acos(x_p_m/r_m);
+  double f_rad = phi_rad - arg_perigee_rad_;
+  f_rad = libra::WrapTo2Pi(f_rad);
+
+  double u_rad = asin(r_m*sin(f_rad)/(semi_major_axis_m_ * sqrt(1.0 - eccentricity_*eccentricity_)));
+  u_rad = libra::WrapTo2Pi(u_rad);
+
+  // epoch t0
+  double n_rad_s = sqrt(mu_m3_s2 / pow(semi_major_axis_m_, 3.0));
+  double dt_s = (u_rad - eccentricity_ * sin(u_rad))/n_rad_s;
+  epoch_jday_ = time_jday - dt_s/(24.0*60.0*60.0);
+}

--- a/src/Library/Orbit/OrbitalElements.cpp
+++ b/src/Library/Orbit/OrbitalElements.cpp
@@ -44,12 +44,12 @@ void OrbitalElements::CalcOeFromPosVel(const double mu_m3_s2, const double time_
   // RAAN
   raan_rad_ = asin(h[0] / sqrt(h[0] * h[0] + h[1] * h[1]));  // TODO: 傾斜角0に対応できない
 
-  // position in plain
+  // position in plane
   double x_p_m = r_i_m[0] * cos(raan_rad_) + r_i_m[1] * sin(raan_rad_);
   double tmp_m = -r_i_m[0] * sin(raan_rad_) + r_i_m[1] * cos(raan_rad_);
   double y_p_m = tmp_m * cos(inclination_rad_) + r_i_m[2] * sin(inclination_rad_);
 
-  // velocity in plain
+  // velocity in plane
   double dx_p_m_s = v_i_m_s[0] * cos(raan_rad_) + v_i_m_s[1] * sin(raan_rad_);
   double dtmp_m_s = -v_i_m_s[0] * sin(raan_rad_) + v_i_m_s[1] * cos(raan_rad_);
   double dy_p_m_s = dtmp_m_s * cos(inclination_rad_) + v_i_m_s[2] * sin(inclination_rad_);

--- a/src/Library/Orbit/OrbitalElements.cpp
+++ b/src/Library/Orbit/OrbitalElements.cpp
@@ -1,47 +1,29 @@
 #include "OrbitalElements.h"
+
 #include "../math/s2e_math.hpp"
 
-OrbitalElements::OrbitalElements()
-{
-}
+OrbitalElements::OrbitalElements() {}
 
 // initialize with OE
-OrbitalElements::OrbitalElements(
-  const double epoch_jday,
-  const double semi_major_axis_m, 
-  const double eccentricity,
-  const double inclination_rad,
-  const double raan_rad,
-  const double arg_perigee_rad
-):semi_major_axis_m_(semi_major_axis_m), 
-  eccentricity_(eccentricity),
-  inclination_rad_(inclination_rad),
-  raan_rad_(raan_rad),
-  arg_perigee_rad_(arg_perigee_rad),
-  epoch_jday_(epoch_jday)
-{
-}
-  
+OrbitalElements::OrbitalElements(const double epoch_jday, const double semi_major_axis_m, const double eccentricity, const double inclination_rad,
+                                 const double raan_rad, const double arg_perigee_rad)
+    : semi_major_axis_m_(semi_major_axis_m),
+      eccentricity_(eccentricity),
+      inclination_rad_(inclination_rad),
+      raan_rad_(raan_rad),
+      arg_perigee_rad_(arg_perigee_rad),
+      epoch_jday_(epoch_jday) {}
+
 // initialize with position and velocity
-OrbitalElements::OrbitalElements(
-  const double mu_m3_s2,
-  const double time_jday,
-  const libra::Vector<3> position_i_m,
-  const libra::Vector<3> velocity_i_m_s
-)
-{
+OrbitalElements::OrbitalElements(const double mu_m3_s2, const double time_jday, const libra::Vector<3> position_i_m,
+                                 const libra::Vector<3> velocity_i_m_s) {
   CalcOeFromPosVel(mu_m3_s2, time_jday, position_i_m, velocity_i_m_s);
 }
 
-OrbitalElements::~OrbitalElements(){}
+OrbitalElements::~OrbitalElements() {}
 
 // Private Function
-void OrbitalElements::CalcOeFromPosVel(
-  const double mu_m3_s2,
-  const double time_jday,
-  const libra::Vector<3> r_i_m,
-  const libra::Vector<3> v_i_m_s)
-{
+void OrbitalElements::CalcOeFromPosVel(const double mu_m3_s2, const double time_jday, const libra::Vector<3> r_i_m, const libra::Vector<3> v_i_m_s) {
   // common variables
   double r_m = norm(r_i_m);
   double r2_m2 = inner_product(r_i_m, r_i_m);
@@ -52,7 +34,7 @@ void OrbitalElements::CalcOeFromPosVel(
   double h_norm = norm(h);
 
   // semi major axis
-  semi_major_axis_m_ = mu_m3_s2/(2.0*mu_m3_s2/r_m - v2_m2_s2);
+  semi_major_axis_m_ = mu_m3_s2 / (2.0 * mu_m3_s2 / r_m - v2_m2_s2);
 
   // inclination
   libra::Vector<3> h_direction = h;
@@ -60,22 +42,22 @@ void OrbitalElements::CalcOeFromPosVel(
   inclination_rad_ = acos(h_direction[2]);
 
   // RAAN
-  raan_rad_ = asin(h[0]/sqrt(h[0]*h[0] + h[1]*h[1])); // TODO: 傾斜角0に対応できない
+  raan_rad_ = asin(h[0] / sqrt(h[0] * h[0] + h[1] * h[1]));  // TODO: 傾斜角0に対応できない
 
   // position in plain
   double x_p_m = r_i_m[0] * cos(raan_rad_) + r_i_m[1] * sin(raan_rad_);
-  double tmp_m =-r_i_m[0] * sin(raan_rad_) + r_i_m[1] * cos(raan_rad_);
+  double tmp_m = -r_i_m[0] * sin(raan_rad_) + r_i_m[1] * cos(raan_rad_);
   double y_p_m = tmp_m * cos(inclination_rad_) + r_i_m[2] * sin(inclination_rad_);
 
   // velocity in plain
   double dx_p_m_s = v_i_m_s[0] * cos(raan_rad_) + v_i_m_s[1] * sin(raan_rad_);
-  double dtmp_m_s =-v_i_m_s[0] * sin(raan_rad_) + v_i_m_s[1] * cos(raan_rad_);
+  double dtmp_m_s = -v_i_m_s[0] * sin(raan_rad_) + v_i_m_s[1] * cos(raan_rad_);
   double dy_p_m_s = dtmp_m_s * cos(inclination_rad_) + v_i_m_s[2] * sin(inclination_rad_);
- 
+
   // eccentricity
-  double t1 = (h_norm/mu_m3_s2)*dy_p_m_s - x_p_m / r_m;
-  double t2 =-(h_norm/mu_m3_s2)*dx_p_m_s - y_p_m / r_m;
-  eccentricity_ = sqrt(t1*t1 + t2*t2);
+  double t1 = (h_norm / mu_m3_s2) * dy_p_m_s - x_p_m / r_m;
+  double t2 = -(h_norm / mu_m3_s2) * dx_p_m_s - y_p_m / r_m;
+  eccentricity_ = sqrt(t1 * t1 + t2 * t2);
 
   // arg perigee
   arg_perigee_rad_ = atan2(t2, t1);
@@ -85,12 +67,11 @@ void OrbitalElements::CalcOeFromPosVel(
   double f_rad = phi_rad - arg_perigee_rad_;
   f_rad = libra::WrapTo2Pi(f_rad);
 
-  double u_rad = atan2(r_m*sin(f_rad)/sqrt(1.0 - eccentricity_*eccentricity_),
-                       r_m*cos(f_rad) + semi_major_axis_m_ * eccentricity_);
+  double u_rad = atan2(r_m * sin(f_rad) / sqrt(1.0 - eccentricity_ * eccentricity_), r_m * cos(f_rad) + semi_major_axis_m_ * eccentricity_);
   u_rad = libra::WrapTo2Pi(u_rad);
 
   // epoch t0
   double n_rad_s = sqrt(mu_m3_s2 / pow(semi_major_axis_m_, 3.0));
-  double dt_s = (u_rad - eccentricity_ * sin(u_rad))/n_rad_s;
-  epoch_jday_ = time_jday - dt_s/(24.0*60.0*60.0);
+  double dt_s = (u_rad - eccentricity_ * sin(u_rad)) / n_rad_s;
+  epoch_jday_ = time_jday - dt_s / (24.0 * 60.0 * 60.0);
 }

--- a/src/Library/Orbit/OrbitalElements.h
+++ b/src/Library/Orbit/OrbitalElements.h
@@ -1,0 +1,54 @@
+#pragma once
+#include "../math/Vector.hpp"
+
+class OrbitalElements
+{
+public:
+  OrbitalElements();
+  // initialize with OE
+  OrbitalElements(
+    const double epoch_jday,
+    const double semi_major_axis_m,
+    const double eccentricity,
+    const double inclination_rad,
+    const double raan_rad,
+    const double arg_perigee_rad
+  );
+  // initialize with position and velocity
+  OrbitalElements(
+    const double mu_m3_s2,
+    const double time_jday,
+    const libra::Vector<3> position_i_m,
+    const libra::Vector<3> velocity_i_m_s
+  );
+  ~OrbitalElements();
+
+  // Getter
+  inline const double GetSemiMajor()const{return semi_major_axis_m_;}
+  inline const double GetEccentricity()const{return eccentricity_;}
+  inline const double GetInclination()const{return inclination_rad_;}
+  inline const double GetRaan()const{return raan_rad_;}
+  inline const double GetArgPerigee()const{return arg_perigee_rad_;}
+  inline const double GetEpoch()const{return epoch_jday_;}
+
+private:
+  // Common Variables
+  // Shape
+  double semi_major_axis_m_;
+  double eccentricity_;
+  // Corrdinate
+  double inclination_rad_;
+  double raan_rad_;            //!< Right Ascension of the Ascending Node [rad]
+  double arg_perigee_rad_;     //!< Argument of Perigee [rad] 
+  // Time, phase
+  double epoch_jday_;          //!< epoch (time at the perigee) [julian day]
+ 
+  // Functions
+  // Calculation of Orbital Elements from Position and Velocity
+  void CalcOeFromPosVel(
+    const double mu_m3_s2,
+    const double time_jday,
+    const libra::Vector<3> r_i_m,
+    const libra::Vector<3> v_i_m_s
+  );
+};

--- a/src/Library/Orbit/OrbitalElements.h
+++ b/src/Library/Orbit/OrbitalElements.h
@@ -1,54 +1,37 @@
 #pragma once
 #include "../math/Vector.hpp"
 
-class OrbitalElements
-{
-public:
+class OrbitalElements {
+ public:
   OrbitalElements();
   // initialize with OE
-  OrbitalElements(
-    const double epoch_jday,
-    const double semi_major_axis_m,
-    const double eccentricity,
-    const double inclination_rad,
-    const double raan_rad,
-    const double arg_perigee_rad
-  );
+  OrbitalElements(const double epoch_jday, const double semi_major_axis_m, const double eccentricity, const double inclination_rad,
+                  const double raan_rad, const double arg_perigee_rad);
   // initialize with position and velocity
-  OrbitalElements(
-    const double mu_m3_s2,
-    const double time_jday,
-    const libra::Vector<3> position_i_m,
-    const libra::Vector<3> velocity_i_m_s
-  );
+  OrbitalElements(const double mu_m3_s2, const double time_jday, const libra::Vector<3> position_i_m, const libra::Vector<3> velocity_i_m_s);
   ~OrbitalElements();
 
   // Getter
-  inline const double GetSemiMajor()const{return semi_major_axis_m_;}
-  inline const double GetEccentricity()const{return eccentricity_;}
-  inline const double GetInclination()const{return inclination_rad_;}
-  inline const double GetRaan()const{return raan_rad_;}
-  inline const double GetArgPerigee()const{return arg_perigee_rad_;}
-  inline const double GetEpoch()const{return epoch_jday_;}
+  inline const double GetSemiMajor() const { return semi_major_axis_m_; }
+  inline const double GetEccentricity() const { return eccentricity_; }
+  inline const double GetInclination() const { return inclination_rad_; }
+  inline const double GetRaan() const { return raan_rad_; }
+  inline const double GetArgPerigee() const { return arg_perigee_rad_; }
+  inline const double GetEpoch() const { return epoch_jday_; }
 
-private:
+ private:
   // Common Variables
   // Shape
   double semi_major_axis_m_;
   double eccentricity_;
   // Corrdinate
   double inclination_rad_;
-  double raan_rad_;            //!< Right Ascension of the Ascending Node [rad]
-  double arg_perigee_rad_;     //!< Argument of Perigee [rad] 
+  double raan_rad_;         //!< Right Ascension of the Ascending Node [rad]
+  double arg_perigee_rad_;  //!< Argument of Perigee [rad]
   // Time, phase
-  double epoch_jday_;          //!< epoch (time at the perigee) [julian day]
- 
+  double epoch_jday_;  //!< epoch (time at the perigee) [julian day]
+
   // Functions
   // Calculation of Orbital Elements from Position and Velocity
-  void CalcOeFromPosVel(
-    const double mu_m3_s2,
-    const double time_jday,
-    const libra::Vector<3> r_i_m,
-    const libra::Vector<3> v_i_m_s
-  );
+  void CalcOeFromPosVel(const double mu_m3_s2, const double time_jday, const libra::Vector<3> r_i_m, const libra::Vector<3> v_i_m_s);
 };

--- a/src/Library/math/CMakeLists.txt
+++ b/src/Library/math/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(${PROJECT_NAME} STATIC
   Ran0.cpp
   Ran1.cpp
   Vector.cpp
+  s2e_math.cpp
 )
 
 include(../../../common.cmake)

--- a/src/Library/math/s2e_math.cpp
+++ b/src/Library/math/s2e_math.cpp
@@ -1,28 +1,19 @@
 #include "s2e_math.hpp"
 
-namespace libra
-{
-double WrapTo2Pi(const double angle)
-{
+namespace libra {
+double WrapTo2Pi(const double angle) {
   double angle_out = angle;
-  if (angle_out < 0.0)
-  {
-    while (angle_out < 0.0)
-    {
-      angle_out += 2.0*M_PI;
+  if (angle_out < 0.0) {
+    while (angle_out < 0.0) {
+      angle_out += 2.0 * M_PI;
     }
-  }
-  else if (angle_out > 2.0*M_PI)
-  {
-    while (angle_out  > 2.0*M_PI)
-    {
-      angle_out -= 2.0*M_PI;
+  } else if (angle_out > 2.0 * M_PI) {
+    while (angle_out > 2.0 * M_PI) {
+      angle_out -= 2.0 * M_PI;
     }
-  }
-  else 
-  {
-    // nothing to do    
+  } else {
+    // nothing to do
   }
   return angle_out;
 }
-}
+}  // namespace libra

--- a/src/Library/math/s2e_math.cpp
+++ b/src/Library/math/s2e_math.cpp
@@ -1,0 +1,28 @@
+#include "s2e_math.hpp"
+
+namespace libra
+{
+double WrapTo2Pi(const double angle)
+{
+  double angle_out = angle;
+  if (angle_out < 0.0)
+  {
+    while (angle_out < 0.0)
+    {
+      angle_out += 2.0*M_PI;
+    }
+  }
+  else if (angle_out > 2.0*M_PI)
+  {
+    while (angle_out  > 2.0*M_PI)
+    {
+      angle_out -= 2.0*M_PI;
+    }
+  }
+  else 
+  {
+    // nothing to do    
+  }
+  return angle_out;
+}
+}

--- a/src/Library/math/s2e_math.cpp
+++ b/src/Library/math/s2e_math.cpp
@@ -1,15 +1,17 @@
 #include "s2e_math.hpp"
 
+#include <Library/math/Constant.hpp>
+
 namespace libra {
 double WrapTo2Pi(const double angle) {
   double angle_out = angle;
   if (angle_out < 0.0) {
     while (angle_out < 0.0) {
-      angle_out += 2.0 * M_PI;
+      angle_out += libra::tau;
     }
-  } else if (angle_out > 2.0 * M_PI) {
-    while (angle_out > 2.0 * M_PI) {
-      angle_out -= 2.0 * M_PI;
+  } else if (angle_out > libra::tau) {
+    while (angle_out > libra::tau) {
+      angle_out -= libra::tau;
     }
   } else {
     // nothing to do

--- a/src/Library/math/s2e_math.hpp
+++ b/src/Library/math/s2e_math.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include<cmath>
+
+namespace libra
+{
+
+double WrapTo2Pi(const double angle);
+
+}

--- a/src/Library/math/s2e_math.hpp
+++ b/src/Library/math/s2e_math.hpp
@@ -1,8 +1,7 @@
 #pragma once
-#include<cmath>
+#include <cmath>
 
-namespace libra
-{
+namespace libra {
 
 double WrapTo2Pi(const double angle);
 


### PR DESCRIPTION
## Overview
Add Kepler and Encke orbit propagation method

## Issue
- #23 

## Details
Kepler orbit propagation for pure two-body problem is newly implemented. I believe it is easier to use and faster than other methods.  
Encke's orbit propagation method is also newly implemented. It is more accurate than the normal RK4 method and it can be apply for relative orbit propagation.  
I also fixed some issues in the `Orbit` class like #23. 


##  Validation results
It will be write in the `s2e-document` soon.


## Scope of influence
Huge. Users need to update their ini file to suit with the #23.

## Supplement
NA

## Note
NA