### PR TITLE
Fix warnings in Vector-Matrix library

### DIFF
--- a/src/Library/math/MatVec_impl.hpp
+++ b/src/Library/math/MatVec_impl.hpp
@@ -1,5 +1,6 @@
 /*!
   \file   MatVec_impl.hpp
+  \author TAKISAWA Jun'ichi.
   \brief  MatVec.hppの実装
 */
 #ifndef MAT_VEC_IMPL_HPP_

--- a/src/Library/math/MatVec_impl.hpp
+++ b/src/Library/math/MatVec_impl.hpp
@@ -1,8 +1,5 @@
 /*!
   \file   MatVec_impl.hpp
-  \author TAKISAWA Jun'ichi.
-  \date   Wed Oct 27 21:18:38 2010
-
   \brief  MatVec.hppの実装
 */
 #ifndef MAT_VEC_IMPL_HPP_
@@ -14,8 +11,8 @@ namespace libra {
 template <size_t R, size_t C, typename TM, typename TC>
 Vector<R, TC> operator*(const Matrix<R, C, TM>& m, const Vector<C, TC>& v) {
   Vector<R, TC> temp(0.0);
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       temp[i] += m[i][j] * v[j];
     }
   }
@@ -30,11 +27,11 @@ Matrix<N, N> invert(const Matrix<N, N>& a) {
 
   Matrix<N, N> inv;
   Vector<N> v;
-  for (unsigned int i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     fill_up(v, 0.0);
     v[i] = 1.0;
     lubksb(temp, index, v);
-    for (unsigned int j = 0; j < N; ++j) {
+    for (size_t j = 0; j < N; ++j) {
       inv[j][i] = v[j];
     }
   }
@@ -44,9 +41,9 @@ Matrix<N, N> invert(const Matrix<N, N>& a) {
 template <std::size_t N>
 Matrix<N, N>& ludcmp(Matrix<N, N>& a, unsigned int index[]) {
   double coef[N];
-  for (unsigned int i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     double biggest = 0.0;
-    for (unsigned int j = 0; j < N; ++j) {
+    for (size_t j = 0; j < N; ++j) {
       double temp;
       if ((temp = fabs(a[i][j])) > biggest) {
         biggest = temp;
@@ -59,20 +56,20 @@ Matrix<N, N>& ludcmp(Matrix<N, N>& a, unsigned int index[]) {
     coef[i] = 1.0 / biggest;
   }
 
-  for (unsigned int j = 0; j < N; ++j) {
-    for (unsigned int i = 0; i < j; ++i) {
+  for (size_t j = 0; j < N; ++j) {
+    for (size_t i = 0; i < j; ++i) {
       double sum = a[i][j];
-      for (unsigned int k = 0; k < i; ++k) {
+      for (size_t k = 0; k < i; ++k) {
         sum -= a[i][k] * a[k][j];
       }
       a[i][j] = sum;
     }
 
     double biggest = 0.0;
-    unsigned int imax;
-    for (unsigned int i = j; i < N; ++i) {
+    size_t imax;
+    for (size_t i = j; i < N; ++i) {
       double sum = a[i][j];
-      for (unsigned int k = 0; k < j; ++k) {
+      for (size_t k = 0; k < j; ++k) {
         sum -= a[i][k] * a[k][j];
       }
       a[i][j] = sum;
@@ -86,7 +83,7 @@ Matrix<N, N>& ludcmp(Matrix<N, N>& a, unsigned int index[]) {
 
     if (j != imax)  // Pivotting
     {
-      for (unsigned int i = 0; i < N; ++i) {
+      for (size_t i = 0; i < N; ++i) {
         double temp = a[imax][i];
         a[imax][i] = a[j][i];
         a[j][i] = temp;
@@ -101,7 +98,7 @@ Matrix<N, N>& ludcmp(Matrix<N, N>& a, unsigned int index[]) {
     }
     if (j != N) {
       double temp = 1.0 / a[j][j];
-      for (unsigned int i = j + 1; i < N; ++i) {
+      for (size_t i = j + 1; i < N; ++i) {
         a[i][j] *= temp;
       }
     }
@@ -114,12 +111,12 @@ Vector<N>& lubksb(const Matrix<N, N>& a, const unsigned int index[], Vector<N>& 
   double sum;
   bool non_zero = false;
   unsigned int mark;
-  for (unsigned int i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     unsigned int ip = index[i];
     sum = b[ip];
     b[ip] = b[i];
     if (non_zero) {
-      for (unsigned int j = mark; j < i; ++j) {
+      for (size_t j = mark; j < i; ++j) {
         sum -= a[i][j] * b[j];
       }
     } else if (sum != 0.0) {
@@ -129,9 +126,9 @@ Vector<N>& lubksb(const Matrix<N, N>& a, const unsigned int index[], Vector<N>& 
     b[i] = sum;
   }
 
-  for (int i = N - 1; i >= 0; --i) {
+  for (size_t i = N - 1; i >= 0; --i) {
     sum = b[i];
-    for (unsigned int j = i + 1; j < N; ++j) {
+    for (size_t j = i + 1; j < N; ++j) {
       sum -= a[i][j] * b[j];
     }
     b[i] = sum / a[i][i];

--- a/src/Library/math/Matrix_tfs.hpp
+++ b/src/Library/math/Matrix_tfs.hpp
@@ -1,5 +1,6 @@
 /*!
   \file   Matrix_tfs.hpp
+  \author TAKISAWA Jun'ichi.
   \brief  Matrix.hppのtemplate関数実装
 */
 #ifndef MATRIX_TFS_HPP_

--- a/src/Library/math/Matrix_tfs.hpp
+++ b/src/Library/math/Matrix_tfs.hpp
@@ -1,7 +1,5 @@
 /*!
   \file   Matrix_tfs.hpp
-  \author TAKISAWA Jun'ichi.
-  \date   Sun Oct 24 07:22:34 2010
   \brief  Matrix.hppのtemplate関数実装
 */
 #ifndef MATRIX_TFS_HPP_
@@ -14,8 +12,8 @@ namespace libra {
 
 template <size_t R, size_t C, typename T>
 Matrix<R, C, T>::Matrix(const T& n) {
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       matrix_[i][j] = n;
     }
   }
@@ -23,8 +21,8 @@ Matrix<R, C, T>::Matrix(const T& n) {
 
 template <size_t R, size_t C, typename T>
 const Matrix<R, C, T>& Matrix<R, C, T>::operator+=(const Matrix<R, C, T>& m) {
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       matrix_[i][j] += m.matrix_[i][j];
     }
   }
@@ -33,8 +31,8 @@ const Matrix<R, C, T>& Matrix<R, C, T>::operator+=(const Matrix<R, C, T>& m) {
 
 template <size_t R, size_t C, typename T>
 const Matrix<R, C, T>& Matrix<R, C, T>::operator*=(const T& n) {
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       matrix_[i][j] *= n;
     }
   }
@@ -48,8 +46,8 @@ const Matrix<R, C, T>& Matrix<R, C, T>::operator/=(const T& n) {
 
 template <size_t R, size_t C, typename T>
 const Matrix<R, C, T>& Matrix<R, C, T>::operator-=(const Matrix<R, C, T>& m) {
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       matrix_[i][j] -= m.matrix_[i][j];
     }
   }
@@ -58,8 +56,8 @@ const Matrix<R, C, T>& Matrix<R, C, T>::operator-=(const Matrix<R, C, T>& m) {
 
 template <size_t R, size_t C, typename T>
 void fill_up(Matrix<R, C, T>& m, const T& t) {
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       m[i][j] = t;
     }
   }
@@ -68,7 +66,7 @@ void fill_up(Matrix<R, C, T>& m, const T& t) {
 template <size_t N, typename T>
 T trace(const Matrix<N, N, T>& m) {
   T trace = 0.0;
-  for (int i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     trace += m[i][i];
   }
   return trace;
@@ -76,9 +74,9 @@ T trace(const Matrix<N, N, T>& m) {
 
 template <size_t R, size_t C, typename T>
 void print(const Matrix<R, C, T>& m, char delimiter, std::ostream& stream) {
-  for (int i = 0; i < R; ++i) {
+  for (size_t i = 0; i < R; ++i) {
     stream << m[i][0];
-    for (int j = 1; j < C; ++j) {
+    for (size_t j = 1; j < C; ++j) {
       stream << delimiter << m[i][j];
     }
     stream << std::endl;
@@ -88,8 +86,8 @@ void print(const Matrix<R, C, T>& m, char delimiter, std::ostream& stream) {
 template <size_t R, size_t C, typename T>
 const Matrix<R, C, T> operator+(const Matrix<R, C, T>& lhs, const Matrix<R, C, T>& rhs) {
   Matrix<R, C, T> temp;
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       temp[i][j] = lhs[i][j] + rhs[i][j];
     }
   }
@@ -99,8 +97,8 @@ const Matrix<R, C, T> operator+(const Matrix<R, C, T>& lhs, const Matrix<R, C, T
 template <size_t R, size_t C, typename T>
 const Matrix<R, C, T> operator-(const Matrix<R, C, T>& lhs, const Matrix<R, C, T>& rhs) {
   Matrix<R, C, T> temp;
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       temp[i][j] = lhs[i][j] - rhs[i][j];
     }
   }
@@ -110,8 +108,8 @@ const Matrix<R, C, T> operator-(const Matrix<R, C, T>& lhs, const Matrix<R, C, T
 template <size_t R, size_t C, typename T>
 const Matrix<R, C, T> operator*(const T& rhs, const Matrix<R, C, T>& lhs) {
   Matrix<R, C, T> temp;
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       temp[i][j] = rhs * lhs[i][j];
     }
   }
@@ -121,9 +119,9 @@ const Matrix<R, C, T> operator*(const T& rhs, const Matrix<R, C, T>& lhs) {
 template <size_t R, size_t C1, size_t C2, typename T>
 const Matrix<R, C2, T> operator*(const Matrix<R, C1, T>& lhs, const Matrix<C1, C2, T>& rhs) {
   Matrix<R, C2, T> temp(0);
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C2; ++j) {
-      for (int k = 0; k < C1; ++k) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C2; ++j) {
+      for (size_t k = 0; k < C1; ++k) {
         temp[i][j] += lhs[i][k] * rhs[k][j];
       }
     }
@@ -134,8 +132,8 @@ const Matrix<R, C2, T> operator*(const Matrix<R, C1, T>& lhs, const Matrix<C1, C
 template <size_t R, size_t C, typename T>
 const Matrix<C, R, T> transpose(const Matrix<R, C, T>& m) {
   Matrix<C, R, T> temp;
-  for (int i = 0; i < R; ++i) {
-    for (int j = 0; j < C; ++j) {
+  for (size_t i = 0; i < R; ++i) {
+    for (size_t j = 0; j < C; ++j) {
       temp[j][i] = m[i][j];
     }
   }
@@ -145,7 +143,7 @@ const Matrix<C, R, T> transpose(const Matrix<R, C, T>& m) {
 template <size_t R, typename T>
 Matrix<R, R, T>& unitalize(Matrix<R, R, T>& m) {
   fill_up(m, 0.0);
-  for (int i = 0; i < R; ++i) {
+  for (size_t i = 0; i < R; ++i) {
     m[i][i] = 1.0;
   }
   return m;

--- a/src/Library/math/Vector_tfs.hpp
+++ b/src/Library/math/Vector_tfs.hpp
@@ -1,5 +1,6 @@
 /*!
   \file   Vector_impl.hpp
+  \author TAKISAWA Jun'ichi.
   \brief  Vector.hppのテンプレート実装
 */
 #ifndef VECTOR_HPP_TFS_HPP_

--- a/src/Library/math/Vector_tfs.hpp
+++ b/src/Library/math/Vector_tfs.hpp
@@ -1,7 +1,5 @@
 /*!
   \file   Vector_impl.hpp
-  \author TAKISAWA Jun'ichi.
-  \date   Sun Oct 24 13:54:57 2010
   \brief  Vector.hppのテンプレート実装
 */
 #ifndef VECTOR_HPP_TFS_HPP_
@@ -28,7 +26,7 @@ Vector<N, T>& Vector<N, T>::operator+=(const Vector<N, T>& v) {
 
 template <size_t N, typename T>
 Vector<N, T>& Vector<N, T>::operator-=(const Vector<N, T>& v) {
-  for (int i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     vector_[i] -= v.vector_[i];
   }
   return *this;
@@ -64,7 +62,7 @@ void fill_up(Vector<N, T>& v, const T& n) {
 template <size_t N, typename T>
 void print(const Vector<N, T>& v, char delimiter, std::ostream& stream) {
   stream << v[0];
-  for (int i = 1; i < N; ++i) {
+  for (size_t i = 1; i < N; ++i) {
     stream << delimiter << v[i];
   }
 }
@@ -81,7 +79,7 @@ const Vector<N, T> operator+(const Vector<N, T>& lhs, const Vector<N, T>& rhs) {
 template <size_t N, typename T>
 const Vector<N, T> operator-(const Vector<N, T>& lhs, const Vector<N, T>& rhs) {
   Vector<N, T> temp;
-  for (int i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     temp[i] = lhs[i] - rhs[i];
   }
   return temp;
@@ -99,7 +97,7 @@ const Vector<N, T> operator*(const T& lhs, const Vector<N, T>& rhs) {
 template <size_t N, typename T>
 const T inner_product(const Vector<N, T>& lhs, const Vector<N, T>& rhs) {
   T temp = 0;
-  for (int i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     temp += lhs[i] * rhs[i];
   }
   return temp;


### PR DESCRIPTION
## Overview
Fix warnings in Vector-Matrix library

## Issue
- #87 

## Details
Warnings in g++ environment is reduced from 602 to 182 in the `PROBLEMS` window in the VS code.

##  Validation results
NA

## Scope of influence
Small. The algorithm is not changed.

## Supplement
NA

## Note
NA