### PR TITLE
Update vs2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: ./ExtLibraries
         run: |
           $extlib_dir=(pwd).Path
-          cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR="${extlib_dir}"
+          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR="${extlib_dir}"
           cmake --build .
       - name: install extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ on:
 
 jobs:
   build_s2e_win:
-    name: Build on Windows
-    # VS2019 を使うため
-    runs-on: windows-2019
+    name: Build on Windows VS2022
+    # VS2022 を使うため
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
         shell: cmd
         run: |
           cl.exe
-          cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DFLIGHT_SW_DIR=./c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -D${{ matrix.use_c2a }}
+          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DFLIGHT_SW_DIR=./c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -D${{ matrix.use_c2a }}
           cmake --build .
 
   build_s2e_linux:

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -2,7 +2,7 @@
   "configurations": [
     {
       "name": "Win32",
-      "generator": "Visual Studio 16 2019",
+      "generator": "Visual Studio 17 2022",
       "configurationType": "Debug",
       "inheritEnvironments": [
         "msvc_x86"

--- a/ExtLibraries/CMakeSettings.json
+++ b/ExtLibraries/CMakeSettings.json
@@ -1,0 +1,17 @@
+﻿{
+  "configurations": [
+    {
+      "name": "Win32",
+      "generator": "Visual Studio 17 2022",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "buildRoot": "${thisFileDir}\\CMakeBuilds",
+      "installRoot": "${thisFileDir}\\CMakeBuilds",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -38,7 +38,7 @@ function(download_generic_kernel dir kernel sha256)
     URL ${GENERIC_KERNEL_URL_BASE}/${dir}/${kernel}
     URL_HASH SHA256=${sha256}
     DOWNLOAD_NO_EXTRACT true
-    SOURCE_DIR ${CSPICE_INSTALL_DIR}/generic_kernels
+    SOURCE_DIR ${CSPICE_INSTALL_DIR}/generic_kernels/${dir}
   )
   FetchContent_MakeAvailable(${kernel})
 endfunction(download_generic_kernel)

--- a/ExtLibraries/cspice/install_step.cmake
+++ b/ExtLibraries/cspice/install_step.cmake
@@ -22,4 +22,12 @@ file(
   DESTINATION ${CSPICE_INSTALL_DIR}/${CSPICE_LIB_DEST}
 )
 
+# move generic kernel
+message("install cspice/generic_kernels/lsk")
+file(
+  INSTALL ${CSPICE_INSTALL_DIR}/generic_kernels/lsk/a_old_versions/naif0010.tls
+  DESTINATION ${CSPICE_INSTALL_DIR}/generic_kernels/lsk
+)
+
+
 message("install cspice done.")

--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -11,7 +11,7 @@ set(NRLMSISE_URL_BASE https://ccmc.gsfc.nasa.gov/pub/modelweb/atmospheric/msis/n
 set(NRLMSISE_TABLE_URL_BASE ftp://ftp.agi.com/pub/DynamicEarthData)
 set(NRLMSISE_TABLE_FILE SpaceWeather-v1.2.txt)
 
-set(NRLMSISE_TMP_DIR "nrlmsise")
+set(NRLMSISE_TMP_DIR ${NRLMSISE_INSTALL_DIR}/tmp)
 
 # download files
 function(download_file base_url file sha256)
@@ -89,6 +89,6 @@ install(FILES ${NRLMSISE_TMP_DIR}/nrlmsise-00_data.c
 )
 
 ## install table
-install(FILES nrlmsise/${NRLMSISE_TABLE_FILE}
+install(FILES ${NRLMSISE_TMP_DIR}/${NRLMSISE_TABLE_FILE}
   DESTINATION ${NRLMSISE_INSTALL_DIR}/table
 )


### PR DESCRIPTION
## Overview
Update VS2022

## Issue
- #77 

## Details
The default build setting is updated to use VS2022 for Visual Studio users.  
In addition, automatic settings for `ExtLibraries` with Cmake files were confirmed and modified to suit the VS environment.

##  Validation results
Confirmed that the S2E is buildable and executable in the VS2022

## Scope of influence
The source codes are not changed.  
Only for Windows VS users.

## Supplement
Please also see the following document.  
https://github.com/ut-issl/s2e-documents/blob/feature/update-vs2022/General/HowToCompileWithVisualStudio.md 

## Note
NA