### PR TITLE
Add -Wextra to common compile option

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -13,6 +13,7 @@ if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
 else()
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wall")
+  target_compile_options(${PROJECT_NAME} PUBLIC "-Wextra")
   target_compile_options(${PROJECT_NAME} PUBLIC "-rdynamic")
 
   # 32bit


### PR DESCRIPTION
## Overview
Add `-Wextra` to compile option for clang++/g++.

## Issue
- #87 

## Details
Write in detail.

##  Validation results
Link to tests or validation results.

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
