### PR TITLE
delete const function return

### DIFF
--- a/src/Component/AOCS/RWModel.h
+++ b/src/Component/AOCS/RWModel.h
@@ -57,9 +57,9 @@ class RWModel : public ComponentBase, public ILoggable {
   // Getter
   const libra::Vector<3> GetOutputTorqueB() const;
   const libra::Vector<3> GetJitterForceB() const { return rw_jitter_.GetJitterForceB(); }
-  inline const bool isMotorDrove() const { return drive_flag_; };
-  inline const double GetVelocityRad() const { return angular_velocity_rad_; };
-  inline const double GetVelocityRpm() const { return angular_velocity_rpm_; };
+  inline bool isMotorDrove() const { return drive_flag_; };
+  inline double GetVelocityRad() const { return angular_velocity_rad_; };
+  inline double GetVelocityRpm() const { return angular_velocity_rpm_; };
   inline const libra::Vector<3> GetAngMomB() const { return angular_momentum_b_; };
 
   // Setter

--- a/src/Component/AOCS/STT.h
+++ b/src/Component/AOCS/STT.h
@@ -50,7 +50,7 @@ class STT : public ComponentBase, public ILoggable {
 
   // Getter
   inline const libra::Quaternion GetObsQuaternion() const { return q_stt_i2c_; };
-  inline const bool GetErrorFlag() const { return error_flag_; }
+  inline bool GetErrorFlag() const { return error_flag_; }
 
  protected:
   // STT general parameters

--- a/src/Component/AOCS/SunSensor.h
+++ b/src/Component/AOCS/SunSensor.h
@@ -26,12 +26,12 @@ class SunSensor : public ComponentBase, public ILoggable {
   virtual std::string GetLogHeader() const;
   virtual std::string GetLogValue() const;
   // Getter
-  inline const bool GetSunDetectedFlag() const { return sun_detected_flag_; };
+  inline bool GetSunDetectedFlag() const { return sun_detected_flag_; };
   inline const Vector<3> GetMeasuredSun_c() const { return measured_sun_c_; };
   inline const Vector<3> GetMeasuredSun_b() const { return q_b2c_.conjugate().frame_conv(measured_sun_c_); };
-  inline const double GetSunAngleAlpha() const { return alpha_; };
-  inline const double GetSunAngleBeta() const { return beta_; };
-  inline const double GetSolarIlluminance() const { return solar_illuminance_; };
+  inline double GetSunAngleAlpha() const { return alpha_; };
+  inline double GetSunAngleBeta() const { return beta_; };
+  inline double GetSolarIlluminance() const { return solar_illuminance_; };
 
  protected:
   const int id_;

--- a/src/Component/Abstract/ObcCommunicationBase.h
+++ b/src/Component/Abstract/ObcCommunicationBase.h
@@ -20,7 +20,7 @@ class ObcCommunicationBase {
                        HilsPortManager* hils_port_manager);
   ~ObcCommunicationBase();
 
-  inline const bool IsConnected() const { return is_connected_; }
+  inline bool IsConnected() const { return is_connected_; }
 
  protected:
   int ReceiveCommand(const int offset, const int rec_size);

--- a/src/Environment/Global/SimTime.h
+++ b/src/Environment/Global/SimTime.h
@@ -47,33 +47,33 @@ class SimTime : public ILoggable {
 
   // Get functions
   inline const TimeState GetState(void) const { return state_; };
-  inline const double GetElapsedSec(void) const { return elapsed_time_sec_; };
-  inline const double GetStepSec(void) const { return step_sec_; };
-  inline const double GetAttitudeUpdateIntervalSec(void) const { return attitude_update_interval_sec_; };
-  inline const bool GetAttitudePropagateFlag(void) const { return attitude_update_flag_; };
-  inline const double GetAttitudeRKStepSec() const { return attitude_rk_step_sec_; }
-  inline const double GetOrbitUpdateIntervalSec(void) const { return orbit_update_interval_sec_; };
-  inline const bool GetOrbitPropagateFlag(void) const { return orbit_update_flag_; };
-  inline const double GetOrbitRKStepSec() const { return orbit_rk_step_sec_; }
-  inline const double GetThermalUpdateIntervalSec(void) const { return thermal_update_interval_sec_; };
-  inline const bool GetThermalPropagateFlag(void) const { return thermal_update_flag_; };
-  inline const double GetThermalRKStepSec() const { return thermal_rk_step_sec_; }
-  inline const double GetCompoStepSec(void) const { return compo_update_interval_sec_; };
-  inline const bool GetCompoUpdateFlag() const { return compo_update_flag_; }
-  inline const int GetCompoPropagateFrequency(void) const { return compo_propagate_frequency_; };
+  inline double GetElapsedSec(void) const { return elapsed_time_sec_; };
+  inline double GetStepSec(void) const { return step_sec_; };
+  inline double GetAttitudeUpdateIntervalSec(void) const { return attitude_update_interval_sec_; };
+  inline bool GetAttitudePropagateFlag(void) const { return attitude_update_flag_; };
+  inline double GetAttitudeRKStepSec() const { return attitude_rk_step_sec_; }
+  inline double GetOrbitUpdateIntervalSec(void) const { return orbit_update_interval_sec_; };
+  inline bool GetOrbitPropagateFlag(void) const { return orbit_update_flag_; };
+  inline double GetOrbitRKStepSec() const { return orbit_rk_step_sec_; }
+  inline double GetThermalUpdateIntervalSec(void) const { return thermal_update_interval_sec_; };
+  inline bool GetThermalPropagateFlag(void) const { return thermal_update_flag_; };
+  inline double GetThermalRKStepSec() const { return thermal_rk_step_sec_; }
+  inline double GetCompoStepSec(void) const { return compo_update_interval_sec_; };
+  inline bool GetCompoUpdateFlag() const { return compo_update_flag_; }
+  inline int GetCompoPropagateFrequency(void) const { return compo_propagate_frequency_; };
 
-  inline const double GetEndSec(void) const { return end_sec_; };
-  inline const int GetProgressionRate(void) const { return (int)floor((elapsed_time_sec_ / end_sec_ * 100)); };
-  inline const double GetCurrentJd(void) const { return current_jd_; };
-  inline const double GetCurrentSidereal(void) const { return current_sidereal_; };
-  inline const double GetCurrentDecyear(void) const { return current_decyear_; };
+  inline double GetEndSec(void) const { return end_sec_; };
+  inline int GetProgressionRate(void) const { return (int)floor((elapsed_time_sec_ / end_sec_ * 100)); };
+  inline double GetCurrentJd(void) const { return current_jd_; };
+  inline double GetCurrentSidereal(void) const { return current_sidereal_; };
+  inline double GetCurrentDecyear(void) const { return current_decyear_; };
   inline const UTC GetCurrentUTC(void) const { return current_utc_; };
-  inline const int GetStartYear(void) const { return start_year_; };
-  inline const int GetStartMon(void) const { return start_mon_; };
-  inline const int GetStartDay(void) const { return start_day_; };
-  inline const int GetStartHr(void) const { return start_hr_; };
-  inline const int GetStartMin(void) const { return start_min_; };
-  inline const double GetStartSec(void) const { return start_sec_; };
+  inline int GetStartYear(void) const { return start_year_; };
+  inline int GetStartMon(void) const { return start_mon_; };
+  inline int GetStartDay(void) const { return start_day_; };
+  inline int GetStartHr(void) const { return start_hr_; };
+  inline int GetStartMin(void) const { return start_min_; };
+  inline double GetStartSec(void) const { return start_sec_; };
   // logs
   virtual std::string GetLogHeader() const;
   virtual std::string GetLogValue() const;

--- a/src/Interface/SpacecraftInOut/Ports/PowerPort.h
+++ b/src/Interface/SpacecraftInOut/Ports/PowerPort.h
@@ -10,10 +10,10 @@ class PowerPort {
   bool Update(void);  // return is_on_
 
   // Getters
-  inline const double GetVoltage(void) const { return voltage_; }
-  inline const double GetCurrentConsumption() const { return current_consumption_; }
-  inline const double GetAssumedPowerConsumption() const { return assumed_power_consumption_; }
-  inline const bool GetIsOn() const { return is_on_; }
+  inline double GetVoltage(void) const { return voltage_; }
+  inline double GetCurrentConsumption() const { return current_consumption_; }
+  inline double GetAssumedPowerConsumption() const { return assumed_power_consumption_; }
+  inline bool GetIsOn() const { return is_on_; }
 
   // Setters
   bool SetVoltage(const double voltage);  // return is_on_

--- a/src/Library/Orbit/OrbitalElements.h
+++ b/src/Library/Orbit/OrbitalElements.h
@@ -12,12 +12,12 @@ class OrbitalElements {
   ~OrbitalElements();
 
   // Getter
-  inline const double GetSemiMajor() const { return semi_major_axis_m_; }
-  inline const double GetEccentricity() const { return eccentricity_; }
-  inline const double GetInclination() const { return inclination_rad_; }
-  inline const double GetRaan() const { return raan_rad_; }
-  inline const double GetArgPerigee() const { return arg_perigee_rad_; }
-  inline const double GetEpoch() const { return epoch_jday_; }
+  inline double GetSemiMajor() const { return semi_major_axis_m_; }
+  inline double GetEccentricity() const { return eccentricity_; }
+  inline double GetInclination() const { return inclination_rad_; }
+  inline double GetRaan() const { return raan_rad_; }
+  inline double GetArgPerigee() const { return arg_perigee_rad_; }
+  inline double GetEpoch() const { return epoch_jday_; }
 
  private:
   // Common Variables

--- a/src/Library/optics/GaussianBeamBase.h
+++ b/src/Library/optics/GaussianBeamBase.h
@@ -14,9 +14,9 @@ class GaussianBeamBase {
   void SetBeamWaistPos_i(const libra::Vector<3> pos_beamwaist_i);
 
   // getter
-  inline const double GetWaveLength() const { return wavelength_m_; }
-  inline const double GetBeamWaistRadius() const { return r_beam_waist_m_; }
-  inline const double GetTotalPower() const { return total_power_watt_; }
+  inline double GetWaveLength() const { return wavelength_m_; }
+  inline double GetBeamWaistRadius() const { return r_beam_waist_m_; }
+  inline double GetTotalPower() const { return total_power_watt_; }
   inline const libra::Vector<3> GetPointingVector_i() const { return pointing_vector_i_; }
   inline const libra::Vector<3> GetBeamWaistPos_i() const { return pos_beamwaist_i_; }
 

--- a/src/Simulation/Spacecraft/Spacecraft.h
+++ b/src/Simulation/Spacecraft/Spacecraft.h
@@ -35,7 +35,7 @@ class Spacecraft {
   inline const LocalEnvironment& GetLocalEnv() const { return *local_env_; }
   inline const Disturbances& GetDisturbances() const { return *disturbances_; }
   inline const InstalledComponents& GetInstalledComponents() const { return *components_; }
-  inline const int GetSatID() const { return sat_id_; }
+  inline int GetSatID() const { return sat_id_; }
 
  protected:
   ClockGenerator clock_gen_;


### PR DESCRIPTION
## Overview
delete const function return.

## Issue
- #87 

## Details
Several functions has unnecessary `const` type as return.  
I deleted them.

##  Validation results
No effect to calculations.

## Scope of influence
small.

## Supplement
NA

## Note
- The warnings in g++ is dramatically decreased from 1300 to 95 by this modification.