### PR TITLE
Fix thermal initialization to avoid CSV file reading

### DIFF
--- a/src/Dynamics/Thermal/InitTemperature.cpp
+++ b/src/Dynamics/Thermal/InitTemperature.cpp
@@ -53,10 +53,16 @@ Temperature* InitTemperature(const std::string ini_path, const double rk_prop_st
   vector<vector<string>> vnodestr;  // string vector of node property data
   int nodes_num = 1;
 
+  bool is_calc_enabled = mainIni.ReadBoolean("Thermal", "IsCalcEnabled");
+  if (is_calc_enabled == false) {
+    // Return here to avoid CSV file reading
+    Temperature* temperature;
+    temperature = new Temperature();
+    return temperature;
+  }
+
   // read ini-file settings
   string file_path = mainIni.ReadString("Thermal", "thrm_file");
-
-  bool is_calc_enabled = mainIni.ReadBoolean("Thermal", "IsCalcEnabled");
   bool debug = mainIni.ReadBoolean("Thermal", "debug");
 
   // Read Node Properties from CSV File

--- a/src/Dynamics/Thermal/Temperature.cpp
+++ b/src/Dynamics/Thermal/Temperature.cpp
@@ -13,7 +13,7 @@ Temperature::Temperature(const vector<vector<double>> cij, const vector<vector<d
       vnodes_(vnodes),
       node_num_(node_num),
       prop_step_(propstep),  // ルンゲクッタ積分時間刻み幅
-      isCalcEnabled_(is_calc_enabled),
+      is_calc_enabled_(is_calc_enabled),
       debug_(debug) {
   prop_time_ = 0;
   if (debug_) {
@@ -21,10 +21,17 @@ Temperature::Temperature(const vector<vector<double>> cij, const vector<vector<d
   }
 }
 
+Temperature::Temperature() {
+  node_num_ = 0;
+  prop_step_ = 0.0;
+  is_calc_enabled_ = false;
+  debug_ = false;
+}
+
 Temperature::~Temperature() {}
 
 void Temperature::Propagate(Vector<3> sun_direction, const double endtime) {
-  if (!isCalcEnabled_) return;
+  if (!is_calc_enabled_) return;
   while (endtime - prop_time_ - prop_step_ > 1.0e-6) {
     RungeOneStep(prop_time_, prop_step_, sun_direction, node_num_);
     prop_time_ += prop_step_;
@@ -145,7 +152,7 @@ string Temperature::GetLogValue() const {
 
 void Temperature::PrintParams(void) {
   cout << "< Print Thermal Parameters >" << endl;
-  cout << "IsCalcEnabled: " << isCalcEnabled_ << endl;
+  cout << "IsCalcEnabled: " << is_calc_enabled_ << endl;
   cout << "Vnodes:" << endl;
   for (auto itr = vnodes_.begin(); itr != vnodes_.end(); ++itr) {
     itr->PrintParam();

--- a/src/Dynamics/Thermal/Temperature.h
+++ b/src/Dynamics/Thermal/Temperature.h
@@ -16,19 +16,19 @@ class Temperature : public ILoggable {
   std::vector<std::vector<double>> rij_;  // Coupling of node i and node j by thermal radiation
   std::vector<Node> vnodes_;              // vector of nodes
   int node_num_;                          // number of nodes
-  double prop_step_;                      //積分刻み幅[sec]
+  double prop_step_;                      // 積分刻み幅[sec]
   double prop_time_;                      // Temperatureクラス内での累積積分時間(end_timeに等しくなるまで積分する)
-  bool isCalcEnabled_;                    //温度更新をするかどうかのブーリアン
+  bool is_calc_enabled_;                  // 温度更新をするかどうかのブーリアン
   bool debug_;
 
-  void RungeOneStep(double t, double dt, Vector<3> sun_direction,
-                    int node_num);  // ルンゲクッタOne Step
+  void RungeOneStep(double t, double dt, Vector<3> sun_direction, int node_num);
   std::vector<double> OdeTemperature(std::vector<double> x, double t, const Vector<3> sun_direction,
                                      int node_num);  // 温度に関する常微分方程式, xはnodeの温度をならべたもの
 
  public:
   Temperature(const std::vector<std::vector<double>> cij_, const std::vector<std::vector<double>> rij, std::vector<Node> vnodes, const int node_num,
               const double propstep, const bool is_calc_enabled, const bool debug);
+  Temperature();
   virtual ~Temperature();
   void Propagate(Vector<3> sun_direction,
                  const double endtime);  //太陽入熱量計算のため, 太陽方向の情報を入手


### PR DESCRIPTION
## Overview
Fix thermal initialization to avoid CSV file reading

## Issue
NA

## Details
Currently, users must set the correct file path for `ThermalCSV` files even if the users don't use the thermal dynamics calculation. It is bothering to users to set unnecessary files.

I changed to avoid reading files when the thermal calculation is disabled.

##  Validation results
I confirmed that the CSV files are not needed when thermal calculation is disabled.
The result of calculation is not changed.  

## Scope of influence
Almost nothing

## Supplement
NA

## Note
NA