### PR TITLE
Refactor Attitude Dynamics

### DIFF
--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -9,10 +9,11 @@ Omega_b(1) = 0.0
 Omega_b(2) = 0.0
 
 // Initial quaternion，i->b，(real part，imaginary part)
-Quaternion_i2b(0) = 0.0
-Quaternion_i2b(1) = 0.0
-Quaternion_i2b(2) = 0.0
-Quaternion_i2b(3) = 1.0
+// This value also used in INERTIAL_STABILIZE mode of ControlledAttitude
+Quaternion_i2b(0) = 0.5
+Quaternion_i2b(1) = 0.5
+Quaternion_i2b(2) = 0.5
+Quaternion_i2b(3) = 0.5
 
 // Initial torque at body frame，[Nm]
 // Note: The initial torque added just for the first propagation step
@@ -29,12 +30,6 @@ Torque_b(2) =  0.000
 // ORBIT_NORMAL_POINTING = 4,
 main_mode = 3
 sub_mode = 1
-
-// Target Quaternion for INERTIAL_STABILIZE mode，(real part，imaginary part)
-quaternion_i2t(0) = 0.5
-quaternion_i2t(1) = 0.5
-quaternion_i2t(2) = 0.5
-quaternion_i2t(3) = 0.5
 
 // Pointing direction @ body frame for main pointing mode
 pointing_t_b(0) = 0.707

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -10,10 +10,10 @@ Omega_b(2) = 0.0
 
 // Initial quaternion，i->b，(real part，imaginary part)
 // This value also used in INERTIAL_STABILIZE mode of ControlledAttitude
-Quaternion_i2b(0) = 0.5
-Quaternion_i2b(1) = 0.5
-Quaternion_i2b(2) = 0.5
-Quaternion_i2b(3) = 0.5
+Quaternion_i2b(0) = 0.0
+Quaternion_i2b(1) = 0.0
+Quaternion_i2b(2) = 0.0
+Quaternion_i2b(3) = 1.0
 
 // Initial torque at body frame，[Nm]
 // Note: The initial torque added just for the first propagation step

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -1,7 +1,8 @@
 [ATTITUDE]
 // Attitude propagation mode
-// 0: RK4, 1: ControlledAttitude
-propagate_mode = 0
+// RK4 : Attitude Propagation with RK4 including disturbances and control torque
+// CONTROLLED : Attitude Calculation with Controlled Attitude mode. All disturbances and control torque are ignored.
+propagate_mode = RK4
 
 // Initial angular velocity at body frame，[rad/s]
 Omega_b(0) = 0.0
@@ -23,13 +24,13 @@ Torque_b(2) =  0.000
 
 [ControlledAttitude]
 // Mode definitions
-// INERTIAL_STABILIZE = 0,
-// SUN_POINTING = 1,
-// EARTH_CENTER_POINTING = 2
-// VELOCITY_DIRECTION_POINTING = 3,
-// ORBIT_NORMAL_POINTING = 4,
-main_mode = 3
-sub_mode = 1
+// INERTIAL_STABILIZE
+// SUN_POINTING
+// EARTH_CENTER_POINTING
+// VELOCITY_DIRECTION_POINTING
+// ORBIT_NORMAL_POINTING
+main_mode = INERTIAL_STABILIZE
+sub_mode = SUN_POINTING
 
 // Pointing direction @ body frame for main pointing mode
 pointing_t_b(0) = 0.707

--- a/src/Dynamics/Attitude/Attitude.cpp
+++ b/src/Dynamics/Attitude/Attitude.cpp
@@ -1,0 +1,51 @@
+#include "Attitude.h"
+
+#include <Interface/LogOutput/LogUtility.h>
+
+Attitude::Attitude(const std::string& sim_object_name) : SimulationObject(sim_object_name) {
+  omega_b_rad_s_ = libra::Vector<3>(0.0);
+  quaternion_i2b_ = libra::Quaternion(0.0, 0.0, 0.0, 1.0);
+  torque_b_Nm_ = libra::Vector<3>(0.0);
+  h_sc_b_Nms_ = libra::Vector<3>(0.0);
+  h_rw_b_Nms_ = libra::Vector<3>(0.0);
+  h_total_b_Nms_ = libra::Vector<3>(0.0);
+  h_total_i_Nms_ = libra::Vector<3>(0.0);
+  h_total_Nms_ = 0.0;
+  k_sc_J_ = 0.0;
+}
+
+std::string Attitude::GetLogHeader() const {
+  std::string str_tmp = "";
+
+  str_tmp += WriteVector("omega_true", "b", "rad/s", 3);
+  str_tmp += WriteVector("quaternion_true", "i2b", "-", 4);
+  str_tmp += WriteVector("torque_true", "b", "Nm", 3);
+  str_tmp += WriteScalar("h_total", "Nms");
+  str_tmp += WriteScalar("k_sc", "J");
+
+  return str_tmp;
+}
+
+std::string Attitude::GetLogValue() const {
+  std::string str_tmp = "";
+
+  str_tmp += WriteVector(omega_b_rad_s_);
+  str_tmp += WriteQuaternion(quaternion_i2b_);
+  str_tmp += WriteVector(torque_b_Nm_);
+  str_tmp += WriteScalar(h_total_Nms_);
+  str_tmp += WriteScalar(k_sc_J_);
+
+  return str_tmp;
+}
+
+void Attitude::SetParameters(const MCSimExecutor& mc_sim) { GetInitParameterQuaternion(mc_sim, "Q_i2b", quaternion_i2b_); }
+
+void Attitude::CalcAngMom(void) {
+  h_sc_b_Nms_ = inertia_tensor_kgm2_ * omega_b_rad_s_;
+  h_total_b_Nms_ = h_rw_b_Nms_ + h_sc_b_Nms_;
+  Quaternion q_b2i = quaternion_i2b_.conjugate();
+  h_total_i_Nms_ = q_b2i.frame_conv(h_total_b_Nms_);
+  h_total_Nms_ = norm(h_total_i_Nms_);
+}
+
+void Attitude::CalcSatRotationalKineticEnergy(void) { k_sc_J_ = 0.5 * libra::inner_product(h_sc_b_Nms_, omega_b_rad_s_); }

--- a/src/Dynamics/Attitude/Attitude.h
+++ b/src/Dynamics/Attitude/Attitude.h
@@ -1,116 +1,72 @@
 #ifndef __attitude_H__
 #define __attitude_H__
 
+#include <Interface/LogOutput/ILoggable.h>
 #include <Simulation/MCSim/SimulationObject.h>
 
 #include <Library/math/MatVec.hpp>
 #include <Library/math/Quaternion.hpp>
 #include <string>
-using libra::Matrix;
-using libra::Quaternion;
-using libra::Vector;
 
-#include <Interface/LogOutput/ILoggable.h>
-
-enum AttCtrlMode {
-  INERTIAL_STABILIZE,
-  SUN_POINTING,
-  EARTH_CENTER_POINTING,
-  VELOCITY_DIRECTION_POINTING,
-  ORBIT_NORMAL_POINTING,
-  NO_CTRL,
-};
-
-class Attitude : public ILoggable {
+class Attitude : public ILoggable, public SimulationObject {
  public:
-  Attitude() {
-    prop_time_ = 0.0;
-    prop_step_ = 0.0;
-    omega_b_ = Vector<3>(0.0);
-    quaternion_i2b_ = Quaternion(0.0, 0.0, 0.0, 1.0);
-    torque_b_ = Vector<3>(0.0);
-    h_sc_b_ = Vector<3>(0.0);
-    h_rw_b_ = Vector<3>(0.0);
-    h_total_b_ = Vector<3>(0.0);
-    h_total_i_ = Vector<3>(0.0);
-    h_total_ = 0.0;
-    inertia_tensor_[0][0] = 1.0;
-    inertia_tensor_[0][1] = 0.0;
-    inertia_tensor_[0][2] = 0.0;
-    inertia_tensor_[1][0] = 0.0;
-    inertia_tensor_[1][1] = 1.0;
-    inertia_tensor_[1][2] = 0.0;
-    inertia_tensor_[2][0] = 0.0;
-    inertia_tensor_[2][1] = 0.0;
-    inertia_tensor_[2][2] = 1.0;
-    inv_inertia_tensor_ = invert(inertia_tensor_);
-  }
+  Attitude(const std::string& sim_object_name = "Attitude");
   virtual ~Attitude() {}
 
-  // Output from this class
-  inline double GetPropStep() const { return prop_step_; }
-  inline double GetPropTime() const { return prop_time_; }
-  inline double GetEnergy() const { return 0.5f * inner_product(omega_b_, inertia_tensor_ * omega_b_); }
-  inline double GetTotalAngMomNorm() const { return norm(h_total_b_); }
-  inline Matrix<3, 3> GetInertiaTensor() const { return inertia_tensor_; }
-  inline Matrix<3, 3> GetInvInertiaTensor() const { return inv_inertia_tensor_; }
-  inline Vector<3> GetOmega_b() const { return omega_b_; }
-  inline Quaternion GetQuaternion_i2b() const { return quaternion_i2b_; }
-  inline Matrix<3, 3> GetDCM_b2i() const { return quaternion_i2b_.toDCM(); }
-  inline Matrix<3, 3> GetDCM_i2b() const {
-    Matrix<3, 3> DCM_b2i = quaternion_i2b_.toDCM();
+  // Getter
+  inline double GetPropStep() const { return prop_step_s_; }
+  inline libra::Vector<3> GetOmega_b() const { return omega_b_rad_s_; }
+  inline libra::Quaternion GetQuaternion_i2b() const { return quaternion_i2b_; }
+  inline libra::Matrix<3, 3> GetDCM_b2i() const { return quaternion_i2b_.toDCM(); }
+  inline libra::Matrix<3, 3> GetDCM_i2b() const {
+    libra::Matrix<3, 3> DCM_b2i = quaternion_i2b_.toDCM();
     return transpose(DCM_b2i);
   }
+  inline double GetTotalAngMomNorm() const { return norm(h_total_b_Nms_); }
+  inline double GetEnergy() const { return 0.5f * inner_product(omega_b_rad_s_, inertia_tensor_kgm2_ * omega_b_rad_s_); }
+  inline libra::Matrix<3, 3> GetInertiaTensor() const { return inertia_tensor_kgm2_; }
+  inline libra::Matrix<3, 3> GetInvInertiaTensor() const { return inv_inertia_tensor_; }
 
-  // Input to this class
-  inline void SetTime(double set) { prop_time_ = set; }
-  inline void SetPropStep(double set) { prop_step_ = set; }
-  inline void SetOmega_b(Vector<3> set) { omega_b_ = set; }
-  inline void SetQuaternion_i2b(Quaternion set) { quaternion_i2b_ = set; }
-  inline void AddQuaternionOffset(Quaternion offset) { quaternion_i2b_ = quaternion_i2b_ * offset; }
-  inline void SetTorque_b(Vector<3> set) { torque_b_ = set; }
-  inline void SetAngMom_rw(Vector<3> set) { h_rw_b_ = set; }
+  // Setter
+  inline void SetPropStep(double set) { prop_step_s_ = set; }
+  inline void SetOmega_b(const libra::Vector<3> set) { omega_b_rad_s_ = set; }
+  inline void SetQuaternion_i2b(const libra::Quaternion set) { quaternion_i2b_ = set; }
+  inline void AddQuaternionOffset(const libra::Quaternion offset) { quaternion_i2b_ = quaternion_i2b_ * offset; }
+  inline void SetTorque_b(const libra::Vector<3> set) { torque_b_Nm_ = set; }
+  inline void AddTorque_b(const libra::Vector<3> set) { torque_b_Nm_ += set; }
+  inline void SetAngMom_rw(const libra::Vector<3> set) { h_rw_b_Nms_ = set; }
   inline void SetInertiaTensor(const Matrix<3, 3>& set) {
-    inertia_tensor_ = set;
-    inv_inertia_tensor_ = invert(inertia_tensor_);
+    inertia_tensor_kgm2_ = set;
+    inv_inertia_tensor_ = libra::invert(inertia_tensor_kgm2_);
   }
-  inline void AddTorque_b(Vector<3> set) { torque_b_ += set; }
 
-  // Setter for Controlled Attitude
-  inline void SetMainMode(const AttCtrlMode main_mode) { main_mode_ = main_mode; }
-  inline void SetSubMode(const AttCtrlMode sub_mode) { sub_mode_ = sub_mode; }
-  inline void SetQuaternionI2T(const Quaternion quaternion_i2t) { quaternion_i2t_ = quaternion_i2t; }
-  inline void SetPointingTb(Vector<3> pointing_t_b) { pointing_t_b_ = pointing_t_b; }
-  inline void SetPointingSubTb(Vector<3> pointing_sub_t_b) { pointing_sub_t_b_ = pointing_sub_t_b; }
+  // base function for derived class
+  virtual void Propagate(const double endtime_s) = 0;
 
-  virtual void Propagate(double endtime) = 0;
+  // Loggable
+  virtual std::string GetLogHeader() const;
+  virtual std::string GetLogValue() const;
 
-  virtual std::string GetLogHeader() const = 0;
-  virtual std::string GetLogValue() const = 0;
-
-  bool IsCalcEnabled = true;
+  // SimulationObject for McSim
+  virtual void SetParameters(const MCSimExecutor& mc_sim);
 
  protected:
-  // for RK4
-  double prop_time_;  // current time
-  double prop_step_;  // timestep for integral
-  Vector<3> omega_b_;
-  Quaternion quaternion_i2b_;
-  Vector<3> torque_b_;
-  Vector<3> h_sc_b_;
-  Vector<3> h_rw_b_;
-  Vector<3> h_total_b_;
-  Vector<3> h_total_i_;
-  double h_total_;
-  double k_sc_;  // Rotational Kinetic Energy of Spacecraft [J]
-  Matrix<3, 3> inertia_tensor_;
-  Matrix<3, 3> inv_inertia_tensor_;  // inverse matrix of Iner_
+  bool is_calc_enabled_ = true;
+  double prop_step_s_;  // TODO: consider is it really need here
+  libra::Vector<3> omega_b_rad_s_;
+  libra::Quaternion quaternion_i2b_;
+  libra::Vector<3> torque_b_Nm_;
+  libra::Matrix<3, 3> inertia_tensor_kgm2_;
+  libra::Matrix<3, 3> inv_inertia_tensor_;  // inverse matrix of Iner_
+  libra::Vector<3> h_sc_b_Nms_;
+  libra::Vector<3> h_rw_b_Nms_;
+  libra::Vector<3> h_total_b_Nms_;
+  libra::Vector<3> h_total_i_Nms_;
+  double h_total_Nms_;
+  double k_sc_J_;  // Rotational Kinetic Energy of Spacecraft [J]
 
-  // for Controlled Attitude
-  AttCtrlMode main_mode_;
-  AttCtrlMode sub_mode_;        // for control around pointing direction
-  Quaternion quaternion_i2t_;   // ECI->Target
-  Vector<3> pointing_t_b_;      // Pointing target on body frame
-  Vector<3> pointing_sub_t_b_;  // Pointing sub target on body frame
+  void CalcAngMom(void);
+  void CalcSatRotationalKineticEnergy(void);
 };
+
 #endif  //__attitude_H__

--- a/src/Dynamics/Attitude/Attitude.h
+++ b/src/Dynamics/Attitude/Attitude.h
@@ -22,8 +22,8 @@ class Attitude : public ILoggable, public SimulationObject {
     libra::Matrix<3, 3> DCM_b2i = quaternion_i2b_.toDCM();
     return transpose(DCM_b2i);
   }
-  inline double GetTotalAngMomNorm() const { return norm(h_total_b_Nms_); }
-  inline double GetEnergy() const { return 0.5f * inner_product(omega_b_rad_s_, inertia_tensor_kgm2_ * omega_b_rad_s_); }
+  inline double GetTotalAngMomNorm() const { return libra::norm(h_total_b_Nms_); }
+  inline double GetEnergy() const { return 0.5f * libra::inner_product(omega_b_rad_s_, inertia_tensor_kgm2_ * omega_b_rad_s_); }
   inline libra::Matrix<3, 3> GetInertiaTensor() const { return inertia_tensor_kgm2_; }
   inline libra::Matrix<3, 3> GetInvInertiaTensor() const { return inv_inertia_tensor_; }
 

--- a/src/Dynamics/Attitude/AttitudeRK4.cpp
+++ b/src/Dynamics/Attitude/AttitudeRK4.cpp
@@ -9,69 +9,41 @@ using namespace std;
 #include <sstream>
 
 AttitudeRK4::AttitudeRK4(const Vector<3>& omega_b_ini, const Quaternion& quaternion_i2b_ini, const Matrix<3, 3>& InertiaTensor_ini,
-                         const Vector<3>& torque_b_ini, const double prop_step_ini)
-    : SimulationObject("Attitude") {
-  omega_b_ = omega_b_ini;
+                         const Vector<3>& torque_b_ini, const double prop_step_ini, const std::string& sim_object_name)
+    : Attitude(sim_object_name) {
+  omega_b_rad_s_ = omega_b_ini;
   quaternion_i2b_ = quaternion_i2b_ini;
-  torque_b_ = torque_b_ini;
-  inertia_tensor_ = InertiaTensor_ini;
-  prop_step_ = prop_step_ini;
-  prop_time_ = 0;
-  inv_inertia_tensor_ = invert(inertia_tensor_);
-  h_rw_b_ = Vector<3>(0);  //どう取り扱うか要検討，Propagateで参照しているのも良くないかも
+  torque_b_Nm_ = torque_b_ini;
+  inertia_tensor_kgm2_ = InertiaTensor_ini;
+  prop_step_s_ = prop_step_ini;
+  prop_time_s_ = 0.0;
+  inv_inertia_tensor_ = invert(inertia_tensor_kgm2_);
+  h_rw_b_Nms_ = libra::Vector<3>(0);
   CalcAngMom();
-}
-
-AttitudeRK4::AttitudeRK4(const Vector<3>& omega_b_ini, const Quaternion& quaternion_i2b_ini, const Matrix<3, 3>& InertiaTensor_ini,
-                         const Vector<3>& torque_b_ini, const double prop_step_ini, string name)
-    : SimulationObject(name) {
-  omega_b_ = omega_b_ini;
-  quaternion_i2b_ = quaternion_i2b_ini;
-  torque_b_ = torque_b_ini;
-  inertia_tensor_ = InertiaTensor_ini;
-  prop_step_ = prop_step_ini;
-  prop_time_ = 0;
-  inv_inertia_tensor_ = invert(inertia_tensor_);
-  h_rw_b_ = Vector<3>(0);  //どう取り扱うか要検討，Propagateで参照しているのも良くないかも
-  CalcAngMom();
-  CalcSatRotationalKineticEnergy();
 }
 
 AttitudeRK4::~AttitudeRK4() {}
 
 void AttitudeRK4::SetParameters(const MCSimExecutor& mc_sim) {
-  GetInitParameterVec(mc_sim, "Debug", debug_vec_);
-  // cout << "Attitude.Debug = " << debug_vec_[0] << ", " << debug_vec_[1] << ",
-  // " << debug_vec_[2] << endl;
-  GetInitParameterVec(mc_sim, "Omega_b", omega_b_);
-  GetInitParameterQuaternion(mc_sim, "Q_i2b", quaternion_i2b_);
-  // cout << "Attitude.Omega_b = " << omega_b_[0] << ", " << omega_b_[1] << ", "
-  // << omega_b_[2] << endl;
-  prop_time_ = 0;
-  inv_inertia_tensor_ = invert(inertia_tensor_);
-  h_rw_b_ = Vector<3>(0);  //どう取り扱うか要検討，Propagateで参照しているのも良くないかも
+  Attitude::SetParameters(mc_sim);
+  GetInitParameterVec(mc_sim, "Omega_b", omega_b_rad_s_);
+
+  // ?
+  prop_time_s_ = 0.0;
+  inv_inertia_tensor_ = libra::invert(inertia_tensor_kgm2_);
+  h_rw_b_Nms_ = Vector<3>(0);  //どう取り扱うか要検討，Propagateで参照しているのも良くないかも
   CalcAngMom();
   CalcSatRotationalKineticEnergy();
 }
 
-void AttitudeRK4::CalcAngMom(void) {
-  h_sc_b_ = inertia_tensor_ * omega_b_;
-  h_total_b_ = h_rw_b_ + h_sc_b_;
-  Quaternion q_b2i = quaternion_i2b_.conjugate();
-  h_total_i_ = q_b2i.frame_conv(h_total_b_);
-  h_total_ = norm(h_total_i_);
-}
-
-void AttitudeRK4::CalcSatRotationalKineticEnergy(void) { k_sc_ = 0.5 * libra::inner_product(h_sc_b_, omega_b_); }
-
-void AttitudeRK4::Propagate(double endtime) {
-  if (!IsCalcEnabled) return;
-  while (endtime - prop_time_ - prop_step_ > 1.0e-6) {
-    RungeOneStep(prop_time_, prop_step_);
-    prop_time_ += prop_step_;
+void AttitudeRK4::Propagate(const double endtime_s) {
+  if (!is_calc_enabled_) return;
+  while (endtime_s - prop_time_s_ - prop_step_s_ > 1.0e-6) {
+    RungeOneStep(prop_time_s_, prop_step_s_);
+    prop_time_s_ += prop_step_s_;
   }
-  RungeOneStep(prop_time_, endtime - prop_time_);
-  prop_time_ = endtime;
+  RungeOneStep(prop_time_s_, endtime_s - prop_time_s_);
+  prop_time_s_ = endtime_s;
 
   CalcAngMom();
   CalcSatRotationalKineticEnergy();
@@ -109,8 +81,8 @@ Vector<7> AttitudeRK4::DynamicsKinematics(Vector<7> x, double t) {
   for (int i = 0; i < 3; i++) {
     omega_b[i] = x[i];
   }
-  h_total_b_ = (inertia_tensor_ * omega_b) + h_rw_b_;
-  Vector<3> rhs = inv_inertia_tensor_ * (torque_b_ - outer_product(omega_b, h_total_b_));
+  h_total_b_Nms_ = (inertia_tensor_kgm2_ * omega_b) + h_rw_b_Nms_;
+  Vector<3> rhs = inv_inertia_tensor_ * (torque_b_Nm_ - libra::outer_product(omega_b, h_total_b_Nms_));
 
   for (int i = 0; i < 3; ++i) {
     dxdt[i] = rhs[i];
@@ -133,7 +105,7 @@ Vector<7> AttitudeRK4::DynamicsKinematics(Vector<7> x, double t) {
 void AttitudeRK4::RungeOneStep(double t, double dt) {
   Vector<7> x;
   for (int i = 0; i < 3; i++) {
-    x[i] = omega_b_[i];
+    x[i] = omega_b_rad_s_[i];
   }
   for (int i = 0; i < 4; i++) {
     x[i + 3] = quaternion_i2b_[i];
@@ -156,48 +128,10 @@ void AttitudeRK4::RungeOneStep(double t, double dt) {
   Vector<7> next_x = x + (dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4);
 
   for (int i = 0; i < 3; i++) {
-    omega_b_[i] = next_x[i];
+    omega_b_rad_s_[i] = next_x[i];
   }
   for (int i = 0; i < 4; i++) {
     quaternion_i2b_[i] = next_x[i + 3];
   }
   quaternion_i2b_.normalize();
-}
-
-string AttitudeRK4::GetLogHeader() const {
-  string str_tmp = "";
-
-  str_tmp += WriteVector("omega_t", "b", "rad/s", 3);
-  str_tmp += WriteVector("q_t", "i2b", "-", 4);
-  str_tmp += WriteVector("torque_t", "b", "Nm", 3);
-  // str_tmp += WriteVector("h_total", "b", "Nms", 3);
-  // str_tmp += WriteVector("h_total", "i", "Nms", 3);
-  str_tmp += WriteScalar("h_total", "Nms");
-  str_tmp += WriteScalar("k_sc", "J");
-
-  return str_tmp;
-}
-
-string AttitudeRK4::GetLogValue() const {
-  string str_tmp = "";
-
-  str_tmp += WriteVector(omega_b_);
-  str_tmp += WriteQuaternion(quaternion_i2b_);
-  str_tmp += WriteVector(torque_b_);
-  // str_tmp += WriteVector(h_total_b_);
-  // str_tmp += WriteVector(h_total_i_);
-  str_tmp += WriteScalar(h_total_);
-  str_tmp += WriteScalar(k_sc_);
-
-  return str_tmp;
-}
-
-//デバッグ用
-void AttitudeRK4::PrintParams(void) {
-  cout << "Omega_b =(" << omega_b_[0] << "," << omega_b_[1] << "," << omega_b_[2] << ") rad/s \n";
-  cout << "Quaternion_i2b =(" << quaternion_i2b_[0] << "," << quaternion_i2b_[1] << "," << quaternion_i2b_[2] << "," << quaternion_i2b_[3] << ") \n";
-  cout << "Torque_b =(" << torque_b_[0] << "," << torque_b_[1] << "," << torque_b_[2] << ") Nm \n";
-  cout << "               (" << inertia_tensor_[0][0] << "," << inertia_tensor_[0][1] << "," << inertia_tensor_[0][2] << ")\n";
-  cout << "InertiaTensor =(" << inertia_tensor_[1][0] << "," << inertia_tensor_[1][1] << "," << inertia_tensor_[1][2] << ") kg m2\n";
-  cout << "               (" << inertia_tensor_[2][0] << "," << inertia_tensor_[2][1] << "," << inertia_tensor_[2][2] << ")\n";
 }

--- a/src/Dynamics/Attitude/AttitudeRK4.cpp
+++ b/src/Dynamics/Attitude/AttitudeRK4.cpp
@@ -18,7 +18,7 @@ AttitudeRK4::AttitudeRK4(const Vector<3>& omega_b_ini, const Quaternion& quatern
   prop_step_s_ = prop_step_ini;
   prop_time_s_ = 0.0;
   inv_inertia_tensor_ = invert(inertia_tensor_kgm2_);
-  h_rw_b_Nms_ = libra::Vector<3>(0);
+  h_rw_b_Nms_ = libra::Vector<3>(0.0);
   CalcAngMom();
 }
 
@@ -28,10 +28,10 @@ void AttitudeRK4::SetParameters(const MCSimExecutor& mc_sim) {
   Attitude::SetParameters(mc_sim);
   GetInitParameterVec(mc_sim, "Omega_b", omega_b_rad_s_);
 
-  // ?
+  // TODO この部分の必要性を考える
   prop_time_s_ = 0.0;
   inv_inertia_tensor_ = libra::invert(inertia_tensor_kgm2_);
-  h_rw_b_Nms_ = Vector<3>(0);  //どう取り扱うか要検討，Propagateで参照しているのも良くないかも
+  h_rw_b_Nms_ = Vector<3>(0.0);  //どう取り扱うか要検討，Propagateで参照しているのも良くないかも
   CalcAngMom();
   CalcSatRotationalKineticEnergy();
 }

--- a/src/Dynamics/Attitude/AttitudeRK4.h
+++ b/src/Dynamics/Attitude/AttitudeRK4.h
@@ -3,33 +3,28 @@
 
 #include "Attitude.h"
 
-class AttitudeRK4 : public Attitude, public SimulationObject {
+class AttitudeRK4 : public Attitude {
  public:
   AttitudeRK4(const Vector<3>& omega_b_ini, const Quaternion& quaternion_i2b_ini, const Matrix<3, 3>& InertiaTensor_ini,
-              const Vector<3>& torque_b_ini, const double prop_step_ini);
-
-  AttitudeRK4(const Vector<3>& omega_b_ini, const Quaternion& quaternion_i2b_ini, const Matrix<3, 3>& InertiaTensor_ini,
-              const Vector<3>& torque_b_ini, const double prop_step_ini, std::string name);
+              const Vector<3>& torque_b_ini, const double prop_step_ini, const std::string& sim_object_name = "Attitude");
   ~AttitudeRK4();
 
-  // MonteCalro
-  void SetParameters(const MCSimExecutor& mc_sim);
+  // Getter
+  inline double GetPropTime() const { return prop_time_s_; }
 
-  virtual void Propagate(double endtime);  // 姿勢・角速度のプロパゲーション
+  // Setter
+  inline void SetTime(double set) { prop_time_s_ = set; }
 
-  virtual std::string GetLogHeader() const;
-  virtual std::string GetLogValue() const;
-
-  //デバッグ出力
-  void PrintParams(void);
+  // Attitude
+  virtual void Propagate(const double endtime_s);
+  virtual void SetParameters(const MCSimExecutor& mc_sim);
 
  private:
-  Vector<3> debug_vec_;
+  double prop_time_s_;  // current time
 
   Matrix<4, 4> Omega4Kinematics(Vector<3> omega);
   Vector<7> DynamicsKinematics(Vector<7> x, double t);
   void RungeOneStep(double t, double dt);
-  void CalcAngMom(void);
-  void CalcSatRotationalKineticEnergy(void);  // 衛星の回転運動エネルギー計算関数
 };
+
 #endif  //__attitude_rk4_H__

--- a/src/Dynamics/Attitude/ControlledAttitude.cpp
+++ b/src/Dynamics/Attitude/ControlledAttitude.cpp
@@ -118,3 +118,19 @@ Matrix<3, 3> ControlledAttitude::CalcDCM(const Vector<3> main_direction, const V
   }
   return DCM_;
 }
+
+AttCtrlMode ConvertStringToCtrlMode(const std::string mode) {
+  if (mode == "INERTIAL_STABILIZE") {
+    return INERTIAL_STABILIZE;
+  } else if (mode == "SUN_POINTING") {
+    return SUN_POINTING;
+  } else if (mode == "EARTH_CENTER_POINTING") {
+    return EARTH_CENTER_POINTING;
+  } else if (mode == "VELOCITY_DIRECTION_POINTING") {
+    return VELOCITY_DIRECTION_POINTING;
+  } else if (mode == "ORBIT_NORMAL_POINTING") {
+    return ORBIT_NORMAL_POINTING;
+  } else {
+    return NO_CTRL;
+  }
+}

--- a/src/Dynamics/Attitude/ControlledAttitude.cpp
+++ b/src/Dynamics/Attitude/ControlledAttitude.cpp
@@ -9,15 +9,17 @@ using namespace std;
 
 #define THRESHOLD_CA cos(30.0 / 180.0 * libra::pi)  // fix me
 
-ControlledAttitude::ControlledAttitude(const AttCtrlMode main_mode, const AttCtrlMode sub_mode, const Quaternion quaternion_i2t,
+ControlledAttitude::ControlledAttitude(const AttCtrlMode main_mode, const AttCtrlMode sub_mode, const Quaternion quaternion_i2b,
                                        const Vector<3> pointing_t_b, const Vector<3> pointing_sub_t_b,
-                                       const LocalCelestialInformation* local_celes_info, const Orbit* orbit)
-    : local_celes_info_(local_celes_info), orbit_(orbit) {
-  main_mode_ = main_mode;
-  sub_mode_ = sub_mode;
-  quaternion_i2t_ = quaternion_i2t;
-  pointing_t_b_ = pointing_t_b;
-  pointing_sub_t_b_ = pointing_sub_t_b;
+                                       const LocalCelestialInformation* local_celes_info, const Orbit* orbit, const std::string& sim_object_name)
+    : Attitude(sim_object_name),
+      main_mode_(main_mode),
+      sub_mode_(sub_mode),
+      pointing_t_b_(pointing_t_b),
+      pointing_sub_t_b_(pointing_sub_t_b),
+      local_celes_info_(local_celes_info),
+      orbit_(orbit) {
+  quaternion_i2b_ = quaternion_i2b;
   Initialize();
 }
 
@@ -25,19 +27,16 @@ ControlledAttitude::~ControlledAttitude() {}
 
 // Main function
 void ControlledAttitude::Initialize(void) {
-  quaternion_i2b_ = Quaternion(0, 0, 0, 1);
-
-  if (main_mode_ >= NO_CTRL) IsCalcEnabled = false;
-  if (sub_mode_ >= NO_CTRL) IsCalcEnabled = false;
+  if (main_mode_ >= NO_CTRL) is_calc_enabled_ = false;
+  if (sub_mode_ >= NO_CTRL) is_calc_enabled_ = false;
   if (main_mode_ == INERTIAL_STABILIZE) {
-    quaternion_i2b_ = quaternion_i2t_;
-    quaternion_i2b_.normalize();
+    //
   } else  // Pointing control
   {
     // sub mode check
     if (main_mode_ == sub_mode_) {
       cout << "sub mode should not equal to main mode. \n";
-      IsCalcEnabled = false;
+      is_calc_enabled_ = false;
       return;
     }
     // pointing direction check
@@ -46,22 +45,22 @@ void ControlledAttitude::Initialize(void) {
     double tmp = inner_product(pointing_t_b_, pointing_sub_t_b_);
     tmp = std::abs(tmp);
     if (tmp > THRESHOLD_CA) {
-      cout << "sub target direction should separate from the main target "
-              "direction. \n";
-      IsCalcEnabled = false;
+      cout << "sub target direction should separate from the main target direction. \n";
+      is_calc_enabled_ = false;
       return;
     }
   }
   return;
 }
-void ControlledAttitude::Propagate(double endtime) {
-  UNUSED(endtime);
 
+void ControlledAttitude::Propagate(const double endtime_s) {
+  UNUSED(endtime_s);
+  
   Vector<3> main_direction_i, sub_direction_i;
-  if (!IsCalcEnabled) return;
+  if (!is_calc_enabled_) return;
 
   if (main_mode_ == INERTIAL_STABILIZE) {
-    quaternion_i2b_ = quaternion_i2t_;
+    // quaternion_i2b_ = quaternion_i2t_;
     return;
   }
 
@@ -99,6 +98,7 @@ void ControlledAttitude::PointingCtrl(const Vector<3> main_direction_i, const Ve
   // Convert to Quaternion
   quaternion_i2b_ = Quaternion::fromDCM(DCM_i2b);
 }
+
 Matrix<3, 3> ControlledAttitude::CalcDCM(const Vector<3> main_direction, const Vector<3> sub_direction) {
   // Calc basis vectors
   Vector<3> ex, ey, ez;
@@ -117,22 +117,4 @@ Matrix<3, 3> ControlledAttitude::CalcDCM(const Vector<3> main_direction, const V
     DCM_[i][2] = ez[i];
   }
   return DCM_;
-}
-
-string ControlledAttitude::GetLogHeader() const {
-  string str_tmp = "";
-
-  str_tmp += WriteVector("omega_t", "b", "rad/s", 3);
-  str_tmp += WriteVector("q_t", "i2b", "-", 4);
-
-  return str_tmp;
-}
-
-string ControlledAttitude::GetLogValue() const {
-  string str_tmp = "";
-
-  str_tmp += WriteVector(omega_b_);
-  str_tmp += WriteQuaternion(quaternion_i2b_);
-
-  return str_tmp;
 }

--- a/src/Dynamics/Attitude/ControlledAttitude.h
+++ b/src/Dynamics/Attitude/ControlledAttitude.h
@@ -29,7 +29,7 @@ class ControlledAttitude : public Attitude {
   // Setter
   inline void SetMainMode(const AttCtrlMode main_mode) { main_mode_ = main_mode; }
   inline void SetSubMode(const AttCtrlMode sub_mode) { sub_mode_ = sub_mode; }
-  inline void SetQuaternionI2T(const Quaternion quaternion_i2t) { quaternion_i2t_ = quaternion_i2t; }
+  inline void SetQuaternionI2T(const Quaternion quaternion_i2t) { quaternion_i2b_ = quaternion_i2t; }
   inline void SetPointingTb(Vector<3> pointing_t_b) { pointing_t_b_ = pointing_t_b; }
   inline void SetPointingSubTb(Vector<3> pointing_sub_t_b) { pointing_sub_t_b_ = pointing_sub_t_b; }
 
@@ -39,7 +39,6 @@ class ControlledAttitude : public Attitude {
  private:
   AttCtrlMode main_mode_;
   AttCtrlMode sub_mode_;               // for control around pointing direction
-  libra::Quaternion quaternion_i2t_;   // ECI->Target
   libra::Vector<3> pointing_t_b_;      // Pointing target on body frame
   libra::Vector<3> pointing_sub_t_b_;  // Pointing sub target on body frame
 

--- a/src/Dynamics/Attitude/ControlledAttitude.h
+++ b/src/Dynamics/Attitude/ControlledAttitude.h
@@ -8,24 +8,45 @@
 #include "../Orbit/Orbit.h"
 #include "Attitude.h"
 
+enum AttCtrlMode {
+  INERTIAL_STABILIZE,
+  SUN_POINTING,
+  EARTH_CENTER_POINTING,
+  VELOCITY_DIRECTION_POINTING,
+  ORBIT_NORMAL_POINTING,
+  NO_CTRL,
+};
+
 class ControlledAttitude : public Attitude {
  public:
-  ControlledAttitude(const AttCtrlMode main_mode, const AttCtrlMode sub_mode, const Quaternion quaternion_i2t, const Vector<3> pointing_t_b,
-                     const Vector<3> pointing_sub_t_b, const LocalCelestialInformation* local_celes_info, const Orbit* orbit);
+  ControlledAttitude(const AttCtrlMode main_mode, const AttCtrlMode sub_mode, const Quaternion quaternion_i2b, const Vector<3> pointing_t_b,
+                     const Vector<3> pointing_sub_t_b, const LocalCelestialInformation* local_celes_info, const Orbit* orbit,
+                     const std::string& sim_object_name = "Attitude");
   ~ControlledAttitude();
-  // Main functions
-  void Initialize(void);
-  virtual void Propagate(double endtime);
 
-  // Override ILoggable
-  virtual std::string GetLogHeader() const;
-  virtual std::string GetLogValue() const;
+  // Setter
+  inline void SetMainMode(const AttCtrlMode main_mode) { main_mode_ = main_mode; }
+  inline void SetSubMode(const AttCtrlMode sub_mode) { sub_mode_ = sub_mode; }
+  inline void SetQuaternionI2T(const Quaternion quaternion_i2t) { quaternion_i2t_ = quaternion_i2t; }
+  inline void SetPointingTb(Vector<3> pointing_t_b) { pointing_t_b_ = pointing_t_b; }
+  inline void SetPointingSubTb(Vector<3> pointing_sub_t_b) { pointing_sub_t_b_ = pointing_sub_t_b; }
+
+  // Attitude
+  virtual void Propagate(const double endtime_s);
 
  private:
+  AttCtrlMode main_mode_;
+  AttCtrlMode sub_mode_;               // for control around pointing direction
+  libra::Quaternion quaternion_i2t_;   // ECI->Target
+  libra::Vector<3> pointing_t_b_;      // Pointing target on body frame
+  libra::Vector<3> pointing_sub_t_b_;  // Pointing sub target on body frame
+
   // Inputs
   const LocalCelestialInformation* local_celes_info_;
   const Orbit* orbit_;
+
   // Local functions
+  void Initialize(void);
   Vector<3> CalcTargetDirection(AttCtrlMode mode);
   void PointingCtrl(const Vector<3> main_direction_i, const Vector<3> sub_direction_i);
   Matrix<3, 3> CalcDCM(const Vector<3> main_direction, const Vector<3> sub_direction);

--- a/src/Dynamics/Attitude/ControlledAttitude.h
+++ b/src/Dynamics/Attitude/ControlledAttitude.h
@@ -17,6 +17,8 @@ enum AttCtrlMode {
   NO_CTRL,
 };
 
+AttCtrlMode ConvertStringToCtrlMode(const std::string mode);
+
 class ControlledAttitude : public Attitude {
  public:
   ControlledAttitude(const AttCtrlMode main_mode, const AttCtrlMode sub_mode, const Quaternion quaternion_i2b, const Vector<3> pointing_t_b,

--- a/src/Dynamics/Attitude/InitAttitude.cpp
+++ b/src/Dynamics/Attitude/InitAttitude.cpp
@@ -9,9 +9,9 @@ Attitude* InitAttitude(std::string file_name, const Orbit* orbit, const LocalCel
   std::string mc_name = section_ + std::to_string(sat_id);  // "Attitude" + to_string(id);
   Attitude* attitude;
 
-  int propagate_mode = ini_file.ReadInt(section_, "propagate_mode");
+  const std::string propagate_mode = ini_file.ReadString(section_, "propagate_mode");
 
-  if (propagate_mode == 0) {
+  if (propagate_mode == "RK4") {
     // RK4 propagator
     Vector<3> omega_b;
     ini_file.ReadVector(section_, "Omega_b", omega_b);
@@ -21,12 +21,15 @@ Attitude* InitAttitude(std::string file_name, const Orbit* orbit, const LocalCel
     ini_file.ReadVector(section_, "Torque_b", torque_b);
 
     attitude = new AttitudeRK4(omega_b, quaternion_i2b, inertia_tensor, torque_b, step_sec, mc_name);
-  } else if (propagate_mode == 1) {
+  } else if (propagate_mode == "CONTROLLED") {
     // Controlled attitude
     IniAccess ini_file_ca(file_name);
     const char* section_ca_ = "ControlledAttitude";
-    AttCtrlMode main_mode = static_cast<AttCtrlMode>(ini_file_ca.ReadInt(section_ca_, "main_mode"));
-    AttCtrlMode sub_mode = static_cast<AttCtrlMode>(ini_file_ca.ReadInt(section_ca_, "sub_mode"));
+    const std::string main_mode_in = ini_file.ReadString(section_ca_, "main_mode");
+    const std::string sub_mode_in = ini_file.ReadString(section_ca_, "sub_mode");
+
+    AttCtrlMode main_mode = ConvertStringToCtrlMode(main_mode_in);
+    AttCtrlMode sub_mode = ConvertStringToCtrlMode(sub_mode_in);
     Quaternion quaternion_i2b;
     ini_file_ca.ReadQuaternion(section_, "Quaternion_i2b", quaternion_i2b);
     Vector<3> pointing_t_b, pointing_sub_t_b;

--- a/src/Dynamics/Attitude/InitAttitude.cpp
+++ b/src/Dynamics/Attitude/InitAttitude.cpp
@@ -6,6 +6,7 @@ Attitude* InitAttitude(std::string file_name, const Orbit* orbit, const LocalCel
                        const Matrix<3, 3> inertia_tensor, const int sat_id) {
   IniAccess ini_file(file_name);
   const char* section_ = "ATTITUDE";
+  std::string mc_name = section_ + std::to_string(sat_id);  // "Attitude" + to_string(id);
   Attitude* attitude;
 
   int propagate_mode = ini_file.ReadInt(section_, "propagate_mode");
@@ -19,8 +20,7 @@ Attitude* InitAttitude(std::string file_name, const Orbit* orbit, const LocalCel
     Vector<3> torque_b;
     ini_file.ReadVector(section_, "Torque_b", torque_b);
 
-    std::string name = section_ + std::to_string(sat_id);  // "Attitude" + to_string(id);
-    attitude = new AttitudeRK4(omega_b, quaternion_i2b, inertia_tensor, torque_b, step_sec, name);
+    attitude = new AttitudeRK4(omega_b, quaternion_i2b, inertia_tensor, torque_b, step_sec, mc_name);
   } else if (propagate_mode == 1) {
     // Controlled attitude
     IniAccess ini_file_ca(file_name);
@@ -28,11 +28,11 @@ Attitude* InitAttitude(std::string file_name, const Orbit* orbit, const LocalCel
     AttCtrlMode main_mode = static_cast<AttCtrlMode>(ini_file_ca.ReadInt(section_ca_, "main_mode"));
     AttCtrlMode sub_mode = static_cast<AttCtrlMode>(ini_file_ca.ReadInt(section_ca_, "sub_mode"));
     Quaternion quaternion_i2b;
-    ini_file_ca.ReadQuaternion(section_, "quaternion_i2b", quaternion_i2b);
+    ini_file_ca.ReadQuaternion(section_, "Quaternion_i2b", quaternion_i2b);
     Vector<3> pointing_t_b, pointing_sub_t_b;
     ini_file_ca.ReadVector(section_ca_, "pointing_t_b", pointing_t_b);
     ini_file_ca.ReadVector(section_ca_, "pointing_sub_t_b", pointing_sub_t_b);
-    attitude = new ControlledAttitude(main_mode, sub_mode, quaternion_i2b, pointing_t_b, pointing_sub_t_b, celes_info, orbit);
+    attitude = new ControlledAttitude(main_mode, sub_mode, quaternion_i2b, pointing_t_b, pointing_sub_t_b, celes_info, orbit, mc_name);
   } else {
     std::cerr << "ERROR: attitude propagation mode: " << propagate_mode << " is not defined!" << std::endl;
   }

--- a/src/Dynamics/Attitude/InitAttitude.cpp
+++ b/src/Dynamics/Attitude/InitAttitude.cpp
@@ -27,12 +27,12 @@ Attitude* InitAttitude(std::string file_name, const Orbit* orbit, const LocalCel
     const char* section_ca_ = "ControlledAttitude";
     AttCtrlMode main_mode = static_cast<AttCtrlMode>(ini_file_ca.ReadInt(section_ca_, "main_mode"));
     AttCtrlMode sub_mode = static_cast<AttCtrlMode>(ini_file_ca.ReadInt(section_ca_, "sub_mode"));
-    Quaternion quaternion_i2t;
-    ini_file_ca.ReadQuaternion(section_ca_, "quaternion_i2t", quaternion_i2t);
+    Quaternion quaternion_i2b;
+    ini_file_ca.ReadQuaternion(section_, "quaternion_i2b", quaternion_i2b);
     Vector<3> pointing_t_b, pointing_sub_t_b;
     ini_file_ca.ReadVector(section_ca_, "pointing_t_b", pointing_t_b);
     ini_file_ca.ReadVector(section_ca_, "pointing_sub_t_b", pointing_sub_t_b);
-    attitude = new ControlledAttitude(main_mode, sub_mode, quaternion_i2t, pointing_t_b, pointing_sub_t_b, celes_info, orbit);
+    attitude = new ControlledAttitude(main_mode, sub_mode, quaternion_i2b, pointing_t_b, pointing_sub_t_b, celes_info, orbit);
   } else {
     std::cerr << "ERROR: attitude propagation mode: " << propagate_mode << " is not defined!" << std::endl;
   }

--- a/src/Dynamics/CMakeLists.txt
+++ b/src/Dynamics/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(${PROJECT_NAME} STATIC
   Thermal/InitNode.cpp
   Thermal/InitTemperature.cpp
 
+  Attitude/Attitude.cpp
   Attitude/AttitudeRK4.cpp
   Attitude/ControlledAttitude.cpp
   Attitude/InitAttitude.cpp


### PR DESCRIPTION
## Overview
Refactor Attitude Dynamics

## Issue
- #58 

## Details
Attitude dynamics classes were refactored as follows
- Refactor the relationships b/w the base Attitude class and the derived classes.
- Attitude mode can be set by string instead of numbers in the ini file.
- Initial quaternion of `ControlledAttitude` mode is changeable by Monte Carlo Simulation.

##  Validation results
The log output of attitude is not changed by this modification.  

## Scope of influence
Users need to change the ini file to suit the string initialize setting.

## Supplement
NA

## Note
NA