### PR TITLE
Fix unknown pragma warnings

### DIFF
--- a/src/Library/igrf/igrf.cpp
+++ b/src/Library/igrf/igrf.cpp
@@ -53,8 +53,10 @@ using namespace std;
 
 double testglobal[3];
 
+#ifdef WIN32
 #pragma warning(disable : 4996)  // fopenなど回避
 #pragma warning(disable : 4305)  // double->float回避
+#endif
 
 /*--------------------*/
 /*   Basic Routines   */

--- a/src/Library/sgp4/sgp4ext.cpp
+++ b/src/Library/sgp4/sgp4ext.cpp
@@ -23,7 +23,9 @@
  *                           original baseline
  *       ---------------------------------------------------------------- */
 
+#ifdef WIN32
 #pragma warning(disable : 4996)
+#endif
 
 #include "sgp4ext.h"
 

--- a/src/Library/sgp4/sgp4io.cpp
+++ b/src/Library/sgp4/sgp4io.cpp
@@ -29,7 +29,9 @@
 #include "sgp4ext.h"   // for several misc routines
 #include "sgp4unit.h"  // for sgp4init and getgravconst
 
+#ifdef WIN32
 #pragma warning(disable : 4996)  // fopenエラー回避
+#endif
 
 #define pi 3.14159265358979323846
 

--- a/src/Library/sgp4/sgp4unit.cpp
+++ b/src/Library/sgp4/sgp4unit.cpp
@@ -30,7 +30,9 @@
  *                           original baseline
  *       ---------------------------------------------------------------- */
 
+#ifdef WIN32
 #pragma warning(disable : 4996)  // fopenエラー回避
+#endif
 
 #include "sgp4unit.h"
 


### PR DESCRIPTION
## Overview
Fix unknown pragma warnings

## Issue
- #87 

## Details
To fix the unknown pragma warnings in g++, the `pragma warning` setting is modified to activated only for WIN32 environment.

##  Validation results
NA

## Scope of influence
No effect

## Supplement
NA

## Note
NA