### PR TITLE
Add GetI2cAddress function

### DIFF
--- a/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
+++ b/src/Component/Abstract/ObcI2cTargetCommunicationBase.h
@@ -21,6 +21,7 @@ class ObcI2cTargetCommunicationBase {
   int SendTelemetry(const unsigned char len);
   int GetStoredFrameCounter();
   int StoreTelemetry(const unsigned int stored_frame_num, const unsigned char tlm_size);
+  unsigned char GetI2cAddress() const { return i2c_address_; }
 
  private:
   unsigned int sils_port_id_;


### PR DESCRIPTION
## Overview
Add GetI2cAddress function

## Issue
NA

## Details
Add GetI2cAddress function to ObcI2cTargetCommunicationBase Class. Each component that inherits the class will have access to the i2c address.

##  Validation results
NA

## Scope of influence
eg. Additional function is available.

## Supplement
NA

## Note
NA