### PR TITLE
Fix NRLMSISE-00 CMake to use git

### DIFF
--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -7,24 +7,23 @@ include(FetchContent)
 
 set(NRLMSISE_INSTALL_DIR ${EXT_LIB_DIR}/nrlmsise00)
 
-set(NRLMSISE_URL_BASE https://ccmc.gsfc.nasa.gov/pub/modelweb/atmospheric/msis/nrlmsise00/nrlmsis00_c_version)
 set(NRLMSISE_TABLE_URL_BASE ftp://ftp.agi.com/pub/DynamicEarthData)
 set(NRLMSISE_TABLE_FILE SpaceWeather-v1.2.txt)
 
 set(NRLMSISE_TMP_DIR ${NRLMSISE_INSTALL_DIR}/tmp)
 
 # download files
-function(download_file base_url file sha256)
-  message("downloading ${file}")
-  FetchContent_Declare(
-    ${file}
-    SOURCE_DIR ${NRLMSISE_TMP_DIR}
-    URL ${base_url}/${file}
-    URL_HASH SHA256=${sha256}
-    DOWNLOAD_NO_EXTRACT true
-  )
-  FetchContent_MakeAvailable(${file})
-endfunction()
+# download source files
+FetchContent_Declare(
+  nrlmsise
+  GIT_REPOSITORY git://git.linta.de/~brodo/nrlmsise-00.git
+  GIT_TAG bc9a2feba4344e74201281e563332688a4d09cc3
+  SOURCE_DIR ${NRLMSISE_TMP_DIR}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+)
+FetchContent_MakeAvailable(nrlmsise)
+
 function(download_file_without_validate base_url file)
   message("downloading ${file}")
   FetchContent_Declare(
@@ -35,17 +34,8 @@ function(download_file_without_validate base_url file)
   )
   FetchContent_MakeAvailable(${file})
 endfunction()
-
-## download source files
-download_file(${NRLMSISE_URL_BASE} makefile "6c58c08dc6f83b11407750733a08b45e6a63d39b6d24ea3127e4cec7d6807d34")
-download_file(${NRLMSISE_URL_BASE} nrlmsise-00.c "a20d6523420188241963f095ad0b65df44ac0a6fa6db52d2e1df823c366f0285")
-download_file(${NRLMSISE_URL_BASE} nrlmsise-00.h "d5b45be690bbc6cf394f69b18c0e641a1769da0a87015704fdabf0e7560794aa")
-download_file(${NRLMSISE_URL_BASE} nrlmsise-00_data.c "d0b3022f3c3e7ffdf703cc0e0d02339dfee01c0bf1520b29c68d5f4afd8784d5")
-download_file(${NRLMSISE_URL_BASE} nrlmsise-00_test.c "5a95faa996dc265ab85a0f6db641628abe84c9aef504638b4aa465ed76c89113")
-
 ## download table
 download_file_without_validate(${NRLMSISE_TABLE_URL_BASE} ${NRLMSISE_TABLE_FILE})
-
 
 # build
 if(WIN32)


### PR DESCRIPTION
## Overview
Write briefly.

## Issue
NA

## Details
Because NASA newly released [NRLMSISE v2.0](https://ccmc.gsfc.nasa.gov/models/NRLMSIS~v2.0) at the beginning of this May, currently we cannot access the old URL to download the source codes of NRLMSISE-00.  
We need to fix the CMake file to use the [original git repository](https://git.linta.de/?p=~brodo/nrlmsise-00.git;a=summary).  

At this moment, I just changed the download method of the source files, but we need to consider the following things.
- Use `git submodule`?
- Use the new NRLMSISE v2.0?

##  Validation results
I confirmed that I can successfully download the files and make the lib file with VS2022

## Scope of influence
Users who need the ExtLib setup, they cannot do that without this modification.

## Supplement
NA

## Note
NA