### PR TITLE
Skip time only when step time exceeds countinuously for over a second

### DIFF
--- a/src/Environment/Global/SimTime.cpp
+++ b/src/Environment/Global/SimTime.cpp
@@ -84,17 +84,16 @@ void SimTime::UpdateTime(void) {
     int toWaitTime =
         (int)(elapsed_time_sec_ * 1000 - chrono::duration_cast<chrono::milliseconds>(clk.now() - clock_start_time_millisec_).count() * sim_speed_);
     if (toWaitTime <= 0) {
-      // PCの処理速度が足りていない場合、この分岐に入る
+      // When the execution time is larger than specified step_sec
 
       int exceeded_duration_ms = chrono::duration_cast<chrono::milliseconds>(clk.now() - clock_last_time_completed_step_in_time_).count();
       if (exceeded_duration_ms > time_exceeds_continuously_limit_sec_ * 1000) {
-        // Actual step_sec is larger than specified for long time
+        // Skip time and warn only when execition time exceeds continuously for long time
           
-        cout << "Error: the specified step_sec is too small for this "
-                "computer.\r\n";
+        cout << "Error: the specified step_sec is too small for this computer.\r\n";
 
-        // カウントアップしてきた経過時刻を強制的に実際の経過時刻に合わせる
-        // 意図としては、ブレークポイントからの復帰後に一瞬でリアルタイムに追いつかせるため
+        // Forcibly set elapsed_tim_sec_ as actual elapced time 
+        // Reason: to catch up with real time when resume from a breakpoint
         elapsed_time_sec_ = (chrono::duration_cast<chrono::duration<double, ratio<1, 1>>>(clk.now() - clock_start_time_millisec_).count() * sim_speed_);
 
         clock_last_time_completed_step_in_time_ = clk.now();

--- a/src/Environment/Global/SimTime.cpp
+++ b/src/Environment/Global/SimTime.cpp
@@ -29,6 +29,7 @@ SimTime::SimTime(const double end_sec, const double step_sec, const double attit
   compo_propagate_frequency_ = int(1.0 / compo_update_interval_sec_);
   sim_speed_ = sim_speed;
   disp_period_ = (1.0 * end_sec / step_sec / 100);  // 1%毎に更新
+  time_exceeds_continuously_limit_sec_ = 1.0;
 
   //  sscanf_s(start_ymdhms, "%d/%d/%d %d:%d:%lf", &start_year_, &start_mon_,
   //  &start_day_, &start_hr_, &start_min_, &start_sec_);
@@ -84,13 +85,23 @@ void SimTime::UpdateTime(void) {
         (int)(elapsed_time_sec_ * 1000 - chrono::duration_cast<chrono::milliseconds>(clk.now() - clock_start_time_millisec_).count() * sim_speed_);
     if (toWaitTime <= 0) {
       // PCの処理速度が足りていない場合、この分岐に入る
-      cout << "Error: the specified step_sec is too small for this "
-              "computer.\r\n";
 
-      // カウントアップしてきた経過時刻を強制的に実際の経過時刻に合わせる
-      // 意図としては、ブレークポイントからの復帰後に一瞬でリアルタイムに追いつかせるため
-      elapsed_time_sec_ = (chrono::duration_cast<chrono::duration<double, ratio<1, 1>>>(clk.now() - clock_start_time_millisec_).count() * sim_speed_);
+      int exceeded_duration_ms = chrono::duration_cast<chrono::milliseconds>(clk.now() - clock_last_time_completed_step_in_time_).count();
+      if (exceeded_duration_ms > time_exceeds_continuously_limit_sec_ * 1000) {
+        // Actual step_sec is larger than specified for long time
+          
+        cout << "Error: the specified step_sec is too small for this "
+                "computer.\r\n";
+
+        // カウントアップしてきた経過時刻を強制的に実際の経過時刻に合わせる
+        // 意図としては、ブレークポイントからの復帰後に一瞬でリアルタイムに追いつかせるため
+        elapsed_time_sec_ = (chrono::duration_cast<chrono::duration<double, ratio<1, 1>>>(clk.now() - clock_start_time_millisec_).count() * sim_speed_);
+
+        clock_last_time_completed_step_in_time_ = clk.now();
+      }
     } else {
+      clock_last_time_completed_step_in_time_ = clk.now();
+
 #ifdef WIN32
       Sleep(toWaitTime);
 #else

--- a/src/Environment/Global/SimTime.cpp
+++ b/src/Environment/Global/SimTime.cpp
@@ -86,7 +86,7 @@ void SimTime::UpdateTime(void) {
     if (toWaitTime <= 0) {
       // When the execution time is larger than specified step_sec
 
-      int exceeded_duration_ms = chrono::duration_cast<chrono::milliseconds>(clk.now() - clock_last_time_completed_step_in_time_).count();
+      int exceeded_duration_ms = (int)chrono::duration_cast<chrono::milliseconds>(clk.now() - clock_last_time_completed_step_in_time_).count();
       if (exceeded_duration_ms > time_exceeds_continuously_limit_sec_ * 1000) {
         // Skip time and warn only when execition time exceeds continuously for long time
           

--- a/src/Environment/Global/SimTime.h
+++ b/src/Environment/Global/SimTime.h
@@ -102,6 +102,7 @@ class SimTime : public ILoggable {
   std::chrono::system_clock::time_point clock_start_time_millisec_;
   // chrono::system_clock::time_point clock_elapsed_time_millisec_;
   // //実時間でのシミュレーション実行時間
+  std::chrono::system_clock::time_point clock_last_time_completed_step_in_time_;
 
   //固定値
   double end_sec_;   // Time from start of simulation to end
@@ -125,6 +126,9 @@ class SimTime : public ILoggable {
   double start_sec_;
   double sim_speed_;  // The speed of the simulation relative to real time (if
                       // negative, real time is not taken into account)
+  double time_exceeds_continuously_limit_sec_; // Maximum duration to allow
+                                               // actual step_sec to be larger
+                                               // than specified continuously
 
   void InitializeState();
   void AssertTimeStepParams();

--- a/src/Environment/Global/SimTime.h
+++ b/src/Environment/Global/SimTime.h
@@ -126,9 +126,7 @@ class SimTime : public ILoggable {
   double start_sec_;
   double sim_speed_;  // The speed of the simulation relative to real time (if
                       // negative, real time is not taken into account)
-  double time_exceeds_continuously_limit_sec_; // Maximum duration to allow
-                                               // actual step_sec to be larger
-                                               // than specified continuously
+  double time_exceeds_continuously_limit_sec_; // Maximum duration to allow actual step_sec to be larger than specified continuously
 
   void InitializeState();
   void AssertTimeStepParams();


### PR DESCRIPTION

## Overview
Change to skip time only when time exceeds countinuously for over a second.

## Issue
- #127 

## Details
今まではあるステップの実行時間が期待される時間を超えていた場合に、処理が追い付いていないと判断し時間をスキップしていた。実際には実行時間が長いステップと短いステップが混在しているため、平均的には処理が時間内に終わっているといえる場合が多い。
そのため時間超過を１秒以内に相殺できている場合には、時間をスキップせず警告メッセージも出さないようにした。

##  Validation results
s2e-core内のSampleを用いて確認した。
- シミュレーションの実行結果に影響しないことを確認した。
- 時間超過を相殺できる範囲のsim_speed（<50）では警告および時間スキップが行われないことを確認した。
- sim_speedが早すぎ（>100）て本当に処理が追い付いていない場合には、以前と同様（ただし１秒毎）に警告＋時間スキップが行われることを確認した。

## Scope of influence
C2Aと組み合わせる場合にのみ影響がある。S2Eの内部時間が必ずC2Aの内部時間と一致するようになる。

## Supplement
NA

## Note
時間超過の相殺期間を１秒としたことについては特別な理由はない。
そもそも時間スキップが必要かについては要検討。
