### PR TITLE
Add 64bit build option for linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,13 +142,13 @@ jobs:
           path: ExtLibraries
 
       - name: build extlib
-        #if: steps.cache-extlib.outputs.cache-hit != 'true'
+        if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./ExtLibraries
         run: |
           cmake . -DEXT_LIB_DIR="$(pwd)" -D${{ matrix.build_option }}
           cmake --build .
       - name: install extlib
-        #if: steps.cache-extlib.outputs.cache-hit != 'true'
+        if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./ExtLibraries
         run: |
           cmake --install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,13 +142,13 @@ jobs:
           path: ExtLibraries
 
       - name: build extlib
-        if: steps.cache-extlib.outputs.cache-hit != 'true'
+        #if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./ExtLibraries
         run: |
           cmake . -DEXT_LIB_DIR="$(pwd)" -D${{ matrix.build_option }}
           cmake --build .
       - name: install extlib
-        if: steps.cache-extlib.outputs.cache-hit != 'true'
+        #if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./ExtLibraries
         run: |
           cmake --install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
         id: cache-extlib
         uses: actions/cache@v3
         with:
-          key: extlib-${{ runner.os }}-${{ hashFiles('./ExtLibraries/**') }}-${{ matrix.build_option }}
+          key: extlib-${{ runner.os }}-${{ hashFiles('./ExtLibraries/**') }}-${{ matrix.build_bit }}
           path: ExtLibraries
 
       - name: build extlib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ['gcc-11 g++-11', 'clang clang++']
+        build_option: ['BUILD_64BIT=OFF', 'BUILD_64BIT=ON']
 
     steps:
       - uses: actions/checkout@v3
@@ -144,7 +145,7 @@ jobs:
         if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./ExtLibraries
         run: |
-          cmake . -DEXT_LIB_DIR="$(pwd)"
+          cmake . -DEXT_LIB_DIR="$(pwd)" -D${{ matrix.build_option }}
           cmake --build .
       - name: install extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'
@@ -156,12 +157,15 @@ jobs:
         run: |
           ls cspice
           ls cspice/cspice_unix
+          ls cspice/cspice_unix_64bit
           ls cspice/include
           ls cspice/generic_kernels
           ls nrlmsise00
           ls nrlmsise00/table
           ls nrlmsise00/lib
           ls nrlmsise00/lib/libnrlmsise00.a
+          ls nrlmsise00/lib_64bit
+          ls nrlmsise00/lib_64bit/libnrlmsise00.a
           ls nrlmsise00/src
 
       - name: build
@@ -169,5 +173,5 @@ jobs:
           CC:  ${{ steps.compiler.outputs.CC  }}
           CXX: ${{ steps.compiler.outputs.CXX }}
         run: |
-          cmake . -DEXT_LIB_DIR=./ExtLibraries
+          cmake . -DEXT_LIB_DIR=./ExtLibraries -D${{ matrix.build_option }}
           cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ['gcc-11 g++-11', 'clang clang++']
-        build_option: ['BUILD_64BIT=OFF', 'BUILD_64BIT=ON']
+        build_bit: ['BUILD_64BIT=OFF', 'BUILD_64BIT=ON']
 
     steps:
       - uses: actions/checkout@v3
@@ -145,7 +145,7 @@ jobs:
         if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./ExtLibraries
         run: |
-          cmake . -DEXT_LIB_DIR="$(pwd)" -D${{ matrix.build_option }}
+          cmake . -DEXT_LIB_DIR="$(pwd)" -D${{ matrix.build_bit }}
           cmake --build .
       - name: install extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'
@@ -170,5 +170,5 @@ jobs:
           CC:  ${{ steps.compiler.outputs.CC  }}
           CXX: ${{ steps.compiler.outputs.CXX }}
         run: |
-          cmake . -DEXT_LIB_DIR=./ExtLibraries -D${{ matrix.build_option }}
+          cmake . -DEXT_LIB_DIR=./ExtLibraries -D${{ matrix.build_bit }}
           cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,15 +157,12 @@ jobs:
         run: |
           ls cspice
           ls cspice/cspice_unix
-          ls cspice/cspice_unix_64bit
           ls cspice/include
           ls cspice/generic_kernels
           ls nrlmsise00
           ls nrlmsise00/table
           ls nrlmsise00/lib
           ls nrlmsise00/lib/libnrlmsise00.a
-          ls nrlmsise00/lib_64bit
-          ls nrlmsise00/lib_64bit/libnrlmsise00.a
           ls nrlmsise00/src
 
       - name: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ elseif(UNIX)
   if(BUILD_64BIT)
     find_library(CSPICE_LIB
       NAMES cspice.a csupport.a
-      PATHS ${CSPICE_DIR}/cspice_unix_64bit/lib)
+      PATHS ${CSPICE_DIR}/cspice_unix64/lib)
   else()
     find_library(CSPICE_LIB
       NAMES cspice.a csupport.a
@@ -133,7 +133,7 @@ elseif(UNIX)
   if(BUILD_64BIT)
     find_library(NRLMSISE00_LIB
       NAMES libnrlmsise00.a
-      PATHS ${NRLMSISE00_DIR}/lib_64bit)
+      PATHS ${NRLMSISE00_DIR}/lib64)
   else()
     find_library(NRLMSISE00_LIB
       NAMES libnrlmsise00.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,9 +103,15 @@ if(CYGWIN)
     NAMES cspice.a csupport.a
     PATHS ${CSPICE_DIR}/cspice_cygwin/lib)
 elseif(UNIX)
-  find_library(CSPICE_LIB
-    NAMES cspice.a csupport.a
-    PATHS ${CSPICE_DIR}/cspice_unix/lib)
+  if(BUILD_64BIT)
+    find_library(CSPICE_LIB
+      NAMES cspice.a csupport.a
+      PATHS ${CSPICE_DIR}/cspice_unix_64bit/lib)
+  else()
+    find_library(CSPICE_LIB
+      NAMES cspice.a csupport.a
+      PATHS ${CSPICE_DIR}/cspice_unix/lib)
+  endif()
 elseif(WIN32)
   SET (CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
   find_library(CSPICE_LIB
@@ -124,9 +130,15 @@ if(CYGWIN)
     NAMES libnrlmsise00.a
     PATHS ${NRLMSISE00_DIR}/lib)
 elseif(UNIX)
-  find_library(NRLMSISE00_LIB 
-    NAMES libnrlmsise00.a
-    PATHS ${NRLMSISE00_DIR}/lib)
+  if(BUILD_64BIT)
+    find_library(NRLMSISE00_LIB
+      NAMES libnrlmsise00.a
+      PATHS ${NRLMSISE00_DIR}/lib_64bit)
+  else()
+    find_library(NRLMSISE00_LIB
+      NAMES libnrlmsise00.a
+      PATHS ${NRLMSISE00_DIR}/lib)
+  endif()
 elseif(WIN32)
   SET (CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
   find_library(NRLMSISE00_LIB 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ cmake_minimum_required(VERSION 3.13)
 # build config
 option(USE_HILS "Use HILS" OFF)
 option(USE_C2A "Use C2A" OFF)
+option(BUILD_64BIT "Build 64bit" OFF)
 
 # preprocessor
 if(WIN32)
@@ -32,6 +33,7 @@ endif()
 
 ## options to use C2A
 if(USE_C2A)
+  option(BUILD_64BIT OFF) # force to build with 32bit
   set(C2A_DIR ${FLIGHT_SW_DIR}/${C2A_NAME})
   message("C2A dir: ${C2A_DIR}")
   add_definitions(-DUSE_C2A)

--- a/ExtLibraries/CMakeLists.txt
+++ b/ExtLibraries/CMakeLists.txt
@@ -2,6 +2,9 @@ project(ExtLibraries)
 
 cmake_minimum_required(VERSION 3.13)
 
+# build config
+option(BUILD_64BIT "Build 64bit" OFF)
+
 if(NOT DEFINED EXT_LIB_DIR)
   set(EXT_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../../ExtLibraries/")
 endif()

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -14,12 +14,18 @@ if(WIN32)
   set(CSPICE_BUILD_COMMAND "")
 else()
   # Linux
-  set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_32bit/packages/cspice.tar.Z)
-  set(CSPICE_SHA256 "33d75cd94acf6546e53d7ebc4e7d3d6d42ac27c83cb0d8f04c91a8b50c1149e3")
-  set(CSPICE_BUILD_COMMAND "")
+  if(BUILD_64BIT)
+    set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z)
+    set(CSPICE_SHA256 "60a95b51a6472f1afe7e40d77ebdee43c12bb5b8823676ccc74692ddfede06ce")
+    set(CSPICE_BUILD_COMMAND "")
+  else()
+    set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_32bit/packages/cspice.tar.Z)
+    set(CSPICE_SHA256 "33d75cd94acf6546e53d7ebc4e7d3d6d42ac27c83cb0d8f04c91a8b50c1149e3")
+    set(CSPICE_BUILD_COMMAND "")
+  endif()
 endif()
-
 # build & install cspice
+message("URL" ${CSPICE_URL})
 ExternalProject_Add(cspice
   URL ${CSPICE_URL}
   URL_HASH SHA256=${CSPICE_SHA256}
@@ -28,7 +34,7 @@ ExternalProject_Add(cspice
   BUILD_IN_SOURCE true
   BUILD_COMMAND "${CSPICE_BUILD_COMMAND}"
   INSTALL_COMMAND
-    ${CMAKE_COMMAND} -DCSPICE_INSTALL_DIR=${CSPICE_INSTALL_DIR} -P ${CMAKE_CURRENT_LIST_DIR}/install_step.cmake
+    ${CMAKE_COMMAND} -DCSPICE_INSTALL_DIR=${CSPICE_INSTALL_DIR} -DBUILD_64BIT=${BUILD_64BIT} -P ${CMAKE_CURRENT_LIST_DIR}/install_step.cmake
 )
 
 # install generic kernels

--- a/ExtLibraries/cspice/install_step.cmake
+++ b/ExtLibraries/cspice/install_step.cmake
@@ -14,7 +14,7 @@ if(WIN32)
 else()
   # Linux
   if(BUILD_64BIT)
-    set(CSPICE_LIB_DEST "cspice_unix_64bit")
+    set(CSPICE_LIB_DEST "cspice_unix64")
   else()
     set(CSPICE_LIB_DEST "cspice_unix")
   endif()

--- a/ExtLibraries/cspice/install_step.cmake
+++ b/ExtLibraries/cspice/install_step.cmake
@@ -13,10 +13,14 @@ if(WIN32)
   set(CSPICE_LIB_DEST "cspice_msvs")
 else()
   # Linux
-  set(CSPICE_LIB_DEST "cspice_unix")
+  if(BUILD_64BIT)
+    set(CSPICE_LIB_DEST "cspice_unix_64bit")
+  else()
+    set(CSPICE_LIB_DEST "cspice_unix")
+  endif()
 endif()
 
-message("install cspice/lib")
+message("install cspice/lib to "${CSPICE_LIB_DEST})
 file(
   COPY ${CMAKE_SOURCE_DIR}/lib
   DESTINATION ${CSPICE_INSTALL_DIR}/${CSPICE_LIB_DEST}

--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -66,7 +66,7 @@ install(EXPORT nrlmsise00-config
 
 ## install library
 if(BUILD_64BIT)
-  set(NRLMSISE_LIB_DIR lib_64bit)
+  set(NRLMSISE_LIB_DIR lib64)
 else()
   set(NRLMSISE_LIB_DIR lib)
 endif()

--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -49,8 +49,10 @@ add_library(${NRLMSISE_LIB} STATIC ${NRLMSISE_TMP_DIR}/nrlmsise-00.c ${NRLMSISE_
 if(MSVC)
   target_compile_options(${NRLMSISE_LIB} PUBLIC "/MT")
 else()
-  target_compile_options(${NRLMSISE_LIB} PUBLIC "-m32")
-  target_link_options(${NRLMSISE_LIB} PRIVATE "-m32")
+  if(NOT BUILD_64BIT)
+    target_compile_options(${NRLMSISE_LIB} PUBLIC "-m32")
+    target_link_options(${NRLMSISE_LIB} PRIVATE "-m32")
+  endif()
 endif()
 
 # install
@@ -63,9 +65,15 @@ install(EXPORT nrlmsise00-config
 )
 
 ## install library
+if(BUILD_64BIT)
+  set(NRLMSISE_LIB_DIR lib_64bit)
+else()
+  set(NRLMSISE_LIB_DIR lib)
+endif()
+
 install(TARGETS ${NRLMSISE_LIB}
   EXPORT nrlmsise00-config
-  ARCHIVE DESTINATION ${NRLMSISE_INSTALL_DIR}/lib
+  ARCHIVE DESTINATION ${NRLMSISE_INSTALL_DIR}/${NRLMSISE_LIB_DIR}
 )
 
 ## install source

--- a/common.cmake
+++ b/common.cmake
@@ -20,10 +20,11 @@ else()
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")
   target_compile_options(${PROJECT_NAME} PUBLIC "-rdynamic")
 
-  # 32bit
-  target_compile_options(${PROJECT_NAME} PUBLIC "-m32")
-  target_link_options(${PROJECT_NAME} PUBLIC "-m32")
-
+  if(NOT BUILD_64BIT)
+    # 32bit
+    target_compile_options(${PROJECT_NAME} PUBLIC "-m32")
+    target_link_options(${PROJECT_NAME} PUBLIC "-m32")
+  endif()
   # debug
   target_compile_options(${PROJECT_NAME} PUBLIC "-g")
 endif()


### PR DESCRIPTION
## Overview
Add 64bit build option

## Issue
- #135

## Details
64bit build option for linux is added to the CMake files.

##  Validation results
Confirmed in the local Docker/Ubuntu environment.  
Others will be confirmed in the CI process

## Scope of influence
small

## Supplement
NA

## Note
NA