### PR TITLE
Initialize inertia tensor in controlled attitude

### DIFF
--- a/src/Dynamics/Attitude/ControlledAttitude.cpp
+++ b/src/Dynamics/Attitude/ControlledAttitude.cpp
@@ -10,7 +10,7 @@ using namespace std;
 #define THRESHOLD_CA cos(30.0 / 180.0 * libra::pi)  // fix me
 
 ControlledAttitude::ControlledAttitude(const AttCtrlMode main_mode, const AttCtrlMode sub_mode, const Quaternion quaternion_i2b,
-                                       const Vector<3> pointing_t_b, const Vector<3> pointing_sub_t_b,
+                                       const Vector<3> pointing_t_b, const Vector<3> pointing_sub_t_b, const Matrix<3, 3>& inertia_tensor_kgm2,
                                        const LocalCelestialInformation* local_celes_info, const Orbit* orbit, const std::string& sim_object_name)
     : Attitude(sim_object_name),
       main_mode_(main_mode),
@@ -20,6 +20,9 @@ ControlledAttitude::ControlledAttitude(const AttCtrlMode main_mode, const AttCtr
       local_celes_info_(local_celes_info),
       orbit_(orbit) {
   quaternion_i2b_ = quaternion_i2b;
+  inertia_tensor_kgm2_ = inertia_tensor_kgm2;
+  inv_inertia_tensor_ = invert(inertia_tensor_kgm2_);
+
   Initialize();
 }
 

--- a/src/Dynamics/Attitude/ControlledAttitude.cpp
+++ b/src/Dynamics/Attitude/ControlledAttitude.cpp
@@ -20,7 +20,7 @@ ControlledAttitude::ControlledAttitude(const AttCtrlMode main_mode, const AttCtr
       local_celes_info_(local_celes_info),
       orbit_(orbit) {
   quaternion_i2b_ = quaternion_i2b;
-  inertia_tensor_kgm2_ = inertia_tensor_kgm2;
+  inertia_tensor_kgm2_ = inertia_tensor_kgm2;  // FIXME: inertia tensor should be initialized in the Attitude base class
   inv_inertia_tensor_ = invert(inertia_tensor_kgm2_);
 
   Initialize();

--- a/src/Dynamics/Attitude/ControlledAttitude.h
+++ b/src/Dynamics/Attitude/ControlledAttitude.h
@@ -22,8 +22,8 @@ AttCtrlMode ConvertStringToCtrlMode(const std::string mode);
 class ControlledAttitude : public Attitude {
  public:
   ControlledAttitude(const AttCtrlMode main_mode, const AttCtrlMode sub_mode, const Quaternion quaternion_i2b, const Vector<3> pointing_t_b,
-                     const Vector<3> pointing_sub_t_b, const LocalCelestialInformation* local_celes_info, const Orbit* orbit,
-                     const std::string& sim_object_name = "Attitude");
+                     const Vector<3> pointing_sub_t_b, const Matrix<3, 3>& inertia_tensor_kgm2, const LocalCelestialInformation* local_celes_info,
+                     const Orbit* orbit, const std::string& sim_object_name = "Attitude");
   ~ControlledAttitude();
 
   // Setter

--- a/src/Dynamics/Attitude/InitAttitude.cpp
+++ b/src/Dynamics/Attitude/InitAttitude.cpp
@@ -35,7 +35,7 @@ Attitude* InitAttitude(std::string file_name, const Orbit* orbit, const LocalCel
     Vector<3> pointing_t_b, pointing_sub_t_b;
     ini_file_ca.ReadVector(section_ca_, "pointing_t_b", pointing_t_b);
     ini_file_ca.ReadVector(section_ca_, "pointing_sub_t_b", pointing_sub_t_b);
-    attitude = new ControlledAttitude(main_mode, sub_mode, quaternion_i2b, pointing_t_b, pointing_sub_t_b, celes_info, orbit, mc_name);
+    attitude = new ControlledAttitude(main_mode, sub_mode, quaternion_i2b, pointing_t_b, pointing_sub_t_b, inertia_tensor, celes_info, orbit, mc_name);
   } else {
     std::cerr << "ERROR: attitude propagation mode: " << propagate_mode << " is not defined!" << std::endl;
     std::cerr << "The attitude mode is automatically set as RK4" << std::endl;


### PR DESCRIPTION
## Overview
Initialize inertia tensor in the controlled attitude mode

## Issue
- NA

## Details
The gravity gradient disturbance calculation generates incorrect values since the inertia tensor in the attitude class was not initialized in the controlled attitude mode.

##  Validation results
The output torque in the log file is fixed.

## Scope of influence
The constructor of the ControlledAttitude is changed but it does not affect normal users.

## Supplement
NA

## Note
NA