### PR TITLE
Add angular velocity and torque calculation in the ControlledAttitude

### DIFF
--- a/src/Dynamics/Attitude/ControlledAttitude.h
+++ b/src/Dynamics/Attitude/ControlledAttitude.h
@@ -38,10 +38,13 @@ class ControlledAttitude : public Attitude {
 
  private:
   AttCtrlMode main_mode_;
-  AttCtrlMode sub_mode_;               // for control around pointing direction
-  libra::Vector<3> pointing_t_b_;      // Pointing target on body frame
-  libra::Vector<3> pointing_sub_t_b_;  // Pointing sub target on body frame
-
+  AttCtrlMode sub_mode_;                   //!< for control around pointing direction
+  libra::Vector<3> pointing_t_b_;          //!< Pointing target on body frame
+  libra::Vector<3> pointing_sub_t_b_;      //!< Pointing sub target on body frame
+  double previous_calc_time_s_ = -1.0;     //!< previous time of velocity calculation
+  libra::Quaternion prev_quaternion_i2b_;  //!< previous quaternion
+  libra::Vector<3> prev_omega_b_rad_s_;    //!< previous angular velocity
+  
   // Inputs
   const LocalCelestialInformation* local_celes_info_;
   const Orbit* orbit_;
@@ -50,6 +53,8 @@ class ControlledAttitude : public Attitude {
   void Initialize(void);
   Vector<3> CalcTargetDirection(AttCtrlMode mode);
   void PointingCtrl(const Vector<3> main_direction_i, const Vector<3> sub_direction_i);
+  void CalcAngularVelocity(const double current_time_s);
+  void CalcTorque(const double current_time_s);
   Matrix<3, 3> CalcDCM(const Vector<3> main_direction, const Vector<3> sub_direction);
 };
 

--- a/src/Library/math/Quaternion.cpp
+++ b/src/Library/math/Quaternion.cpp
@@ -94,6 +94,14 @@ Quaternion operator*(const Quaternion& lhs, const Vector<3>& rhs) {
   return temp;
 }
 
+Quaternion operator*(const double& lhs, const Quaternion& rhs) {
+  Quaternion temp;
+  for (size_t i = 0; i < 4; i++) {
+    temp[i] = lhs * rhs[i];
+  }
+  return temp;
+}
+
 Quaternion Quaternion::normalize(void) {
   double n = 0.0;
   for (int i = 0; i < 4; ++i) {

--- a/src/Library/math/Quaternion.hpp
+++ b/src/Library/math/Quaternion.hpp
@@ -177,6 +177,9 @@ Quaternion operator*(const Quaternion& lhs, const Quaternion& rhs);
 
 //! QuaternionとVectorの積演算子
 Quaternion operator*(const Quaternion& lhs, const Vector<3>& rhs);
+
+//! Quaternionとスカラーの積演算子
+Quaternion operator*(const double& lhs, const Quaternion& rhs);
 }  // namespace libra
 
 #include "Quaternion_ifs.hpp"  // inline function definisions.


### PR DESCRIPTION
## Overview
Add angular velocity and torque calculation in the ControlledAttitude.

## Issue
- #110 

## Details
Angular velocity and torque calculation features are added in the controlled attitude mode.  
The torque calculation will be validated after merging [this PR](https://github.com/ut-issl/s2e-core/pull/141).

##  Validation results
> The angular velocity calculation result
- Conditions
  - ControlledAttitude mode
  - Main: Body +X points to the earth's center
  - Sub: Body +Z points to the velocity direction
- Result
  - The angular velocity in the Y-axis is compatible with the orbital period.
  - 0.00112 rad/s = 92.8 min/rev

<img width="513" alt="image" src="https://user-images.githubusercontent.com/19573779/170890644-831bb775-1ae7-46d1-ab24-7d935419ccba.png">


## Scope of influence
Only for controlled attitude users.

## Supplement
NA

## Note
NA