### PR TITLE
Add EGM96 table file

### DIFF
--- a/ExtLibraries/CMakeLists.txt
+++ b/ExtLibraries/CMakeLists.txt
@@ -16,3 +16,4 @@ message("ExtLibraries install dir: ${EXT_LIB_DIR}")
 
 add_subdirectory(nrlmsise00)
 add_subdirectory(cspice)
+add_subdirectory(GeoPotential)

--- a/ExtLibraries/GeoPotential/CMakeLists.txt
+++ b/ExtLibraries/GeoPotential/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(geopotential)
+
+cmake_minimum_required(VERSION 3.13)
+
+
+set(GEOPOTENTIAL_INSTALL_DIR ${EXT_LIB_DIR}/GeoPotential/)
+
+## install table
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/egm96_to360.ascii
+  DESTINATION ${GEOPOTENTIAL_INSTALL_DIR}
+)

--- a/ExtLibraries/README.md
+++ b/ExtLibraries/README.md
@@ -1,0 +1,14 @@
+# ExtLibraries
+
+## Overview
+- S2E uses the following external libraries
+  - [SPICE Toolkit](https://naif.jpl.nasa.gov/naif/toolkit.html)
+    - For celestial body's information
+  - [NRLMSISE00](https://www.brodo.de/space/nrlmsise/)
+    - For precise air density model around the earth
+  - [EGM96](https://cddis.nasa.gov/926/egm96/egm96.html)
+    - For geopotential coefficient table
+  - others
+
+## Note
+- Currently, we cannot access the original download page of the `egm96_to360.ascii` coefficient table file. Therefore, we decided to provide the table file in this repository.


### PR DESCRIPTION
## Overview
Add EGM96 table file

## Issue
- #139 

## Details
The coefficient table file for EGM96 model is added.

##  Validation results
Confirmed that the file is coped to the ExtLibraries directory with the CMake.

## Scope of influence
No effect to the codes.

## Supplement
NA

## Note
NA