### PR TITLE
Rename from minimum_user_for_s2e to minimum_user

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         shell: cmd
         run: |
           cl.exe
-          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DFLIGHT_SW_DIR=./c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -D${{ matrix.use_c2a }}
+          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=./ExtLibraries -DFLIGHT_SW_DIR=./c2a-core -DC2A_NAME=Examples/minimum_user -D${{ matrix.use_c2a }}
           cmake --build .
 
   build_s2e_linux:


### PR DESCRIPTION
## Overview
Rename from minimum_user_for_s2e to minimum_user

## Issue
- https://github.com/ut-issl/c2a-core/issues/361

## Details
See issue

##  Validation results
Pass CI

## Note
- [x] After merging https://github.com/ut-issl/c2a-core/pull/362 , run CI again and check it
