### PR TITLE
Fix set -rdynamic on link time only

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -18,7 +18,9 @@ else()
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wall")
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wextra")
   target_compile_options(${PROJECT_NAME} PUBLIC "-Wpedantic")
-  target_compile_options(${PROJECT_NAME} PUBLIC "-rdynamic")
+
+  # link option
+  target_link_options(${PROJECT_NAME} PUBLIC "-rdynamic")
 
   if(NOT BUILD_64BIT)
     # 32bit


### PR DESCRIPTION
## Overview
SSIA

## Issue
N/A

## Details
Set `-rdynamic` option on link time only. Not compile time(= `-c`).

##  Validation results
Link to tests or validation results.

## Scope of influence
reduce warnings on build with clang/clang++

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
