### PR TITLE
Modify for FF simulation

### DIFF
--- a/src/RelativeInformation/RelativeInformation.cpp
+++ b/src/RelativeInformation/RelativeInformation.cpp
@@ -109,5 +109,6 @@ void RelativeInformation::ResizeLists() {
   rel_pos_list_i_m_.assign(size, vector<libra::Vector<3>>(size, libra::Vector<3>(0)));
   rel_vel_list_i_m_s_.assign(size, vector<libra::Vector<3>>(size, libra::Vector<3>(0)));
   rel_distance_list_m_.assign(size, vector<double>(size, 0.0));
+  rel_pos_list_rtn_m_.assign(size, vector<libra::Vector<3>>(size, libra::Vector<3>(0)));
   rel_att_quaternion_list_.assign(size, vector<libra::Quaternion>(size, libra::Quaternion(0, 0, 0, 1)));
 }

--- a/src/RelativeInformation/RelativeInformation.cpp
+++ b/src/RelativeInformation/RelativeInformation.cpp
@@ -34,23 +34,12 @@ const libra::Vector<3> RelativeInformation::GetRelativeVelocity_i(const int targ
 libra::Vector<3> RelativeInformation::CalcRelativePosition_rtn(const int target_sat_id, const int reference_sat_id) const {
   libra::Vector<3> target_sat_pos_i = dynamics_database_.at(target_sat_id)->GetOrbit().GetSatPosition_i();
   libra::Vector<3> reference_sat_pos_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatPosition_i();
-  libra::Vector<3> reference_sat_vel_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatVelocity_i();
   libra::Vector<3> relative_pos_i = target_sat_pos_i - reference_sat_pos_i;
 
   // RTN frame for the reference satellite
-  libra::Vector<3> direction_r_i = normalize(reference_sat_pos_i);
-  libra::Vector<3> direction_v_i = normalize(reference_sat_vel_i);
-  libra::Vector<3> normal_i = cross(direction_r_i, direction_v_i);
-  libra::Vector<3> direction_n_i = normalize(normal_i);
-  libra::Vector<3> direction_t_i = cross(direction_n_i, direction_r_i);
-  direction_t_i = normalize(direction_t_i);
-  libra::Matrix<3, 3> dcm_eci2rtn;
-  for (size_t i = 0; i < 3; i++) {
-    dcm_eci2rtn[0][i] = direction_r_i[i];
-    dcm_eci2rtn[1][i] = direction_t_i[i];
-    dcm_eci2rtn[2][i] = direction_n_i[i];
-  }
-  libra::Vector<3> relative_pos_rtn = dcm_eci2rtn * relative_pos_i;
+  libra::Quaternion q_i2rtn = dynamics_database_.at(reference_sat_id)->GetOrbit().CalcQuaternionI2LVLH();
+
+  libra::Vector<3> relative_pos_rtn = q_i2rtn.frame_conv(relative_pos_i);
   return relative_pos_rtn;
 }
 

--- a/src/RelativeInformation/RelativeInformation.cpp
+++ b/src/RelativeInformation/RelativeInformation.cpp
@@ -4,43 +4,34 @@ RelativeInformation::RelativeInformation() {}
 
 RelativeInformation::~RelativeInformation() {}
 
-void RelativeInformation::RegisterDynamicsInfo(const int sat_id, const Dynamics* dynamics) { dynamics_database_.emplace(sat_id, dynamics); }
-
-void RelativeInformation::RemoveDynamicsInfo(const int sat_id) { dynamics_database_.erase(sat_id); }
-
-const libra::Quaternion RelativeInformation::CalcRelativeAttitudeQuaternion(const int target_sat_id, const int reference_sat_id) const {
-  // Observer SC Body frame(obs_sat) -> ECI frame(i)
-  Quaternion q_reference_i2b = dynamics_database_.at(reference_sat_id)->GetAttitude().GetQuaternion_i2b();
-  Quaternion q_reference_b2i = q_reference_i2b.conjugate();
-
-  // ECI frame(i) -> Target SC body frame(main_sat)
-  Quaternion q_target_i2b = dynamics_database_.at(target_sat_id)->GetAttitude().GetQuaternion_i2b();
-
-  return q_target_i2b * q_reference_b2i;
+void RelativeInformation::Update() {
+  for (size_t target_sat_id = 0; target_sat_id < dynamics_database_.size(); target_sat_id++) {
+    for (size_t reference_sat_id = 0; reference_sat_id < dynamics_database_.size(); reference_sat_id++) {
+      // Position
+      libra::Vector<3> target_sat_pos_i = dynamics_database_.at(target_sat_id)->GetOrbit().GetSatPosition_i();
+      libra::Vector<3> reference_sat_pos_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatPosition_i();
+      rel_pos_list_i_m_[target_sat_id][reference_sat_id] = target_sat_pos_i - reference_sat_pos_i;
+      rel_pos_list_rtn_m_[target_sat_id][reference_sat_id] = CalcRelativePosition_rtn_m(target_sat_id, reference_sat_id);
+      // Distance
+      rel_distance_list_m_[target_sat_id][reference_sat_id] = norm(rel_pos_list_i_m_[target_sat_id][reference_sat_id]);
+      // Velociry
+      libra::Vector<3> target_sat_vel_i = dynamics_database_.at(target_sat_id)->GetOrbit().GetSatVelocity_i();
+      libra::Vector<3> reference_sat_vel_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatVelocity_i();
+      rel_vel_list_i_m_s_[target_sat_id][reference_sat_id] = target_sat_vel_i - reference_sat_vel_i;
+      // Attitude Quaternion
+      rel_att_quaternion_list_[target_sat_id][reference_sat_id] = CalcRelativeAttitudeQuaternion(target_sat_id, reference_sat_id);
+    }
+  }
 }
 
-const libra::Vector<3> RelativeInformation::GetRelativePosition_i(const int target_sat_id, const int reference_sat_id) const {
-  libra::Vector<3> target_sat_pos_i = dynamics_database_.at(target_sat_id)->GetOrbit().GetSatPosition_i();
-  libra::Vector<3> reference_sat_pos_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatPosition_i();
-  return target_sat_pos_i - reference_sat_pos_i;
+void RelativeInformation::RegisterDynamicsInfo(const int sat_id, const Dynamics* dynamics) {
+  dynamics_database_.emplace(sat_id, dynamics);
+  ResizeLists();
 }
 
-const libra::Vector<3> RelativeInformation::GetRelativeVelocity_i(const int target_sat_id, const int reference_sat_id) const {
-  libra::Vector<3> target_sat_vel_i = dynamics_database_.at(target_sat_id)->GetOrbit().GetSatVelocity_i();
-  libra::Vector<3> reference_sat_vel_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatVelocity_i();
-  return target_sat_vel_i - reference_sat_vel_i;
-}
-
-libra::Vector<3> RelativeInformation::CalcRelativePosition_rtn(const int target_sat_id, const int reference_sat_id) const {
-  libra::Vector<3> target_sat_pos_i = dynamics_database_.at(target_sat_id)->GetOrbit().GetSatPosition_i();
-  libra::Vector<3> reference_sat_pos_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatPosition_i();
-  libra::Vector<3> relative_pos_i = target_sat_pos_i - reference_sat_pos_i;
-
-  // RTN frame for the reference satellite
-  libra::Quaternion q_i2rtn = dynamics_database_.at(reference_sat_id)->GetOrbit().CalcQuaternionI2LVLH();
-
-  libra::Vector<3> relative_pos_rtn = q_i2rtn.frame_conv(relative_pos_i);
-  return relative_pos_rtn;
+void RelativeInformation::RemoveDynamicsInfo(const int sat_id) {
+  dynamics_database_.erase(sat_id);
+  ResizeLists();
 }
 
 std::string RelativeInformation::GetLogHeader() const {
@@ -69,19 +60,19 @@ std::string RelativeInformation::GetLogValue() const {
   std::string str_tmp = "";
   for (size_t target_sat_id = 0; target_sat_id < dynamics_database_.size(); target_sat_id++) {
     for (size_t reference_sat_id = 0; reference_sat_id < target_sat_id; reference_sat_id++) {
-      str_tmp += WriteVector(GetRelativePosition_i(target_sat_id, reference_sat_id));
+      str_tmp += WriteVector(GetRelativePosition_i_m(target_sat_id, reference_sat_id));
     }
   }
 
   for (size_t target_sat_id = 0; target_sat_id < dynamics_database_.size(); target_sat_id++) {
     for (size_t reference_sat_id = 0; reference_sat_id < target_sat_id; reference_sat_id++) {
-      str_tmp += WriteVector(GetRelativeVelocity_i(target_sat_id, reference_sat_id));
+      str_tmp += WriteVector(GetRelativeVelocity_i_m_s(target_sat_id, reference_sat_id));
     }
   }
 
   for (size_t target_sat_id = 0; target_sat_id < dynamics_database_.size(); target_sat_id++) {
     for (size_t reference_sat_id = 0; reference_sat_id < target_sat_id; reference_sat_id++) {
-      str_tmp += WriteVector(CalcRelativePosition_rtn(target_sat_id, reference_sat_id));
+      str_tmp += WriteVector(GetRelativePosition_rtn_m(target_sat_id, reference_sat_id));
     }
   }
 
@@ -89,3 +80,34 @@ std::string RelativeInformation::GetLogValue() const {
 }
 
 void RelativeInformation::LogSetup(Logger& logger) { logger.AddLoggable(this); }
+
+libra::Quaternion RelativeInformation::CalcRelativeAttitudeQuaternion(const int target_sat_id, const int reference_sat_id) {
+  // Observer SC Body frame(obs_sat) -> ECI frame(i)
+  Quaternion q_reference_i2b = dynamics_database_.at(reference_sat_id)->GetAttitude().GetQuaternion_i2b();
+  Quaternion q_reference_b2i = q_reference_i2b.conjugate();
+
+  // ECI frame(i) -> Target SC body frame(main_sat)
+  Quaternion q_target_i2b = dynamics_database_.at(target_sat_id)->GetAttitude().GetQuaternion_i2b();
+
+  return q_target_i2b * q_reference_b2i;
+}
+
+libra::Vector<3> RelativeInformation::CalcRelativePosition_rtn_m(const int target_sat_id, const int reference_sat_id) {
+  libra::Vector<3> target_sat_pos_i = dynamics_database_.at(target_sat_id)->GetOrbit().GetSatPosition_i();
+  libra::Vector<3> reference_sat_pos_i = dynamics_database_.at(reference_sat_id)->GetOrbit().GetSatPosition_i();
+  libra::Vector<3> relative_pos_i = target_sat_pos_i - reference_sat_pos_i;
+
+  // RTN frame for the reference satellite
+  libra::Quaternion q_i2rtn = dynamics_database_.at(reference_sat_id)->GetOrbit().CalcQuaternionI2LVLH();
+
+  libra::Vector<3> relative_pos_rtn = q_i2rtn.frame_conv(relative_pos_i);
+  return relative_pos_rtn;
+}
+
+void RelativeInformation::ResizeLists() {
+  size_t size = dynamics_database_.size();
+  rel_pos_list_i_m_.assign(size, vector<libra::Vector<3>>(size, libra::Vector<3>(0)));
+  rel_vel_list_i_m_s_.assign(size, vector<libra::Vector<3>>(size, libra::Vector<3>(0)));
+  rel_distance_list_m_.assign(size, vector<double>(size, 0.0));
+  rel_att_quaternion_list_.assign(size, vector<libra::Quaternion>(size, libra::Quaternion(0, 0, 0, 1)));
+}

--- a/src/RelativeInformation/RelativeInformation.h
+++ b/src/RelativeInformation/RelativeInformation.h
@@ -9,26 +9,45 @@ class RelativeInformation : public ILoggable {
  public:
   RelativeInformation();
   ~RelativeInformation();
-  virtual std::string GetLogHeader() const;
-  virtual std::string GetLogValue() const;
-  void LogSetup(Logger& logger);
+
+  void Update();
   void RegisterDynamicsInfo(const int sat_id, const Dynamics* dynamics);
   void RemoveDynamicsInfo(const int sat_id);
 
+  // ILoggable
+  virtual std::string GetLogHeader() const;
+  virtual std::string GetLogValue() const;
+  void LogSetup(Logger& logger);
+
   // Getter
-
-  // Transformation Quaternion: Calculate a quaternion represents the coordinate
-  // transformation from the body frame of reference satellite to the body frame
-  // of target satellite target_sat_id: satellite ID in relative motion
-  // reference_sat_id: satellite ID to observe relative motion
-  const libra::Quaternion CalcRelativeAttitudeQuaternion(const int target_sat_id, const int reference_sat_id) const;
-
-  const libra::Vector<3> GetRelativePosition_i(const int target_sat_id, const int reference_sat_id) const;
-  const libra::Vector<3> GetRelativeVelocity_i(const int target_sat_id, const int reference_sat_id) const;
-  libra::Vector<3> CalcRelativePosition_rtn(const int target_sat_id, const int reference_sat_id) const;
+  inline libra::Quaternion GetRelativeAttitudeQuaternion(const int target_sat_id, const int reference_sat_id) const {
+    return rel_att_quaternion_list_[target_sat_id][reference_sat_id];
+  }
+  inline libra::Vector<3> GetRelativePosition_i_m(const int target_sat_id, const int reference_sat_id) const {
+    return rel_pos_list_i_m_[target_sat_id][reference_sat_id];
+  }
+  inline libra::Vector<3> GetRelativeVelocity_i_m_s(const int target_sat_id, const int reference_sat_id) const {
+    return rel_vel_list_i_m_s_[target_sat_id][reference_sat_id];
+  }
+  inline double GetRelativeDistance_m(const int target_sat_id, const int reference_sat_id) const {
+    return rel_distance_list_m_[target_sat_id][reference_sat_id];
+  };
+  inline libra::Vector<3> GetRelativePosition_rtn_m(const int target_sat_id, const int reference_sat_id) const {
+    return rel_pos_list_rtn_m_[target_sat_id][reference_sat_id];
+  }
 
   inline const Dynamics* GetReferenceSatDynamics(const int reference_sat_id) const { return dynamics_database_.at(reference_sat_id); };
 
  private:
   std::map<const int, const Dynamics*> dynamics_database_;
+
+  std::vector<std::vector<libra::Vector<3>>> rel_pos_list_i_m_;
+  std::vector<std::vector<libra::Vector<3>>> rel_vel_list_i_m_s_;
+  std::vector<std::vector<libra::Vector<3>>> rel_pos_list_rtn_m_;
+  std::vector<std::vector<double>> rel_distance_list_m_;
+  std::vector<std::vector<libra::Quaternion>> rel_att_quaternion_list_;
+
+  libra::Quaternion CalcRelativeAttitudeQuaternion(const int target_sat_id, const int reference_sat_id);
+  libra::Vector<3> CalcRelativePosition_rtn_m(const int target_sat_id, const int reference_sat_id);
+  void ResizeLists();
 };

--- a/src/RelativeInformation/RelativeInformation.h
+++ b/src/RelativeInformation/RelativeInformation.h
@@ -25,6 +25,7 @@ class RelativeInformation : public ILoggable {
 
   const libra::Vector<3> GetRelativePosition_i(const int target_sat_id, const int reference_sat_id) const;
   const libra::Vector<3> GetRelativeVelocity_i(const int target_sat_id, const int reference_sat_id) const;
+  libra::Vector<3> CalcRelativePosition_rtn(const int target_sat_id, const int reference_sat_id) const;
 
   inline const Dynamics* GetReferenceSatDynamics(const int reference_sat_id) const { return dynamics_database_.at(reference_sat_id); };
 


### PR DESCRIPTION
## Overview
Modify for FF simulation

## Issue
- NA

## Details
The following features are added
- Log output of position in `RTN frame` was added for FF analysis.
- Update function of `RelativeInformation` is added.
  - The previous style cannot fix the return value of the getter functions.
  - Especially when components use the `RelativeInformation`, the wrong value was calculated shown as follows.
    - Previous code: The calculated relative value is wrong since the Sat2 information is still old.
    ```
    Sat1 orbit update -> Compo on Sat1 update and calculate relative value -> Sat2 orbit update
    ```
    - New code: The gotten value is correct since the value is calculated at the Update function of `RelativeInformation`.
    ```
    Sat1 orbit update -> Compo on Sat1 update and get relative value -> Sat2 orbit update -> RelativeInformation update
    ```

##  Validation results
NA

## Scope of influence
Only for multiple satellite user.

## Supplement
NA

## Note
NA
