### PR TITLE
Add function driven when the component power off

### DIFF
--- a/src/Component/AOCS/MagTorquer.cpp
+++ b/src/Component/AOCS/MagTorquer.cpp
@@ -50,6 +50,8 @@ void MagTorquer::MainRoutine(int count) {
   CalcOutputTorque();
 }
 
+void MagTorquer::PowerOffRoutine() { torque_b_(0.0); }
+
 libra::Vector<kMtqDim> MagTorquer::CalcOutputTorque(void) {
   for (size_t i = 0; i < kMtqDim; ++i) {
     // Limit Check

--- a/src/Component/AOCS/MagTorquer.cpp
+++ b/src/Component/AOCS/MagTorquer.cpp
@@ -50,7 +50,7 @@ void MagTorquer::MainRoutine(int count) {
   CalcOutputTorque();
 }
 
-void MagTorquer::PowerOffRoutine() { torque_b_(0.0); }
+void MagTorquer::PowerOffRoutine() { torque_b_ *= 0.0; }
 
 libra::Vector<kMtqDim> MagTorquer::CalcOutputTorque(void) {
   for (size_t i = 0; i < kMtqDim; ++i) {

--- a/src/Component/AOCS/MagTorquer.h
+++ b/src/Component/AOCS/MagTorquer.h
@@ -41,6 +41,7 @@ class MagTorquer : public ComponentBase, public ILoggable {
 
   // ComponentBase override functions
   void MainRoutine(int count) override;
+  void PowerOffRoutine() override;
   // ILogabble override functions
   virtual std::string GetLogHeader() const;
   virtual std::string GetLogValue() const;

--- a/src/Component/AOCS/RWModel.cpp
+++ b/src/Component/AOCS/RWModel.cpp
@@ -93,6 +93,8 @@ void RWModel::MainRoutine(int count) {
   CalcTorque();
 }
 
+void RWModel::PowerOffRoutine() { drive_flag_ = 0; }
+
 // Jitter calculation
 void RWModel::FastUpdate() { rw_jitter_.CalcJitter(angular_velocity_rad_); }
 

--- a/src/Component/AOCS/RWModel.h
+++ b/src/Component/AOCS/RWModel.h
@@ -47,8 +47,8 @@ class RWModel : public ComponentBase, public ILoggable {
 
   // ComponentBase override function
   void MainRoutine(int count) override;
-  // Fast Update for jitter
-  void FastUpdate() override;
+  void PowerOffRoutine() override;
+  void FastUpdate() override;  // Fast Update for jitter
 
   // Iloggable override function
   std::string GetLogHeader() const;

--- a/src/Component/Abstract/ComponentBase.cpp
+++ b/src/Component/Abstract/ComponentBase.cpp
@@ -30,13 +30,19 @@ ComponentBase::~ComponentBase() { clock_gen_->RemoveComponent(this); }
 
 // 時を刻む
 void ComponentBase::Tick(int count) {
-  if (!power_port_->GetIsOn()) return;
-  if (count % prescaler_ > 0) return;
-  MainRoutine(count);
+  if (power_port_->GetIsOn()) {
+    if (count % prescaler_ > 0) return;
+    MainRoutine(count);
+  } else {
+    PowerOffRoutine();
+  }
 }
 
 void ComponentBase::FastTick(int count) {
-  if (!power_port_->GetIsOn()) return;
-  if (count % fast_prescaler_ > 0) return;
-  FastUpdate();
+  if (power_port_->GetIsOn()) {
+    if (count % fast_prescaler_ > 0) return;
+    FastUpdate();
+  } else {
+    PowerOffRoutine();
+  }
 }

--- a/src/Component/Abstract/ComponentBase.cpp
+++ b/src/Component/Abstract/ComponentBase.cpp
@@ -14,8 +14,6 @@ ComponentBase::ComponentBase(int prescaler, ClockGenerator* clock_gen, PowerPort
   fast_prescaler_ = (fast_prescaler > 0) ? fast_prescaler : 1;
 }
 
-// コピーされたらそのインスタンスもClockGeneratorに登録しないとならない
-// 実用上、コピー元かコピー先のどちらか（大体コピー元？）はすぐに破棄されるはずだが
 ComponentBase::ComponentBase(const ComponentBase& obj) {
   prescaler_ = obj.prescaler_;
   fast_prescaler_ = obj.fast_prescaler_;
@@ -25,13 +23,11 @@ ComponentBase::ComponentBase(const ComponentBase& obj) {
   power_port_ = obj.power_port_;
 }
 
-// 破棄されたらClockGeneratorから削除しないとならない
 ComponentBase::~ComponentBase() { clock_gen_->RemoveComponent(this); }
 
-// 時を刻む
 void ComponentBase::Tick(int count) {
+  if (count % prescaler_ > 0) return;
   if (power_port_->GetIsOn()) {
-    if (count % prescaler_ > 0) return;
     MainRoutine(count);
   } else {
     PowerOffRoutine();
@@ -39,8 +35,8 @@ void ComponentBase::Tick(int count) {
 }
 
 void ComponentBase::FastTick(int count) {
+  if (count % prescaler_ > 0) return;
   if (power_port_->GetIsOn()) {
-    if (count % fast_prescaler_ > 0) return;
     FastUpdate();
   } else {
     PowerOffRoutine();

--- a/src/Component/Abstract/ComponentBase.h
+++ b/src/Component/Abstract/ComponentBase.h
@@ -22,7 +22,8 @@ class ComponentBase : public ITickable {
   int prescaler_;           //!< Frequency scale factor for normal update
   int fast_prescaler_ = 1;  //!< Frequency scale factor for fast update
 
-  // The method periodically executed. The period is decided with the prescaler_ and the base clock.
+  // The method periodically executed when the power switch is on.
+  // The period is decided with the prescaler_ and the base clock.
   virtual void MainRoutine(int time_count) = 0;
 
   // Method used to calculate high-frequency disturbances(e.g. RW jitter)

--- a/src/Component/Abstract/ComponentBase.h
+++ b/src/Component/Abstract/ComponentBase.h
@@ -6,7 +6,7 @@
 
 #include "ITickable.h"
 
-// 電源ON/OFFと時間の概念のみを持った、コンポーネントの基底クラス
+// Base class for components with clock and power on/off features
 class ComponentBase : public ITickable {
  public:
   ComponentBase(int prescaler, ClockGenerator* clock_gen, int fast_prescaler = 1);
@@ -14,27 +14,23 @@ class ComponentBase : public ITickable {
   ComponentBase(const ComponentBase& obj);
   virtual ~ComponentBase();
 
-  // クロック入力を受けるメソッド
-  // 外部から周期的に呼び出すという前提
+  // The methods to input clock. This will be called periodically.
   virtual void Tick(int count);
   virtual void FastTick(int fast_count);
 
  protected:
-  // クロックの分周率
-  // クロックは他所で指定された周波数で入力される
-  // コンポの動作周波数がそれよりも低い場合は、分周するとクロック周波数を下げることができる
-  // TODO:基本の周期は確定させたほうが良いだろう
-  int prescaler_;
-  //  Frequency scale factor for fast update
-  int fast_prescaler_ = 1;
+  int prescaler_;           //!< Frequency scale factor for normal update
+  int fast_prescaler_ = 1;  //!< Frequency scale factor for fast update
 
-  // クロックを分周した周期で呼び出されるメソッド
-  // 周期的な処理をここに書く（定期テレメ送信・コマンド受信など）
+  // The method periodically executed. The period is decided with the prescaler_ and the base clock.
   virtual void MainRoutine(int time_count) = 0;
 
   // Method used to calculate high-frequency disturbances(e.g. RW jitter)
   // Override only when high-frequency disturbances need to be calculated.
   virtual void FastUpdate(){};
+
+  // The method executed when the power switch is off.
+  virtual void PowerOffRoutine(){};
 
   ClockGenerator* clock_gen_;
   PowerPort* power_port_;

--- a/src/Component/Propulsion/SimpleThruster.cpp
+++ b/src/Component/Propulsion/SimpleThruster.cpp
@@ -50,8 +50,8 @@ void SimpleThruster::MainRoutine(int count) {
 }
 
 void SimpleThruster::PowerOffRoutine() {
-  thrust_b_(0.0);
-  torque_b_(0.0);
+  thrust_b_ *= 0.0;
+  torque_b_ *= 0.0;
 }
 
 void SimpleThruster::CalcThrust() {

--- a/src/Component/Propulsion/SimpleThruster.cpp
+++ b/src/Component/Propulsion/SimpleThruster.cpp
@@ -49,6 +49,11 @@ void SimpleThruster::MainRoutine(int count) {
   CalcTorque(structure_->GetKinematicsParams().GetCGb());
 }
 
+void SimpleThruster::PowerOffRoutine() {
+  thrust_b_(0.0);
+  torque_b_(0.0);
+}
+
 void SimpleThruster::CalcThrust() {
   double mag = CalcThrustMagnitude();
   if (duty_ > 0.0 + DBL_EPSILON) mag += mag_nr_;

--- a/src/Component/Propulsion/SimpleThruster.h
+++ b/src/Component/Propulsion/SimpleThruster.h
@@ -27,6 +27,7 @@ class SimpleThruster : public ComponentBase, public ILoggable {
 
   // ComponentBase override function
   void MainRoutine(int count);
+  void PowerOffRoutine() override;
 
   // ILogabble override function
   virtual std::string GetLogHeader() const;


### PR DESCRIPTION
## Overview
Add function driven when the component power off

## Issue
- #175 

## Details
- `PowerOffRoutine` function which is executed when the power switch is off was added on `ComponentBase`
- Actuator classes use the `PowerOffRoutine` function to stop the force and torque output.

##  Validation results
- Validated with private s2e-user for an ISSL's satellite project.

## Scope of influence
No bad effect for users who don't care about the power state.

## Supplement
NA

## Note
NA