### PR TITLE
[hotfix] Fix acceleration logging bug for RK4 and ENCKE

### DIFF
--- a/src/Dynamics/Orbit/EnckeOrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/EnckeOrbitPropagation.cpp
@@ -40,7 +40,6 @@ void EnckeOrbitPropagation::Propagate(double endtime, double current_jd) {
   Update();
   prop_time_s_ = endtime;
 
-  acc_i_ *= 0.0;  // Reset disturbance acceleration
   diff_position_i_m_[0] = state()[0];
   diff_position_i_m_[1] = state()[1];
   diff_position_i_m_[2] = state()[2];

--- a/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
@@ -74,7 +74,6 @@ void Rk4OrbitPropagation::Propagate(double endtime, double current_jd) {
   Update();
   prop_time_ = endtime;
 
-  acc_i_ *= 0;  // Reset disturbance acceleration
   sat_position_i_[0] = state()[0];
   sat_position_i_[1] = state()[1];
   sat_position_i_[2] = state()[2];


### PR DESCRIPTION
## Overview
Fix acceleration logging bug for RK4 and ENCKE.

## Issue
- #64 

## Details
The acceleration was reset to zero after the orbit propagation with RK4 and Encke.
It was no problem for propagation, but we could not get the acceleration log in CSV.
We don't need to reset the acceleration here since the spacecraft class reset the value at the appropriate timing.

##  Validation results
I confirmed that the RK4 orbit propagation result is completely the same before and after the modification.

## Scope of influence
small

## Supplement
NA

## Note
NA