### PR TITLE
[hotfix] Fix initial orbit to avoid zero inclination

### DIFF
--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -65,16 +65,20 @@ wgs = 2 // 0: wgs72old, 1: wgs72, 2: wgs84
 //////////////////////////////////////////////////////////////////////////
 
 // Initial value definition for RK4 //////////////////////////////////////
-// ＊The coordinate system is defined in PlanetSelect.ini
-// Initial satellite position[m] 
-init_position(0) = 4.2164140100E+07  // radius of GEO
-init_position(1) = 0
-init_position(2) = 0
+// * The coordinate system is defined in PlanetSelect.ini
+// * For KEPLER or ENCKE method, orbit with i = 0 cannot be handled now.
+//   Users need to set with small inclination. (This issue will be solved.)
+// Initial satellite position[m]
+// Example: ISS
+init_position(0) = -2111769.7723711144
+init_position(1) = -5360353.2254375768
+init_position(2) = 3596181.6497774957
 
 //initial satellite velocity[m/s]
-init_velocity(0) = 0
-init_velocity(1) = 3.074661E+03  // Speed of a spacecraft in GEO
-init_velocity(2) = 0
+// Example: ISS
+init_velocity(0) = 4200.4344740455268
+init_velocity(1) = -4637.540129059361
+init_velocity(2) = -4429.2361258448807
 ///////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
## Overview
Fix initial orbit to avoid zero inclination

## Issue
Related discussion: https://github.com/ut-issl/s2e-core/pull/177

## Details
ENCKE method and KEPLER method with `init_mode_kepler = INIT_POSVEL` cannot support zero inclination orbit now.  
Because the default initial value was zero inclination geosynchronous orbit, users cannot test the ENCKE and KEPLER with the default orbit.

##  Validation results
I confirmed KEPLER and ENCKE methods successfully work with these initial parameters.

## Scope of influence
small

## Supplement
Issue to completely solve this problem: https://github.com/ut-issl/s2e-core/issues/178

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
