### PR TITLE
Move nrlmsise tmp dir to build dir from install dir

### DIFF
--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -10,7 +10,7 @@ set(NRLMSISE_INSTALL_DIR ${EXT_LIB_DIR}/nrlmsise00)
 set(NRLMSISE_TABLE_URL_BASE ftp://ftp.agi.com/pub/DynamicEarthData)
 set(NRLMSISE_TABLE_FILE SpaceWeather-v1.2.txt)
 
-set(NRLMSISE_TMP_DIR ${NRLMSISE_INSTALL_DIR}/tmp)
+set(NRLMSISE_TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp)
 
 # download files
 # download source files


### PR DESCRIPTION
## Overview
SSIA

## Issue
- N/A

## Details
Current `ExtLibraries/nrlmsise00` CMake config will create temporary dir to install destination.
It should be move to build dir.

##  Validation results
Link to tests or validation results.

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
