### PR TITLE
Fix fast tick prescaler

### DIFF
--- a/src/Component/Abstract/ComponentBase.cpp
+++ b/src/Component/Abstract/ComponentBase.cpp
@@ -35,7 +35,7 @@ void ComponentBase::Tick(int count) {
 }
 
 void ComponentBase::FastTick(int count) {
-  if (count % prescaler_ > 0) return;
+  if (count % fast_prescaler_ > 0) return;
   if (power_port_->GetIsOn()) {
     FastUpdate();
   } else {


### PR DESCRIPTION
## Overview
Fix fast tick prescaler

## Issue
NA

## Details
The prescaler for FastTick was accidentally changed as normal prescaler, so I fixed it.

##  Validation results
NA

## Scope of influence
Small

## Supplement
NA

## Note
NA
