### PR TITLE
hotfix: Fix bug in GNSS satellite latitude calculation

### DIFF
--- a/src/Component/AOCS/GNSSReceiver.cpp
+++ b/src/Component/AOCS/GNSSReceiver.cpp
@@ -157,7 +157,7 @@ void GNSSReceiver::SetGnssInfo(Vector<3> ant2gnss_i, Quaternion q_i2b, std::stri
 
   double dist = norm(ant2gnss_c);
   double lon = AcTan(ant2gnss_c[1], ant2gnss_c[0]);
-  double lat = AcTan(ant2gnss_c[2], dist);
+  double lat = AcTan(ant2gnss_c[2], sqrt(pow(ant2gnss_c[0], 2.0) + pow(ant2gnss_c[1], 2.0)));
 
   GnssInfo gnss_info_new = {gnss_id, lat, lon, dist};
   vec_gnssinfo_.push_back(gnss_info_new);


### PR DESCRIPTION
## Overview
Fix bug of latitude calculation in GNSSReceiver class.

## Issue
- Related issues

## Details
The calculation of GNSS satellite latitude in GNSS receiver frame was wrong, which was `arctan(z / r)`. So I modified it to `\arctan(z / \sqrt{x^2 + y^2})`.

##  Validation results
GNSS skyplot seems correct.
![newplot (1)](https://user-images.githubusercontent.com/51637212/202842268-818d6fe1-1ba1-42a1-9f45-356b4699d2aa.png)


## Scope of influence
Users can get correct GNSS information from GNSSReceiver class.

## Supplement
NA

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
