### PR TITLE
Add GetStructure method to Spacecraft class

### DIFF
--- a/src/Simulation/Spacecraft/Spacecraft.h
+++ b/src/Simulation/Spacecraft/Spacecraft.h
@@ -34,6 +34,7 @@ class Spacecraft {
   inline const Dynamics& GetDynamics() const { return *dynamics_; }
   inline const LocalEnvironment& GetLocalEnv() const { return *local_env_; }
   inline const Disturbances& GetDisturbances() const { return *disturbances_; }
+  inline const Structure& GetStructure() const { return *structure_; }
   inline const InstalledComponents& GetInstalledComponents() const { return *components_; }
   inline int GetSatID() const { return sat_id_; }
 


### PR DESCRIPTION
## Overview
Add GetStructure method to Spacecraft class

## Issue
- N/A

## Details
For getting structure information from other class not in spacecraft. 

##  Validation results
Check CI

## Scope of influence
it is only const get, so no influence

## Supplement
N/A

## Note
