### PR TITLE
Read `ini` file in plot to get ground station position

### DIFF
--- a/scripts/Plot/plot_gs_visibility.py
+++ b/scripts/Plot/plot_gs_visibility.py
@@ -27,8 +27,6 @@ aparser = argparse.ArgumentParser()
 
 aparser.add_argument('--logs-dir', type=str, help='logs directory like "../../data/SampleSat/logs"', default='../../data/SampleSat/logs')
 aparser.add_argument('--file-tag', type=str, help='log file tag like 220627_142946')
-aparser.add_argument('--gs-lat', type=float, help='ground station lat(deg)')
-aparser.add_argument('--gs-lon', type=float, help='ground station lon(deg)')
 aparser.add_argument('--no-gui', action='store_true')
 
 args = aparser.parse_args()
@@ -47,20 +45,12 @@ if read_file_tag == None:
 
 print("log: " + read_file_tag)
 
-gs_lat_deg = args.gs_lat
-gs_lon_deg = args.gs_lon
-
 # Read Gound Station position from the ini file in the logs directory
 gs_ini_file_name  = path_to_logs + '/' + 'logs_' + read_file_tag + "/SampleGS.ini"
 configur = ConfigParser(comment_prefixes=('#', ';', '//'), inline_comment_prefixes=('#', ';', '//'))
 configur.read(gs_ini_file_name)
-gs_lat_in_inifile_deg = configur.getfloat('GS0', 'latitude_deg')
-gs_lon_in_inifile_deg = configur.getfloat('GS0', 'longitude_deg')
-
-if not gs_lat_deg:
-  gs_lat_deg = gs_lat_in_inifile_deg
-if not gs_lon_deg:
-  gs_lon_deg = gs_lon_in_inifile_deg
+gs_lat_deg = configur.getfloat('GS0', 'latitude_deg')
+gs_lon_deg = configur.getfloat('GS0', 'longitude_deg')
 
 #
 # CSV file name

--- a/scripts/Plot/plot_gs_visibility.py
+++ b/scripts/Plot/plot_gs_visibility.py
@@ -15,6 +15,8 @@ from mpl_toolkits.basemap import Basemap
 import matplotlib.pyplot as plt
 # csv
 import pandas
+# ini file
+from configparser import ConfigParser
 # local function
 from make_miller_projection_map import make_miller_projection_map
 from common import find_latest_log_tag
@@ -48,11 +50,17 @@ print("log: " + read_file_tag)
 gs_lat_deg = args.gs_lat
 gs_lon_deg = args.gs_lon
 
-# TODO: Read from the ini file in the logs directory
+# Read Gound Station position from the ini file in the logs directory
+gs_ini_file_name  = path_to_logs + '/' + 'logs_' + read_file_tag + "/SampleGS.ini"
+configur = ConfigParser(comment_prefixes=('#', ';', '//'), inline_comment_prefixes=('#', ';', '//'))
+configur.read(gs_ini_file_name)
+gs_lat_in_inifile_deg = configur.getfloat('GS0', 'latitude_deg')
+gs_lon_in_inifile_deg = configur.getfloat('GS0', 'longitude_deg')
+
 if not gs_lat_deg:
-  gs_lat_deg = 26.140837
+  gs_lat_deg = gs_lat_in_inifile_deg
 if not gs_lon_deg:
-  gs_lon_deg = 127.661483
+  gs_lon_deg = gs_lon_in_inifile_deg
 
 #
 # CSV file name

--- a/src/Simulation/GroundStation/GroundStation.cpp
+++ b/src/Simulation/GroundStation/GroundStation.cpp
@@ -35,6 +35,8 @@ void GroundStation::Initialize(int gs_id, SimulationConfig* config) {
   gs_position_ecef_ = gs_position_geo_.CalcEcefPosition();
 
   elevation_limit_angle_deg_ = conf.ReadDouble(Section, "elevation_limit_angle_deg");
+
+  config->main_logger_->CopyFileToLogDir(gs_ini_path);
 }
 
 void GroundStation::LogSetup(Logger& logger) { logger.AddLoggable(this); }


### PR DESCRIPTION
## Overview
Read `ini` file in plot to get ground station position.

## Issue
NA

## Details
The feature to read `ini` file was implemented in plot to get ground station position.  
I also add a code to save the `GS.ini` file in a log directory.

##  Validation results
We can get the same result as follows.

![image](https://user-images.githubusercontent.com/19573779/204305354-9eb600f0-8662-44ce-9e9c-dde7f6b61d36.png)

## Scope of influence
No effect

## Supplement
NA

## Note
NA