### PR TITLE
Add initialize mode for orbit

### DIFF
--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -71,7 +71,7 @@ wgs = 2 // 0: wgs72old, 1: wgs72, 2: wgs84
 //////////////////////////////////////////////////////////////////////////
 
 // Initial value definition for RK4 //////////////////////////////////////
-// * The coordinate system is defined in PlanetSelect.ini
+// * The coordinate system is defined at [PLANET_SELECTION] in SampleSimBase.ini
 // Initial satellite position[m]
 // Example: ISS
 init_position(0) = -2111769.7723711144
@@ -96,7 +96,7 @@ relative_dynamics_model_type = 0
 // 0: HCW
 stm_model_type = 0
 // Initial satellite position relative to the reference satellite in LVLH frame[m]
-// * The coordinate system is defined in PlanetSelect.ini
+// * The coordinate system is defined at [PLANET_SELECTION] in SampleSimBase.ini
 init_relative_position_lvlh(0) = 0.0
 init_relative_position_lvlh(1) = 100.0
 init_relative_position_lvlh(2) = 0.0

--- a/data/SampleSat/ini/SampleSat.ini
+++ b/data/SampleSat/ini/SampleSat.ini
@@ -55,6 +55,12 @@ logging = ENABLE
 // ENCKE    : Encke orbit propagation with disturbances and thruster maneuver
 propagate_mode = SGP4
 
+// Orbit initialize mode for RK4, KEPLER, and ENCKE
+// DEFAULT             : Use default initialize method (RK4 and ENCKE use pos/vel, KEPLER uses init_mode_kepler)
+// POSITION_VELOCITY_I : Initialize with position and velocity in the inertial frame
+// ORBITAL_ELEMENTS    : Initialize with orbital elements
+initialize_mode = ORBITAL_ELEMENTS
+
 // Settings for SGP4 ///////////////////////////////////////////////
 // TLE
 // Example: ISS
@@ -66,15 +72,13 @@ wgs = 2 // 0: wgs72old, 1: wgs72, 2: wgs84
 
 // Initial value definition for RK4 //////////////////////////////////////
 // * The coordinate system is defined in PlanetSelect.ini
-// * For KEPLER or ENCKE method, orbit with i = 0 cannot be handled now.
-//   Users need to set with small inclination. (This issue will be solved.)
 // Initial satellite position[m]
 // Example: ISS
 init_position(0) = -2111769.7723711144
 init_position(1) = -5360353.2254375768
 init_position(2) = 3596181.6497774957
 
-//initial satellite velocity[m/s]
+// Initial satellite velocity[m/s]
 // Example: ISS
 init_velocity(0) = 4200.4344740455268
 init_velocity(1) = -4637.540129059361
@@ -92,7 +96,7 @@ relative_dynamics_model_type = 0
 // 0: HCW
 stm_model_type = 0
 // Initial satellite position relative to the reference satellite in LVLH frame[m]
-// ＊The coordinate system is defined in PlanetSelect.ini
+// * The coordinate system is defined in PlanetSelect.ini
 init_relative_position_lvlh(0) = 0.0
 init_relative_position_lvlh(1) = 100.0
 init_relative_position_lvlh(2) = 0.0
@@ -106,10 +110,12 @@ reference_sat_id = 1
 
 
 // Information used for orbital propagation by the Kepler Motion ///////////
-// initialize mode for kepler motion
+// initialize mode for kepler motion.
+// WARNINGS: init_mode_kepler will be integrated with initialize_mode mentioned above
+//           The initialize_mode has higher priority than init_mode_kepler
 // INIT_POSVEL : initialize with position and velocity defined for RK4
 // INIT_OE : initialize with the following orbital elements
-init_mode_kepler = INIT_POSVEL
+init_mode_kepler = INIT_OE
 // Orbital Elements for INIT_OE
 semi_major_axis_m = 6794500.0
 eccentricity = 0.0015

--- a/src/Dynamics/Orbit/InitOrbit.cpp
+++ b/src/Dynamics/Orbit/InitOrbit.cpp
@@ -18,25 +18,32 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
   const char* section_ = section.c_str();
   Orbit* orbit;
 
+  // Initialize mode
+  OrbitInitializeMode initialize_mode = SetOrbitInitializeMode(conf.ReadString(section_, "initialize_mode"));
+
+  // Propagate mode
   std::string propagate_mode = conf.ReadString(section_, "propagate_mode");
 
-  if (propagate_mode == "RK4")  // initialize RK4 orbit propagator
-  {
-    Vector<3> init_pos;
-    conf.ReadVector<3>(section_, "init_position", init_pos);
-    Vector<3> init_veloc;
-    conf.ReadVector<3>(section_, "init_velocity", init_veloc);
-
-    orbit = new Rk4OrbitPropagation(celes_info, gravity_constant, stepSec, init_pos, init_veloc);
-  } else if (propagate_mode == "SGP4") {  // Initialize SGP4 orbit propagator
+  if (propagate_mode == "RK4") {
+    // initialize RK4 orbit propagator
+    Vector<3> position_i_m;
+    Vector<3> velocity_i_m_s;
+    Vector<6> pos_vel = InitializePosVel(ini_path, current_jd, gravity_constant);
+    for (size_t i = 0; i < 3; i++) {
+      position_i_m[i] = pos_vel[i];
+      velocity_i_m_s[i] = pos_vel[i + 3];
+    }
+    orbit = new Rk4OrbitPropagation(celes_info, gravity_constant, stepSec, position_i_m, velocity_i_m_s);
+  } else if (propagate_mode == "SGP4") {
+    // Initialize SGP4 orbit propagator
     int wgs = conf.ReadInt(section_, "wgs");
     char tle1[80], tle2[80];
     conf.ReadChar(section_, "tle1", 80, tle1);
     conf.ReadChar(section_, "tle2", 80, tle2);
 
     orbit = new Sgp4OrbitPropagation(celes_info, tle1, tle2, wgs, current_jd);
-  } else if (propagate_mode == "RELATIVE")  // initialize orbit for relative dynamics of formation flying
-  {
+  } else if (propagate_mode == "RELATIVE") {
+    // initialize orbit for relative dynamics of formation flying
     RelativeOrbit::RelativeOrbitUpdateMethod update_method =
         (RelativeOrbit::RelativeOrbitUpdateMethod)(conf.ReadInt(section_, "relative_orbit_update_method"));
     RelativeOrbitModel relative_dynamics_model_type = (RelativeOrbitModel)(conf.ReadInt(section_, "relative_dynamics_model_type"));
@@ -54,17 +61,21 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
     orbit = new RelativeOrbit(celes_info, gravity_constant, stepSec, reference_sat_id, init_relative_position_lvlh, init_relative_velocity_lvlh,
                               update_method, relative_dynamics_model_type, stm_model_type, rel_info);
   } else if (propagate_mode == "KEPLER") {
+    // initialize orbit for Kepler propagation
     std::string init_mode_kepler = conf.ReadString(section_, "init_mode_kepler");
     double mu_m3_s2 = gravity_constant;
     OrbitalElements oe;
-    if (init_mode_kepler == "INIT_POSVEL") {
+    // TODO: init_mode_kepler should be removed in the next major update
+    if ((init_mode_kepler == "INIT_POSVEL" && initialize_mode == OrbitInitializeMode::kDefault) ||
+        initialize_mode == OrbitInitializeMode::kInertialPositionAndVelocity) {
       // initialize with position and velocity
       Vector<3> init_pos_m;
       conf.ReadVector<3>(section_, "init_position", init_pos_m);
       Vector<3> init_vel_m_s;
       conf.ReadVector<3>(section_, "init_velocity", init_vel_m_s);
       oe = OrbitalElements(mu_m3_s2, current_jd, init_pos_m, init_vel_m_s);
-    } else if (init_mode_kepler == "INIT_OE") {
+    } else if ((init_mode_kepler == "INIT_OE" && initialize_mode == OrbitInitializeMode::kDefault) ||
+               initialize_mode == OrbitInitializeMode::kOrbitalElements) {
       // initialize with orbital elements
       double semi_major_axis_m = conf.ReadDouble(section_, "semi_major_axis_m");
       double eccentricity = conf.ReadDouble(section_, "eccentricity");
@@ -79,25 +90,72 @@ Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, d
     KeplerOrbit kepler_orbit(mu_m3_s2, oe);
     orbit = new KeplerOrbitPropagation(celes_info, current_jd, kepler_orbit);
   } else if (propagate_mode == "ENCKE") {
-    Vector<3> init_pos_m;
-    conf.ReadVector<3>(section_, "init_position", init_pos_m);
-    Vector<3> init_vel_m_s;
-    conf.ReadVector<3>(section_, "init_velocity", init_vel_m_s);
+    // initialize orbit for Encke's method
+    Vector<3> position_i_m;
+    Vector<3> velocity_i_m_s;
+    Vector<6> pos_vel = InitializePosVel(ini_path, current_jd, gravity_constant);
+    for (size_t i = 0; i < 3; i++) {
+      position_i_m[i] = pos_vel[i];
+      velocity_i_m_s[i] = pos_vel[i + 3];
+    }
+
     double error_tolerance = conf.ReadDouble(section_, "error_tolerance");
-    orbit = new EnckeOrbitPropagation(celes_info, gravity_constant, stepSec, current_jd, init_pos_m, init_vel_m_s, error_tolerance);
+    orbit = new EnckeOrbitPropagation(celes_info, gravity_constant, stepSec, current_jd, position_i_m, velocity_i_m_s, error_tolerance);
   } else {
     std::cerr << "ERROR: orbit propagation mode: " << propagate_mode << " is not defined!" << std::endl;
     std::cerr << "The orbit mode is automatically set as RK4" << std::endl;
 
-    Vector<3> init_pos;
-    conf.ReadVector<3>(section_, "init_position", init_pos);
-    Vector<3> init_veloc;
-    conf.ReadVector<3>(section_, "init_velocity", init_veloc);
-
-    orbit = new Rk4OrbitPropagation(celes_info, gravity_constant, stepSec, init_pos, init_veloc);
+    Vector<3> position_i_m;
+    Vector<3> velocity_i_m_s;
+    Vector<6> pos_vel = InitializePosVel(ini_path, current_jd, gravity_constant);
+    for (size_t i = 0; i < 3; i++) {
+      position_i_m[i] = pos_vel[i];
+      velocity_i_m_s[i] = pos_vel[i + 3];
+    }
+    orbit = new Rk4OrbitPropagation(celes_info, gravity_constant, stepSec, position_i_m, velocity_i_m_s);
   }
 
   orbit->SetIsCalcEnabled(conf.ReadEnable(section_, "calculation"));
   orbit->IsLogEnabled = conf.ReadEnable(section_, "logging");
   return orbit;
+}
+
+Vector<6> InitializePosVel(std::string ini_path, double current_jd, double mu_m3_s2, std::string section) {
+  auto conf = IniAccess(ini_path);
+  const char* section_ = section.c_str();
+  Vector<3> position_i_m;
+  Vector<3> velocity_i_m_s;
+  Vector<6> pos_vel;
+
+  OrbitInitializeMode initialize_mode = SetOrbitInitializeMode(conf.ReadString(section_, "initialize_mode"));
+  if (initialize_mode == OrbitInitializeMode::kOrbitalElements) {
+    double semi_major_axis_m = conf.ReadDouble(section_, "semi_major_axis_m");
+    double eccentricity = conf.ReadDouble(section_, "eccentricity");
+    double inclination_rad = conf.ReadDouble(section_, "inclination_rad");
+    double raan_rad = conf.ReadDouble(section_, "raan_rad");
+    double arg_perigee_rad = conf.ReadDouble(section_, "arg_perigee_rad");
+    double epoch_jday = conf.ReadDouble(section_, "epoch_jday");
+    OrbitalElements oe(epoch_jday, semi_major_axis_m, eccentricity, inclination_rad, raan_rad, arg_perigee_rad);
+    KeplerOrbit kepler_orbit(mu_m3_s2, oe);
+
+    kepler_orbit.CalcPosVel(current_jd);
+    position_i_m = kepler_orbit.GetPosition_i_m();
+    velocity_i_m_s = kepler_orbit.GetVelocity_i_m_s();
+  } else if (initialize_mode == OrbitInitializeMode::kInertialPositionAndVelocity) {
+    conf.ReadVector<3>(section_, "init_position", position_i_m);
+    conf.ReadVector<3>(section_, "init_velocity", velocity_i_m_s);
+  } else {
+    std::cerr << "WARNINGS: orbit initialize mode is not defined!" << std::endl;
+    std::cerr << "The orbit is automatically initialized as default mode" << std::endl;
+
+    conf.ReadVector<3>(section_, "init_position", position_i_m);
+    conf.ReadVector<3>(section_, "init_velocity", velocity_i_m_s);
+  }
+
+  for (size_t i = 0; i < 3; i++) {
+    pos_vel[i] = position_i_m[i];
+    pos_vel[i + 3] = velocity_i_m_s[i];
+  }
+
+  return pos_vel;
 }

--- a/src/Dynamics/Orbit/InitOrbit.hpp
+++ b/src/Dynamics/Orbit/InitOrbit.hpp
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <Library/Orbit/OrbitalElements.h>
+
 #include "Orbit.h"
 
 class RelativeInformation;
@@ -21,3 +23,13 @@ class RelativeInformation;
  */
 Orbit* InitOrbit(const CelestialInformation* celes_info, std::string ini_path, double stepSec, double current_jd, double gravity_constant,
                  std::string section = "ORBIT", RelativeInformation* rel_info = (RelativeInformation*)nullptr);
+
+/**
+ * @fn InitializePosVel
+ * @brief Initialize position and velocity depends on initialize mode
+ * @param [in] ini_path: Path to initialize file
+ * @param [in] current_jd: Current Julian day [day]
+ * @param [in] mu_m3_s2: Gravity constant [m3/s2]
+ * @param [in] section: Section name
+ */
+Vector<6> InitializePosVel(std::string ini_path, double current_jd, double mu_m3_s2, std::string section = "ORBIT");

--- a/src/Dynamics/Orbit/Orbit.cpp
+++ b/src/Dynamics/Orbit/Orbit.cpp
@@ -40,3 +40,15 @@ void Orbit::TransEciToEcef(void) {
 }
 
 void Orbit::TransEcefToGeo(void) { sat_position_geo_.UpdateFromEcef(sat_position_ecef_); }
+
+OrbitInitializeMode SetOrbitInitializeMode(const std::string initialize_mode) {
+  if (initialize_mode == "DEFAULT") {
+    return OrbitInitializeMode::kDefault;
+  } else if (initialize_mode == "POSITION_VELOCITY_I") {
+    return OrbitInitializeMode::kInertialPositionAndVelocity;
+  } else if (initialize_mode == "ORBITAL_ELEMENTS") {
+    return OrbitInitializeMode::kOrbitalElements;
+  } else {
+    return OrbitInitializeMode::kDefault;
+  }
+}

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -22,6 +22,18 @@ using libra::Vector;
 #include <Library/Geodesy/GeodeticPosition.hpp>
 
 /**
+ * @enum PROPAGATE_MODE
+ * @brief Propagation mode of orbit
+ */
+enum class PROPAGATE_MODE {
+  RK4 = 0,         //!< 4th order Runge-Kutta propagation with disturbances and thruster maneuver
+  SGP4,            //!< SGP4 propagation using TLE without thruster maneuver
+  RELATIVE_ORBIT,  //!< Relative dynamics (for formation flying simulation)
+  KEPLER,          //!< Kepler orbit propagation without disturbances and thruster maneuver
+  ENCKE            //!< Encke orbit propagation with disturbances and thruster maneuver
+};
+
+/**
  * @class Orbit
  * @brief Base class of orbit propagation
  */
@@ -38,12 +50,6 @@ class Orbit : public ILoggable {
    * @brief Destructor
    */
   virtual ~Orbit() {}
-
-  /**
-   * @enum PROPAGATE_MODE
-   * @brief Propagation mode of orbit
-   */
-  enum class PROPAGATE_MODE { RK4 = 0, SGP4, RELATIVE_ORBIT, KEPLER, ENCKE };
 
   /**
    * @fn Propagate

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -22,10 +22,10 @@ using libra::Vector;
 #include <Library/Geodesy/GeodeticPosition.hpp>
 
 /**
- * @enum ORBIT_PROPAGATE_MODE
+ * @enum OrbitPropagateMode
  * @brief Propagation mode of orbit
  */
-enum class ORBIT_PROPAGATE_MODE {
+enum class OrbitPropagateMode {
   RK4 = 0,         //!< 4th order Runge-Kutta propagation with disturbances and thruster maneuver
   SGP4,            //!< SGP4 propagation using TLE without thruster maneuver
   RELATIVE_ORBIT,  //!< Relative dynamics (for formation flying simulation)
@@ -84,7 +84,7 @@ class Orbit : public ILoggable {
    * @fn GetPropagateMode
    * @brief Return propagate mode
    */
-  inline ORBIT_PROPAGATE_MODE GetPropagateMode() const { return propagate_mode_; }
+  inline OrbitPropagateMode GetPropagateMode() const { return propagate_mode_; }
   /**
    * @fn GetSatPosition_i
    * @brief Return spacecraft position in the inertial frame [m]
@@ -189,7 +189,7 @@ class Orbit : public ILoggable {
 
   // Settings
   bool is_calc_enabled_ = false;   //!< Calculate flag
-  ORBIT_PROPAGATE_MODE propagate_mode_;  //!< Propagation mode
+  OrbitPropagateMode propagate_mode_;  //!< Propagation mode
 
   Vector<3> sat_position_i_;           //!< Spacecraft position in the inertial frame [m]
   Vector<3> sat_position_ecef_;        //!< Spacecraft position in the ECEF frame [m]

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -25,7 +25,7 @@ using libra::Vector;
  * @enum PROPAGATE_MODE
  * @brief Propagation mode of orbit
  */
-enum class PROPAGATE_MODE {
+enum class ORBIT_PROPAGATE_MODE {
   RK4 = 0,         //!< 4th order Runge-Kutta propagation with disturbances and thruster maneuver
   SGP4,            //!< SGP4 propagation using TLE without thruster maneuver
   RELATIVE_ORBIT,  //!< Relative dynamics (for formation flying simulation)
@@ -84,7 +84,7 @@ class Orbit : public ILoggable {
    * @fn GetPropagateMode
    * @brief Return propagate mode
    */
-  inline PROPAGATE_MODE GetPropagateMode() const { return propagate_mode_; }
+  inline ORBIT_PROPAGATE_MODE GetPropagateMode() const { return propagate_mode_; }
   /**
    * @fn GetSatPosition_i
    * @brief Return spacecraft position in the inertial frame [m]
@@ -189,7 +189,7 @@ class Orbit : public ILoggable {
 
   // Settings
   bool is_calc_enabled_ = false;   //!< Calculate flag
-  PROPAGATE_MODE propagate_mode_;  //!< Propagation mode
+  ORBIT_PROPAGATE_MODE propagate_mode_;  //!< Propagation mode
 
   Vector<3> sat_position_i_;           //!< Spacecraft position in the inertial frame [m]
   Vector<3> sat_position_ecef_;        //!< Spacecraft position in the ECEF frame [m]

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -34,6 +34,16 @@ enum class OrbitPropagateMode {
 };
 
 /**
+ * @enum OrbitInitializeMode
+ * @brief Initialize mode of orbit
+ */
+enum class OrbitInitializeMode {
+  kDefault = 0,                  //!< Default
+  kInertialPositionAndVelocity,  //!< Position and velocity in the inertial frame
+  kOrbitalElements,              //!< Orbital elements
+};
+
+/**
  * @class Orbit
  * @brief Base class of orbit propagation
  */
@@ -188,8 +198,9 @@ class Orbit : public ILoggable {
   const CelestialInformation* celes_info_;  //!< Celestial information
 
   // Settings
-  bool is_calc_enabled_ = false;       //!< Calculate flag
-  OrbitPropagateMode propagate_mode_;  //!< Propagation mode
+  bool is_calc_enabled_ = false;         //!< Calculate flag
+  OrbitPropagateMode propagate_mode_;    //!< Propagation mode
+  OrbitInitializeMode initialize_mode_;  // A< Initialize mode
 
   Vector<3> sat_position_i_;           //!< Spacecraft position in the inertial frame [m]
   Vector<3> sat_position_ecef_;        //!< Spacecraft position in the ECEF frame [m]
@@ -214,5 +225,7 @@ class Orbit : public ILoggable {
    */
   void TransEcefToGeo(void);
 };
+
+OrbitInitializeMode SetOrbitInitializeMode(const std::string initialize_mode);
 
 #endif  //__orbit_H__

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -26,11 +26,11 @@ using libra::Vector;
  * @brief Propagation mode of orbit
  */
 enum class OrbitPropagateMode {
-  RK4 = 0,         //!< 4th order Runge-Kutta propagation with disturbances and thruster maneuver
-  SGP4,            //!< SGP4 propagation using TLE without thruster maneuver
-  RELATIVE_ORBIT,  //!< Relative dynamics (for formation flying simulation)
-  KEPLER,          //!< Kepler orbit propagation without disturbances and thruster maneuver
-  ENCKE            //!< Encke orbit propagation with disturbances and thruster maneuver
+  kRk4 = 0,        //!< 4th order Runge-Kutta propagation with disturbances and thruster maneuver
+  kSgp4,           //!< SGP4 propagation using TLE without thruster maneuver
+  kRelativeOrbit,  //!< Relative dynamics (for formation flying simulation)
+  kKepler,         //!< Kepler orbit propagation without disturbances and thruster maneuver
+  kEncke           //!< Encke orbit propagation with disturbances and thruster maneuver
 };
 
 /**
@@ -188,7 +188,7 @@ class Orbit : public ILoggable {
   const CelestialInformation* celes_info_;  //!< Celestial information
 
   // Settings
-  bool is_calc_enabled_ = false;   //!< Calculate flag
+  bool is_calc_enabled_ = false;       //!< Calculate flag
   OrbitPropagateMode propagate_mode_;  //!< Propagation mode
 
   Vector<3> sat_position_i_;           //!< Spacecraft position in the inertial frame [m]

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -22,7 +22,7 @@ using libra::Vector;
 #include <Library/Geodesy/GeodeticPosition.hpp>
 
 /**
- * @enum PROPAGATE_MODE
+ * @enum ORBIT_PROPAGATE_MODE
  * @brief Propagation mode of orbit
  */
 enum class ORBIT_PROPAGATE_MODE {

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -198,8 +198,8 @@ class Orbit : public ILoggable {
   const CelestialInformation* celes_info_;  //!< Celestial information
 
   // Settings
-  bool is_calc_enabled_ = false;         //!< Calculate flag
-  OrbitPropagateMode propagate_mode_;    //!< Propagation mode
+  bool is_calc_enabled_ = false;       //!< Calculate flag
+  OrbitPropagateMode propagate_mode_;  //!< Propagation mode
 
   Vector<3> sat_position_i_;           //!< Spacecraft position in the inertial frame [m]
   Vector<3> sat_position_ecef_;        //!< Spacecraft position in the ECEF frame [m]

--- a/src/Dynamics/Orbit/Orbit.h
+++ b/src/Dynamics/Orbit/Orbit.h
@@ -200,7 +200,6 @@ class Orbit : public ILoggable {
   // Settings
   bool is_calc_enabled_ = false;         //!< Calculate flag
   OrbitPropagateMode propagate_mode_;    //!< Propagation mode
-  OrbitInitializeMode initialize_mode_;  // A< Initialize mode
 
   Vector<3> sat_position_i_;           //!< Spacecraft position in the inertial frame [m]
   Vector<3> sat_position_ecef_;        //!< Spacecraft position in the ECEF frame [m]

--- a/src/Dynamics/Orbit/RelativeOrbit.cpp
+++ b/src/Dynamics/Orbit/RelativeOrbit.cpp
@@ -20,7 +20,7 @@ RelativeOrbit::RelativeOrbit(const CelestialInformation* celes_info, double mu, 
       relative_dynamics_model_type_(relative_dynamics_model_type),
       stm_model_type_(stm_model_type),
       rel_info_(rel_info) {
-  propagate_mode_ = OrbitPropagateMode::RELATIVE_ORBIT;
+  propagate_mode_ = OrbitPropagateMode::kRelativeOrbit;
 
   prop_time_ = 0.0;
   prop_step_ = timestep;

--- a/src/Dynamics/Orbit/RelativeOrbit.cpp
+++ b/src/Dynamics/Orbit/RelativeOrbit.cpp
@@ -20,7 +20,7 @@ RelativeOrbit::RelativeOrbit(const CelestialInformation* celes_info, double mu, 
       relative_dynamics_model_type_(relative_dynamics_model_type),
       stm_model_type_(stm_model_type),
       rel_info_(rel_info) {
-  propagate_mode_ = PROPAGATE_MODE::RELATIVE_ORBIT;
+  propagate_mode_ = ORBIT_PROPAGATE_MODE::RELATIVE_ORBIT;
 
   prop_time_ = 0.0;
   prop_step_ = timestep;

--- a/src/Dynamics/Orbit/RelativeOrbit.cpp
+++ b/src/Dynamics/Orbit/RelativeOrbit.cpp
@@ -20,7 +20,7 @@ RelativeOrbit::RelativeOrbit(const CelestialInformation* celes_info, double mu, 
       relative_dynamics_model_type_(relative_dynamics_model_type),
       stm_model_type_(stm_model_type),
       rel_info_(rel_info) {
-  propagate_mode_ = ORBIT_PROPAGATE_MODE::RELATIVE_ORBIT;
+  propagate_mode_ = OrbitPropagateMode::RELATIVE_ORBIT;
 
   prop_time_ = 0.0;
   prop_step_ = timestep;

--- a/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
@@ -13,7 +13,7 @@ using std::string;
 Rk4OrbitPropagation::Rk4OrbitPropagation(const CelestialInformation* celes_info, double mu, double timestep, Vector<3> init_position,
                                          Vector<3> init_velocity, double init_time)
     : Orbit(celes_info), ODE<N>(timestep), mu(mu) {
-  propagate_mode_ = PROPAGATE_MODE::RK4;
+  propagate_mode_ = ORBIT_PROPAGATE_MODE::RK4;
 
   prop_time_ = 0.0;
   prop_step_ = timestep;

--- a/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
@@ -13,7 +13,7 @@ using std::string;
 Rk4OrbitPropagation::Rk4OrbitPropagation(const CelestialInformation* celes_info, double mu, double timestep, Vector<3> init_position,
                                          Vector<3> init_velocity, double init_time)
     : Orbit(celes_info), ODE<N>(timestep), mu(mu) {
-  propagate_mode_ = OrbitPropagateMode::RK4;
+  propagate_mode_ = OrbitPropagateMode::kRk4;
 
   prop_time_ = 0.0;
   prop_step_ = timestep;

--- a/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/Rk4OrbitPropagation.cpp
@@ -13,7 +13,7 @@ using std::string;
 Rk4OrbitPropagation::Rk4OrbitPropagation(const CelestialInformation* celes_info, double mu, double timestep, Vector<3> init_position,
                                          Vector<3> init_velocity, double init_time)
     : Orbit(celes_info), ODE<N>(timestep), mu(mu) {
-  propagate_mode_ = ORBIT_PROPAGATE_MODE::RK4;
+  propagate_mode_ = OrbitPropagateMode::RK4;
 
   prop_time_ = 0.0;
   prop_step_ = timestep;

--- a/src/Dynamics/Orbit/Sgp4OrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/Sgp4OrbitPropagation.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 Sgp4OrbitPropagation::Sgp4OrbitPropagation(const CelestialInformation* celes_info, char* tle1, char* tle2, int wgs, double current_jd)
     : Orbit(celes_info) {
-  propagate_mode_ = ORBIT_PROPAGATE_MODE::SGP4;
+  propagate_mode_ = OrbitPropagateMode::SGP4;
 
   if (wgs == 0) {
     whichconst_ = wgs72old;

--- a/src/Dynamics/Orbit/Sgp4OrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/Sgp4OrbitPropagation.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 Sgp4OrbitPropagation::Sgp4OrbitPropagation(const CelestialInformation* celes_info, char* tle1, char* tle2, int wgs, double current_jd)
     : Orbit(celes_info) {
-  propagate_mode_ = PROPAGATE_MODE::SGP4;
+  propagate_mode_ = ORBIT_PROPAGATE_MODE::SGP4;
 
   if (wgs == 0) {
     whichconst_ = wgs72old;

--- a/src/Dynamics/Orbit/Sgp4OrbitPropagation.cpp
+++ b/src/Dynamics/Orbit/Sgp4OrbitPropagation.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 Sgp4OrbitPropagation::Sgp4OrbitPropagation(const CelestialInformation* celes_info, char* tle1, char* tle2, int wgs, double current_jd)
     : Orbit(celes_info) {
-  propagate_mode_ = OrbitPropagateMode::SGP4;
+  propagate_mode_ = OrbitPropagateMode::kSgp4;
 
   if (wgs == 0) {
     whichconst_ = wgs72old;


### PR DESCRIPTION
## Overview
Add initialize mode for orbit

## Issue
- #237 

## Details
To separate the propagate mode and initialize method of orbit, I added initialize mode for orbit. Currently, the following initialize method is available.
- RK4
  - Position and velocity in the inertial frame
  - Orbital elements
- SGP4
  - TLE
- RELATIVE
  - Relative position and velocity in the LVLH frame
- KEPLER
  - Position and velocity in the inertial frame
  - Orbital elements
- ENCKE
  - Position and velocity in the inertial frame
  - Orbital elements

For backward compatibility, when `initialize_mode` is not defined in `ini` file, the default initialize method is automatically used.

##  Validation results
I confirmed the correct orbit initialization.

## Scope of influence
Dynamics

## Supplement
NA

## Note
NA