### PR TITLE
Fix CMake minimum required version in ExtLibraries by FetchContent DOWNLOAD_NO_EXTRACT

### DIFF
--- a/ExtLibraries/CMakeLists.txt
+++ b/ExtLibraries/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(ExtLibraries)
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.18)
 
 # build config
 option(BUILD_64BIT "Build 64bit" OFF)

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(cspice)
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.18)
 
 include(ExternalProject)
 include(FetchContent)

--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(nrlmsise00)
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.18)
 
 include(ExternalProject)
 include(FetchContent)


### PR DESCRIPTION
## Overview
SSIA

## Issue/PR
- #286 

## Details
Write in detail.

##  Validation results
validate with below CMake versions
- CMake 3.13: failed by `FetchContent_MakeAvailable`
  - https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_makeavailable
- CMake 3.14: failed by `DOWNLOAD_NO_EXTRACT` option in `FetchContent`
- CMake 3.15: failed by `DOWNLOAD_NO_EXTRACT` option in `FetchContent`
- CMake 3.16: failed by `DOWNLOAD_NO_EXTRACT` option in `FetchContent`
- CMake 3.17: failed by `DOWNLOAD_NO_EXTRACT` option in `FetchContent`
- CMake 3.18: OK
- CMake 3.19: OK
- CMake 3.20: OK

## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
