### PR TITLE
Add functions to change structure information

### DIFF
--- a/src/Component/CMakeLists.txt
+++ b/src/Component/CMakeLists.txt
@@ -42,6 +42,8 @@ add_library(${PROJECT_NAME} STATIC
   CommGS/GScalculator.cpp
   CommGS/InitGsCalculator.cpp
 
+  Examples/ChangeStructure.cpp
+
   IdealComponents/ForceGenerator.cpp
   IdealComponents/InitializeForceGenerator.cpp
 

--- a/src/Component/Examples/ChangeStructure.cpp
+++ b/src/Component/Examples/ChangeStructure.cpp
@@ -1,0 +1,28 @@
+/**
+ * @file ChangeStructure.cpp
+ * @brief Class to show an example to change satellite structure information
+ */
+
+#include "ChangeStructure.hpp"
+
+ChangeStructure::ChangeStructure(ClockGenerator* clock_gen, Structure* structure) : ComponentBase(1, clock_gen), structure_(structure) {}
+
+ChangeStructure::~ChangeStructure() {}
+
+void ChangeStructure::MainRoutine(int count) {
+  if (count > 1000) {
+    structure_->GetToSetKinematicsParams().SetMass_kg(100.0);
+  }
+}
+
+std::string ChangeStructure::GetLogHeader() const {
+  std::string str_tmp = "";
+
+  return str_tmp;
+}
+
+std::string ChangeStructure::GetLogValue() const {
+  std::string str_tmp = "";
+
+  return str_tmp;
+}

--- a/src/Component/Examples/ChangeStructure.cpp
+++ b/src/Component/Examples/ChangeStructure.cpp
@@ -11,12 +11,16 @@ ChangeStructure::~ChangeStructure() {}
 
 void ChangeStructure::MainRoutine(int count) {
   if (count > 1000) {
+    // Mass
     structure_->GetToSetKinematicsParams().SetMass_kg(100.0);
+    // RMM
     Vector<3> rmm(0.0);
     rmm[0] = 0.1;
     rmm[1] = -0.1;
     rmm[2] = 0.2;
     structure_->GetToSetRMMParams().SetRmmConstant_b_Am2(rmm);
+    // Surface
+    structure_->GetToSetSurfaces()[0].SetArea(0.5);
   }
 }
 

--- a/src/Component/Examples/ChangeStructure.cpp
+++ b/src/Component/Examples/ChangeStructure.cpp
@@ -13,6 +13,12 @@ void ChangeStructure::MainRoutine(int count) {
   if (count > 1000) {
     // Mass
     structure_->GetToSetKinematicsParams().SetMass_kg(100.0);
+    // Center of gravity
+    Vector<3> cg(0.0);
+    cg[0] = 0.01;
+    cg[1] = -0.01;
+    cg[2] = 0.02;
+    structure_->GetToSetKinematicsParams().SetCenterOfGravityVector_b_m(cg);
     // RMM
     Vector<3> rmm(0.0);
     rmm[0] = 0.1;

--- a/src/Component/Examples/ChangeStructure.cpp
+++ b/src/Component/Examples/ChangeStructure.cpp
@@ -12,6 +12,11 @@ ChangeStructure::~ChangeStructure() {}
 void ChangeStructure::MainRoutine(int count) {
   if (count > 1000) {
     structure_->GetToSetKinematicsParams().SetMass_kg(100.0);
+    Vector<3> rmm(0.0);
+    rmm[0] = 0.1;
+    rmm[1] = -0.1;
+    rmm[2] = 0.2;
+    structure_->GetToSetRMMParams().SetRmmConstant_b_Am2(rmm);
   }
 }
 

--- a/src/Component/Examples/ChangeStructure.hpp
+++ b/src/Component/Examples/ChangeStructure.hpp
@@ -1,0 +1,56 @@
+/**
+ * @file ChangeStructure.hpp
+ * @brief Class to show an example to change satellite structure information
+ */
+
+#ifndef CHANGE_STRUCTURE_H_
+#define CHANGE_STRUCTURE_H_
+
+#include <Interface/LogOutput/ILoggable.h>
+#include <Simulation/Spacecraft/Structure/Structure.h>
+
+#include "../Abstract/ComponentBase.h"
+
+/**
+ * @class ChangeStructure
+ * @brief Class to show an example to change satellite structure information
+ */
+class ChangeStructure : public ComponentBase, public ILoggable {
+ public:
+  /**
+   * @fn ChangeStructure
+   * @brief Constructor with power port
+   * @param [in] clock_gen: Clock generator
+   * @param [in] structure: Structure information
+   */
+  ChangeStructure(ClockGenerator* clock_gen, Structure* structure);
+  /**
+   * @fn ~ChangeStructure
+   * @brief Destructor
+   */
+  ~ChangeStructure();
+
+  // Override functions for ComponentBase
+  /**
+   * @fn MainRoutine
+   * @brief Main routine for sensor observation
+   */
+  void MainRoutine(int count) override;
+
+  // Override ILoggable
+  /**
+   * @fn GetLogHeader
+   * @brief Override GetLogHeader function of ILoggable
+   */
+  virtual std::string GetLogHeader() const;
+  /**
+   * @fn GetLogValue
+   * @brief Override GetLogValue function of ILoggable
+   */
+  virtual std::string GetLogValue() const;
+
+ protected:
+  Structure* structure_;  //!< Structure information
+};
+
+#endif

--- a/src/Disturbance/Disturbances.cpp
+++ b/src/Disturbance/Disturbances.cpp
@@ -87,7 +87,7 @@ void Disturbances::InitializeInstances(const SimulationConfig* sim_config, const
   AirDrag* air_dist = new AirDrag(InitAirDrag(ini_fname_, structure->GetSurfaces(), structure->GetKinematicsParams().GetCGb()));
   disturbances_.push_back(air_dist);
 
-  MagDisturbance* mag_dist = new MagDisturbance(InitMagDisturbance(ini_fname_, structure->GetRMMParams()));
+  MagDisturbance* mag_dist = new MagDisturbance(InitMagDisturbance(ini_fname_, (structure->GetRMMParams())));
   disturbances_.push_back(mag_dist);
 
   GeoPotential* geopotential = new GeoPotential(InitGeoPotential(ini_fname_));

--- a/src/Disturbance/Disturbances.cpp
+++ b/src/Disturbance/Disturbances.cpp
@@ -87,7 +87,7 @@ void Disturbances::InitializeInstances(const SimulationConfig* sim_config, const
   AirDrag* air_dist = new AirDrag(InitAirDrag(ini_fname_, structure->GetSurfaces(), structure->GetKinematicsParams().GetCGb()));
   disturbances_.push_back(air_dist);
 
-  MagDisturbance* mag_dist = new MagDisturbance(InitMagDisturbance(ini_fname_, (structure->GetRMMParams())));
+  MagDisturbance* mag_dist = new MagDisturbance(InitMagDisturbance(ini_fname_, structure->GetRMMParams()));
   disturbances_.push_back(mag_dist);
 
   GeoPotential* geopotential = new GeoPotential(InitGeoPotential(ini_fname_));

--- a/src/Disturbance/GravityGradient.cpp
+++ b/src/Disturbance/GravityGradient.cpp
@@ -19,7 +19,8 @@ GravityGradient::GravityGradient() : GravityGradient(environment::earth_gravitat
 GravityGradient::GravityGradient(const double mu_m3_s2) : mu_m3_s2_(mu_m3_s2) { fill_up(torque_b_, 0.0); }
 
 void GravityGradient::Update(const LocalEnvironment& local_env, const Dynamics& dynamics) {
-  CalcTorque(local_env.GetCelesInfo().GetCenterBodyPosFromSC_b(), dynamics.GetAttitude().GetInertiaTensor());
+  CalcTorque(local_env.GetCelesInfo().GetCenterBodyPosFromSC_b(),
+             dynamics.GetAttitude().GetInertiaTensor());  // TODO: use structure information to get inertia tensor
 }
 
 Vector<3> GravityGradient::CalcTorque(const Vector<3> r_b_m, const Matrix<3, 3> I_b_kgm2) {

--- a/src/Disturbance/InitDisturbance.cpp
+++ b/src/Disturbance/InitDisturbance.cpp
@@ -65,11 +65,11 @@ GravityGradient InitGravityGradient(std::string ini_path, const double mu_m3_s2)
   return ggdist;
 }
 
-MagDisturbance InitMagDisturbance(std::string ini_path, RMMParams rmm_params) {
+MagDisturbance InitMagDisturbance(std::string ini_path, const RMMParams& rmm_params) {
   auto conf = IniAccess(ini_path);
   const char* section = "MAG_DISTURBANCE";
 
-  MagDisturbance mag_dist(rmm_params.GetRMMConst_b(), rmm_params.GetRMMRWDev(), rmm_params.GetRMMRWLimit(), rmm_params.GetRMMWNVar());
+  MagDisturbance mag_dist(rmm_params);
   mag_dist.IsCalcEnabled = conf.ReadEnable(section, CALC_LABEL);
   mag_dist.IsLogEnabled = conf.ReadEnable(section, LOG_LABEL);
 

--- a/src/Disturbance/InitDisturbance.cpp
+++ b/src/Disturbance/InitDisturbance.cpp
@@ -11,7 +11,7 @@
 #define LOG_LABEL "logging"
 #define MIN_VAL 1e-9
 
-AirDrag InitAirDrag(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3> cg_b) {
+AirDrag InitAirDrag(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3>& cg_b) {
   auto conf = IniAccess(ini_path);
   const char* section = "AIRDRAG";
 
@@ -29,7 +29,7 @@ AirDrag InitAirDrag(std::string ini_path, const std::vector<Surface>& surfaces, 
   return airdrag;
 }
 
-SolarRadiation InitSRDist(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3> cg_b) {
+SolarRadiation InitSRDist(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3>& cg_b) {
   auto conf = IniAccess(ini_path);
   const char* section = "SRDIST";
 

--- a/src/Disturbance/InitDisturbance.hpp
+++ b/src/Disturbance/InitDisturbance.hpp
@@ -20,7 +20,7 @@
  * @param [in] surfaces: surface information of the spacecraft
  * @param [in] cg_b: Center of gravity position vector at body frame [m]
  */
-AirDrag InitAirDrag(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3> cg_b);
+AirDrag InitAirDrag(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3>& cg_b);
 /**
  * @fn InitSRDist
  * @brief Initialize SolarRadiation class
@@ -28,7 +28,7 @@ AirDrag InitAirDrag(std::string ini_path, const std::vector<Surface>& surfaces, 
  * @param [in] surfaces: surface information of the spacecraft
  * @param [in] cg_b: Center of gravity position vector at body frame [m]
  */
-SolarRadiation InitSRDist(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3> cg_b);
+SolarRadiation InitSRDist(std::string ini_path, const std::vector<Surface>& surfaces, const Vector<3>& cg_b);
 
 /**
  * @fn InitGravityGradient

--- a/src/Disturbance/InitDisturbance.hpp
+++ b/src/Disturbance/InitDisturbance.hpp
@@ -50,7 +50,7 @@ GravityGradient InitGravityGradient(std::string ini_path, const double mu_m3_s2)
  * @param [in] ini_path: Initialize file path
  * @param [in] rmm_params: RMM parameters
  */
-MagDisturbance InitMagDisturbance(std::string ini_path, RMMParams rmm_params);
+MagDisturbance InitMagDisturbance(std::string ini_path, const RMMParams& rmm_params);
 /**
  * @fn InitGeoPotential
  * @brief Initialize GeoPotential class with earth gravitational constant

--- a/src/Disturbance/MagDisturbance.cpp
+++ b/src/Disturbance/MagDisturbance.cpp
@@ -15,13 +15,12 @@ using libra::NormalRand;
 
 using namespace std;
 
-MagDisturbance::MagDisturbance(const Vector<3>& rmm_const_b, const double rmm_rwdev, const double rmm_rwlimit, const double rmm_wnvar)
-    : rmm_const_b_(rmm_const_b), rmm_rwdev_(rmm_rwdev), rmm_rwlimit_(rmm_rwlimit), rmm_wnvar_(rmm_wnvar) {
+MagDisturbance::MagDisturbance(const RMMParams& rmm_params) : rmm_params_(rmm_params) {
   for (int i = 0; i < 3; ++i) {
     torque_b_[i] = 0;
   }
   mag_unit_ = 1.0E-9;  // [nT] -> [T]
-  rmm_b_ = rmm_const_b_;
+  rmm_b_ = rmm_params_.GetRMMConst_b();
 }
 
 Vector<3> MagDisturbance::CalcTorque(const Vector<3>& mag_b) {
@@ -37,12 +36,12 @@ void MagDisturbance::Update(const LocalEnvironment& local_env, const Dynamics& d
 }
 
 void MagDisturbance::CalcRMM() {
-  static Vector<3> stddev(rmm_rwdev_);
-  static Vector<3> limit(rmm_rwlimit_);
+  static Vector<3> stddev(rmm_params_.GetRMMRWDev());
+  static Vector<3> limit(rmm_params_.GetRMMRWLimit());
   static RandomWalk<3> rw(0.1, stddev, limit);
-  static NormalRand nr(0.0, rmm_wnvar_, g_rand.MakeSeed());
+  static NormalRand nr(0.0, rmm_params_.GetRMMWNVar(), g_rand.MakeSeed());
 
-  rmm_b_ = rmm_const_b_;
+  rmm_b_ = rmm_params_.GetRMMConst_b();
   for (int i = 0; i < 3; ++i) {
     rmm_b_[i] += rw[i] + nr;
   }

--- a/src/Disturbance/MagDisturbance.h
+++ b/src/Disturbance/MagDisturbance.h
@@ -20,19 +20,12 @@ using libra::Vector;
  * @brief Class to calculate the magnetic disturbance torque
  */
 class MagDisturbance : public SimpleDisturbance {
-  Vector<3> rmm_b_;        //!< True RMM of the spacecraft in the body frame [Am2]
-  double mag_unit_;        //!< Constant value to change the unit [nT] -> [T]
-  Vector<3> rmm_const_b_;  //!< Constant component of the RMM in the body frame [Am2]
-  double rmm_rwdev_;       //!< Standard deviation of random walk component of the RMM [Am2]
-  double rmm_rwlimit_;     //!< Limit of random walk component of the RMM [Am2]
-  double rmm_wnvar_;       //!< Standard deviation of white noise of the RMM [Am2]
-
  public:
   /**
    * @fn MagDisturbance
    * @brief Constructor
    */
-  MagDisturbance(const Vector<3>& rmm_const_b, const double rmm_rwdev, const double rmm_rwlimit, const double rmm_wnvar);
+  MagDisturbance(const RMMParams& rmm_params);
 
   /**
    * @fn CalcRMM
@@ -67,6 +60,12 @@ class MagDisturbance : public SimpleDisturbance {
    * @brief Override GetLogValue function of ILoggable
    */
   virtual std::string GetLogValue() const;
+
+ private:
+  double mag_unit_;  //!< Constant value to change the unit [nT] -> [T]
+
+  Vector<3> rmm_b_;              //!< True RMM of the spacecraft in the body frame [Am2]
+  const RMMParams& rmm_params_;  //!< RMM parameters
 };
 
 #endif  //__MagDisturbance_H__

--- a/src/Disturbance/SurfaceForce.h
+++ b/src/Disturbance/SurfaceForce.h
@@ -37,7 +37,7 @@ class SurfaceForce : public SimpleDisturbance {
  protected:
   // Spacecraft Structure parameters
   const vector<Surface>& surfaces_;  //!< List of surfaces
-  Vector<3> cg_b_;                   //!< Position vector of the center of mass at body frame [m]
+  const Vector<3>& cg_b_;            //!< Position vector of the center of mass at body frame [m]
 
   // Internal calculated variables
   vector<double> normal_coef_;      //!< coefficients for out-plane force for each surface

--- a/src/Dynamics/Dynamics.cpp
+++ b/src/Dynamics/Dynamics.cpp
@@ -22,7 +22,7 @@ Dynamics::~Dynamics() {
 
 void Dynamics::Initialize(SimulationConfig* sim_config, const SimTime* sim_time, const LocalCelestialInformation* local_celes_info, const int sat_id,
                           Structure* structure, RelativeInformation* rel_info) {
-  mass_ = structure->GetKinematicsParams().GetMass();
+  structure_ = structure;
 
   // Initialize
   orbit_ = InitOrbit(&(local_celes_info->GetGlobalInfo()), sim_config->sat_file_[sat_id], sim_time->GetOrbitRKStepSec(), sim_time->GetCurrentJd(),
@@ -70,7 +70,9 @@ void Dynamics::LogSetup(Logger& logger) {
 
 void Dynamics::AddTorque_b(Vector<3> torque_b) { attitude_->AddTorque_b(torque_b); }
 
-void Dynamics::AddForce_b(Vector<3> force_b) { orbit_->AddForce_b(force_b, attitude_->GetQuaternion_i2b(), mass_); }
+void Dynamics::AddForce_b(Vector<3> force_b) {
+  orbit_->AddForce_b(force_b, attitude_->GetQuaternion_i2b(), structure_->GetKinematicsParams().GetMass());
+}
 
 void Dynamics::AddAcceleration_i(Vector<3> acceleration_i) { orbit_->AddAcceleration_i(acceleration_i); }
 

--- a/src/Dynamics/Dynamics.h
+++ b/src/Dynamics/Dynamics.h
@@ -119,8 +119,6 @@ class Dynamics {
    */
   inline Attitude& SetAttitude() const { return *attitude_; }
 
-  double mass_;  //!< Mass of spacecraft [kg] FIXME: Move to Structure
-
   /**
    * @fn GetPosition_i
    * @brief Return spacecraft position in the inertial frame [m]
@@ -134,9 +132,10 @@ class Dynamics {
   virtual Quaternion GetQuaternion_i2b() const;
 
  private:
-  Attitude* attitude_;        //!< Attitude dynamics
-  Orbit* orbit_;              //!< Orbit dynamics
-  Temperature* temperature_;  //!< Thermal dynamics
+  Attitude* attitude_;          //!< Attitude dynamics
+  Orbit* orbit_;                //!< Orbit dynamics
+  Temperature* temperature_;    //!< Thermal dynamics
+  const Structure* structure_;  //!< Structure information
 };
 
 #endif  //__dynamics_H__

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
@@ -9,7 +9,7 @@
 
 #include "Sample_PortConfig.h"
 
-SampleComponents::SampleComponents(const Dynamics* dynamics, const Structure* structure, const LocalEnvironment* local_env,
+SampleComponents::SampleComponents(const Dynamics* dynamics, Structure* structure, const LocalEnvironment* local_env,
                                    const GlobalEnvironment* glo_env, const SimulationConfig* config, ClockGenerator* clock_gen, const int sat_id)
     : config_(config), dynamics_(dynamics), structure_(structure), local_env_(local_env), glo_env_(glo_env) {
   IniAccess iniAccess = IniAccess(config_->sat_file_[sat_id]);
@@ -78,6 +78,9 @@ SampleComponents::SampleComponents(const Dynamics* dynamics, const Structure* st
   config_->main_logger_->CopyFileToLogDir(ini_path);
   antenna_ = new Antenna(InitAntenna(1, ini_path));
 
+  // ChangeStructure
+  change_structure_ = new ChangeStructure(clock_gen, structure_);
+
   // PCU power port initial control
   pcu_->GetPowerPort(0)->SetVoltage(3.3);
   pcu_->GetPowerPort(1)->SetVoltage(3.3);
@@ -120,6 +123,7 @@ SampleComponents::~SampleComponents() {
   delete thruster_;
   delete force_generator_;
   delete antenna_;
+  delete change_structure_;
   delete pcu_;
   // delete exp_hils_uart_responder_;
   // delete exp_hils_uart_sender_;

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
@@ -78,8 +78,8 @@ SampleComponents::SampleComponents(const Dynamics* dynamics, Structure* structur
   config_->main_logger_->CopyFileToLogDir(ini_path);
   antenna_ = new Antenna(InitAntenna(1, ini_path));
 
-  // ChangeStructure
-  change_structure_ = new ChangeStructure(clock_gen, structure_);
+  // ChangeStructure: Please uncomment the following line if you want to test the change_structure
+  // change_structure_ = new ChangeStructure(clock_gen, structure_);
 
   // PCU power port initial control
   pcu_->GetPowerPort(0)->SetVoltage(3.3);

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.cpp
@@ -78,7 +78,7 @@ SampleComponents::SampleComponents(const Dynamics* dynamics, Structure* structur
   config_->main_logger_->CopyFileToLogDir(ini_path);
   antenna_ = new Antenna(InitAntenna(1, ini_path));
 
-  // ChangeStructure: Please uncomment the following line if you want to test the change_structure
+  // ChangeStructure: Please uncomment change_structure related codes if you want to test the change_structure
   // change_structure_ = new ChangeStructure(clock_gen, structure_);
 
   // PCU power port initial control
@@ -123,7 +123,7 @@ SampleComponents::~SampleComponents() {
   delete thruster_;
   delete force_generator_;
   delete antenna_;
-  delete change_structure_;
+  // delete change_structure_;
   delete pcu_;
   // delete exp_hils_uart_responder_;
   // delete exp_hils_uart_sender_;

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.h
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.h
@@ -21,6 +21,7 @@
 #include <Component/AOCS/InitStt.hpp>
 #include <Component/AOCS/InitSunSensor.hpp>
 #include <Component/CommGS/InitAntenna.hpp>
+#include <Component/Examples/ChangeStructure.hpp>
 #include <Component/IdealComponents/InitializeForceGenerator.hpp>
 #include <Component/Propulsion/InitSimpleThruster.hpp>
 #include <Library/math/Vector.hpp>
@@ -49,7 +50,7 @@ class SampleComponents : public InstalledComponents {
    * @fn SampleComponents
    * @brief Constructor
    */
-  SampleComponents(const Dynamics* dynamics, const Structure* structure, const LocalEnvironment* local_env, const GlobalEnvironment* glo_env,
+  SampleComponents(const Dynamics* dynamics, Structure* structure, const LocalEnvironment* local_env, const GlobalEnvironment* glo_env,
                    const SimulationConfig* config, ClockGenerator* clock_gen, const int sat_id);
   /**
    * @fn ~SampleComponents
@@ -96,6 +97,9 @@ class SampleComponents : public InstalledComponents {
   // CommGs
   Antenna* antenna_;  //!< Antenna
 
+  // Examples
+  ChangeStructure* change_structure_;  //!< Change structure
+
   // HILS settings examples
   /*
   ExpHils* exp_hils_uart_responder_;               //!< Example of HILS UART responder
@@ -107,7 +111,7 @@ class SampleComponents : public InstalledComponents {
   // States
   const SimulationConfig* config_;     //!< Simulation settings
   const Dynamics* dynamics_;           //!< Dynamics information of the spacecraft
-  const Structure* structure_;         //!< Structure information of the spacecraft
+  Structure* structure_;               //!< Structure information of the spacecraft
   const LocalEnvironment* local_env_;  //!< Local environment information around the spacecraft
   const GlobalEnvironment* glo_env_;   //!< Global environment information
 };

--- a/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.h
+++ b/src/Simulation/Spacecraft/SampleSpacecraft/SampleComponents.h
@@ -98,7 +98,7 @@ class SampleComponents : public InstalledComponents {
   Antenna* antenna_;  //!< Antenna
 
   // Examples
-  ChangeStructure* change_structure_;  //!< Change structure
+  // ChangeStructure* change_structure_;  //!< Change structure
 
   // HILS settings examples
   /*

--- a/src/Simulation/Spacecraft/Structure/KinematicsParams.h
+++ b/src/Simulation/Spacecraft/Structure/KinematicsParams.h
@@ -44,6 +44,31 @@ class KinematicsParams {
    */
   inline const Matrix<3, 3>& GetInertiaTensor() const { return inertia_tensor_; }
 
+  // Setter
+  /**
+   * @fn SetCenterOfGravityVector_b_m
+   * @brief Set center of gravity vector at the body frame [m]
+   * @param [in] center_of_gravity_vector_b_m: Center of gravity vector at the body frame [m]
+   */
+  inline void SetCenterOfGravityVector_b_m(const Vector<3> center_of_gravity_vector_b_m) { cg_b_ = center_of_gravity_vector_b_m; }
+  /**
+   * @fn SetMass_kg
+   * @brief Set mass of the satellite
+   * @param [in] mass_kg: Mass of the satellite [kg]
+   */
+  inline void SetMass_kg(const double mass_kg) {
+    if (mass_kg > 0.0) mass_ = mass_kg;
+  }
+  /**
+   * @fn SetInertiaTensor_b_kgm2
+   * @brief Inertia tensor at body frame
+   * @param [in] inertia_tensor_b_kgm2: Inertia tensor at body frame [kgm2]
+   */
+  inline void SetInertiaTensor_b_kgm2(const Matrix<3, 3> inertia_tensor_b_kgm2) {
+    // TODO add assertion check
+    inertia_tensor_ = inertia_tensor_b_kgm2;
+  }
+
  private:
   Vector<3> cg_b_;               //!< Position vector of center of gravity at body frame [m]
   double mass_;                  //!< Mass of the satellite [kg]

--- a/src/Simulation/Spacecraft/Structure/KinematicsParams.h
+++ b/src/Simulation/Spacecraft/Structure/KinematicsParams.h
@@ -60,6 +60,16 @@ class KinematicsParams {
     if (mass_kg > 0.0) mass_ = mass_kg;
   }
   /**
+   * @fn AddMass_kg
+   * @brief Add mass of the satellite
+   * @param [in] mass_kg: Mass of the satellite [kg]
+   * @note Normally, this function is used to decrease the mass due to the fuel consumption.
+   */
+  inline void AddMass_kg(const double mass_kg) {
+    mass_ += mass_kg;
+    if (mass_ < 0.0) mass_ = 0.0;
+  }
+  /**
    * @fn SetInertiaTensor_b_kgm2
    * @brief Inertia tensor at body frame
    * @param [in] inertia_tensor_b_kgm2: Inertia tensor at body frame [kgm2]

--- a/src/Simulation/Spacecraft/Structure/KinematicsParams.h
+++ b/src/Simulation/Spacecraft/Structure/KinematicsParams.h
@@ -66,8 +66,8 @@ class KinematicsParams {
    * @note Normally, this function is used to decrease the mass due to the fuel consumption.
    */
   inline void AddMass_kg(const double mass_kg) {
-    mass_ += mass_kg;
-    if (mass_ < 0.0) mass_ = 0.0;
+    double temp_mass_kg = mass_ + mass_kg;
+    SetMass_kg(temp_mass_kg);
   }
   /**
    * @fn SetInertiaTensor_b_kgm2

--- a/src/Simulation/Spacecraft/Structure/RMMParams.h
+++ b/src/Simulation/Spacecraft/Structure/RMMParams.h
@@ -53,6 +53,12 @@ class RMMParams {
    * @param [in] rmm_const_b_Am2: Constant value of RMM at the body frame [Am2]
    */
   inline void SetRMMConst_b_Am2(const Vector<3> rmm_const_b_Am2) { rmm_const_b_ = rmm_const_b_Am2; }
+  /**
+   * @fn AddRMMConst_b_Am2
+   * @brief Add Constant value of RMM at body frame [Am2]
+   * @param [in] rmm_const_b_Am2: Constant value of RMM at the body frame [Am2]
+   */
+  inline void AddRMMConst_b_Am2(const Vector<3> rmm_const_b_Am2) { rmm_const_b_ += rmm_const_b_Am2; }
 
  private:
   Vector<3> rmm_const_b_;  //!< Constant value of RMM at body frame [Am2]

--- a/src/Simulation/Spacecraft/Structure/RMMParams.h
+++ b/src/Simulation/Spacecraft/Structure/RMMParams.h
@@ -46,6 +46,14 @@ class RMMParams {
    */
   inline const double& GetRMMWNVar(void) const { return rmm_wnvar_; }
 
+  // Setter
+  /**
+   * @fn SetRMMConst_b_Am2
+   * @brief Set Constant value of RMM at body frame [Am2]
+   * @param [in] rmm_const_b_Am2: Constant value of RMM at the body frame [Am2]
+   */
+  inline void SetRMMConst_b_Am2(const Vector<3> rmm_const_b_Am2) { rmm_const_b_ = rmm_const_b_Am2; }
+
  private:
   Vector<3> rmm_const_b_;  //!< Constant value of RMM at body frame [Am2]
   double rmm_rwdev_;       //!< Random walk standard deviation of RMM [Am2]

--- a/src/Simulation/Spacecraft/Structure/RMMParams.h
+++ b/src/Simulation/Spacecraft/Structure/RMMParams.h
@@ -52,13 +52,13 @@ class RMMParams {
    * @brief Set Constant value of RMM at body frame [Am2]
    * @param [in] rmm_const_b_Am2: Constant value of RMM at the body frame [Am2]
    */
-  inline void SetRMMConst_b_Am2(const Vector<3> rmm_const_b_Am2) { rmm_const_b_ = rmm_const_b_Am2; }
+  inline void SetRmmConstant_b_Am2(const Vector<3> rmm_const_b_Am2) { rmm_const_b_ = rmm_const_b_Am2; }
   /**
    * @fn AddRMMConst_b_Am2
    * @brief Add Constant value of RMM at body frame [Am2]
    * @param [in] rmm_const_b_Am2: Constant value of RMM at the body frame [Am2]
    */
-  inline void AddRMMConst_b_Am2(const Vector<3> rmm_const_b_Am2) { rmm_const_b_ += rmm_const_b_Am2; }
+  inline void AddRmmConstant_b_Am2(const Vector<3> rmm_const_b_Am2) { rmm_const_b_ += rmm_const_b_Am2; }
 
  private:
   Vector<3> rmm_const_b_;  //!< Constant value of RMM at body frame [Am2]

--- a/src/Simulation/Spacecraft/Structure/Structure.h
+++ b/src/Simulation/Spacecraft/Structure/Structure.h
@@ -52,6 +52,22 @@ class Structure {
    */
   inline const RMMParams& GetRMMParams() const { return *rmm_params_; }
 
+  /**
+   * @fn GetToSetSurfaces
+   * @brief Return surface information
+   */
+  inline vector<Surface>& GetToSetSurfaces() { return surfaces_; }
+  /**
+   * @fn GetToSetKinematicsParams
+   * @brief Return kinematics information
+   */
+  inline KinematicsParams& GetToSetKinematicsParams() { return *kinnematics_params_; }
+  /**
+   * @fn GetToSetRMMParams
+   * @brief Return Residual Magnetic Moment information
+   */
+  inline RMMParams& GetToSetRMMParams() { return *rmm_params_; }
+
  private:
   KinematicsParams* kinnematics_params_;  //!< Kinematics parameters
   vector<Surface> surfaces_;              //!< Surface information

--- a/src/Simulation/Spacecraft/Structure/Surface.h
+++ b/src/Simulation/Spacecraft/Structure/Surface.h
@@ -57,6 +57,55 @@ class Surface {
    */
   inline const double& GetAirSpecularity(void) const { return air_specularity_; }
 
+  // Setter
+  /**
+   * @fn SetPosition
+   * @brief Set position vector of geometric center of the surface in body frame [m]
+   * @param[in] position_b_m: Position vector of geometric center of the surface in body frame [m]
+   */
+  inline void SetPosition_b_m(const Vector<3> position_b_m) { position_ = position_b_m; }
+  /**
+   * @fn SetNormal
+   * @brief Set normal vector of the surface in body frame
+   * @param[in] normal_b: Normal vector of the surface in body frame
+   */
+  inline void SetNormal_b(const Vector<3> normal_b) {
+    normal_ = normal_b;
+    normal_ = normalize(normal_);
+  }
+  /**
+   * @fn SetArea
+   * @brief Set area of the surface
+   * @param[in] area_m2: Area of the surface [m2]
+   */
+  inline void SetArea(const double area_m2) {
+    if (area_m2 > 0.0) area_ = area_m2;
+  }
+  /**
+   * @fn SetReflectivity
+   * @brief Set reflectivity of the surface
+   * @param[in] reflectivity: Reflectivity of the surface
+   */
+  inline void SetReflectivity(const double reflectivity) {
+    if (reflectivity >= 0.0 && reflectivity <= 1.0) reflectivity_ = reflectivity;
+  }
+  /**
+   * @fn SetSpecularity
+   * @brief Set specularity of the surface
+   * @param[in] specularity: Specularity of the surface
+   */
+  inline void SetSpecularity(const double specularity) {
+    if (specularity >= 0.0 && specularity <= 1.0) specularity_ = specularity;
+  }
+  /**
+   * @fn SetAirSpecularity
+   * @brief Set air specularity of the surface
+   * @param[in] air_specularity: Air specularity of the surface
+   */
+  inline void SetAirSpecularity(const double air_specularity) {
+    if (air_specularity >= 0.0 && air_specularity <= 1.0) air_specularity_ = air_specularity;
+  }
+
  private:
   Vector<3> position_;      //!< Position vector of the surface @ Body Frame [m]
   Vector<3> normal_;        //!< Normal unit vector of the surface @ Body Frame [-]


### PR DESCRIPTION
## Overview
Add functions to change structure information

## Issue
- NA

## Details
I added the functions to change satellite structure information. They are useful to simulate the following things.
- Mass decreasing and center of mass change due to fuel consumption
- Inertia tensor change due to solar panel deployment
- SRP and Air drag calculation for rotating solar paddles
- Optical property change with Reflectivity Control Device
- RMM change due to the components' power consumption

I also added an example to change these information by components.  
Several interfaces of public functions were changed, but they are not used by user side in normal case. So I manage this update as a minor update.

The interface of the inertia tensor was not modified since it is related with the on-going issue #143.

##  Validation results
I confirmed that we can change the structure information with the example and the changes affect the result of simulation.

![image](https://user-images.githubusercontent.com/19573779/214589344-da79eac2-bdf9-4c7f-bfc4-b655fc1e43c0.png)

![image](https://user-images.githubusercontent.com/19573779/214589400-3af57953-2c58-4d67-a015-25c07a0ed076.png)


## Scope of influence
NA

## Supplement
NA

## Note
NA
