### PR TITLE
Add Newton method to solve Kepler equation

### DIFF
--- a/src/Library/Orbit/KeplerOrbit.cpp
+++ b/src/Library/Orbit/KeplerOrbit.cpp
@@ -39,7 +39,7 @@ void KeplerOrbit::CalcPosVel(double time_jday) {
 
   // Solve Kepler Equation
   double eccentric_anomaly_rad;
-  eccentric_anomaly_rad = SolveKeplerNewtonMethod(e, l_rad, 1.0e-5, 10);  // TODO: Implement Newton method
+  eccentric_anomaly_rad = SolveKeplerNewtonMethod(e, l_rad, 1.0e-5, 10);
   double u_rad = libra::WrapTo2Pi(eccentric_anomaly_rad);
 
   // Calc position and velocity in the plane

--- a/src/Library/Orbit/KeplerOrbit.cpp
+++ b/src/Library/Orbit/KeplerOrbit.cpp
@@ -86,7 +86,7 @@ double KeplerOrbit::SolveKeplerNewtonMethod(const double eccentricity, const dou
   double u_rad = 0.0;
 
   for (int i = 0; i < iteration_limit; i++) {
-    u_rad -= (u_prev_rad - eccentricity * sin(u_prev_rad) - mean_anomaly_rad) / (1 - eccentricity * cos(u_prev_rad));
+    u_rad -= (u_prev_rad - eccentricity * sin(u_prev_rad) - mean_anomaly_rad) / (1.0 - eccentricity * cos(u_prev_rad));
 
     double diff_abs_rad = std::abs(u_rad - u_prev_rad);
     if (diff_abs_rad < angle_limit_rad) break;

--- a/src/Library/Orbit/KeplerOrbit.cpp
+++ b/src/Library/Orbit/KeplerOrbit.cpp
@@ -39,7 +39,7 @@ void KeplerOrbit::CalcPosVel(double time_jday) {
 
   // Solve Kepler Equation
   double eccentric_anomaly_rad;
-  eccentric_anomaly_rad = SolveKeplerFirstOrder(e, l_rad, 1.0e-5, 10);  // TODO: Implement Newton method
+  eccentric_anomaly_rad = SolveKeplerNewtonMethod(e, l_rad, 1.0e-5, 10);  // TODO: Implement Newton method
   double u_rad = libra::WrapTo2Pi(eccentric_anomaly_rad);
 
   // Calc position and velocity in the plane
@@ -77,5 +77,21 @@ double KeplerOrbit::SolveKeplerFirstOrder(const double eccentricity, const doubl
     u_prev_rad = u_rad;
   }
 
+  return u_rad;
+}
+
+double KeplerOrbit::SolveKeplerNewtonMethod(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad,
+                                            const int iteration_limit) {
+  double u_prev_rad = mean_anomaly_rad;
+  double u_rad = 0.0;
+
+  for (int i = 0; i < iteration_limit; i++) {
+    u_rad -= (u_prev_rad - eccentricity * sin(u_prev_rad) - mean_anomaly_rad) / (1 - eccentricity * cos(u_prev_rad));
+
+    double diff_abs_rad = std::abs(u_rad - u_prev_rad);
+    if (diff_abs_rad < angle_limit_rad) break;
+
+    u_prev_rad = u_rad;
+  }
   return u_rad;
 }

--- a/src/Library/Orbit/KeplerOrbit.h
+++ b/src/Library/Orbit/KeplerOrbit.h
@@ -73,4 +73,5 @@ class KeplerOrbit {
    * @param [in] iteration_limit: Limit of iteration
    */
   double SolveKeplerFirstOrder(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad, const int iteration_limit);
+  double SolveKeplerNewtonMethod(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad, const int iteration_limit);
 };

--- a/src/Library/Orbit/KeplerOrbit.h
+++ b/src/Library/Orbit/KeplerOrbit.h
@@ -73,5 +73,13 @@ class KeplerOrbit {
    * @param [in] iteration_limit: Limit of iteration
    */
   double SolveKeplerFirstOrder(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad, const int iteration_limit);
+  /**
+   * @fn SolveKeplerNewtonMethod
+   * @brief Solve Kepler Equation with the Newton Method
+   * @param [in] eccentricity: Eccentricity
+   * @param [in] mean_anomaly_rad: Mean motion of the orbit [rad/s]
+   * @param [in] angle_limit_rad: Limit of angle error for the approximation
+   * @param [in] iteration_limit: Limit of iteration
+   */
   double SolveKeplerNewtonMethod(const double eccentricity, const double mean_anomaly_rad, const double angle_limit_rad, const int iteration_limit);
 };


### PR DESCRIPTION
## Overview
Use Newton Method to solve Kepler equation instead of First Order method.

## Issue
- #282 

## Details
- add SolveKeplerNewtonMethod to KeplerOrbit.h
- add SolveKeplerNewtonMethod to KeplerOrbit.cpp 
- replace SolveKeplerFirstOrder with SolveKeplerNewtonMethod in function CalcPosVel

##  Validation results
Set propagate_mode in ```SampleSat.ini``` to be ```KEPLER``` and compared result in ```develop```` branch and this branch.

- develop branch
![f1](https://user-images.githubusercontent.com/44338851/218326417-1b019e33-c4fe-4877-9530-83a2bb9c5403.png)
![f2](https://user-images.githubusercontent.com/44338851/218326412-1472e0bb-5852-4610-ad08-d91eea138684.png)

- this branch
![n2](https://user-images.githubusercontent.com/44338851/218326422-7a2bc879-a2b1-4fdd-9241-b9873182daae.png)
![n1](https://user-images.githubusercontent.com/44338851/218326430-60e5ddbb-2ec7-49a0-84e2-de82c26055e8.png)





## Scope of influence
eg. The behavior of XX will be change.

## Supplement
Write additional comments if you need.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
