### PR TITLE
Fix gyro sensor default noise

### DIFF
--- a/data/sample/initialize_files/components/gyro_sensor.ini
+++ b/data/sample/initialize_files/components/gyro_sensor.ini
@@ -27,9 +27,9 @@ constant_bias_c_rad_s(1) = -1.0e-3
 constant_bias_c_rad_s(2) = 2.0e-3
 
 // Standard deviation for random walk noise[rad/s]
-normal_random_standard_deviation_c_rad_s(0) = 0.0
-normal_random_standard_deviation_c_rad_s(1) = 0.0
-normal_random_standard_deviation_c_rad_s(2) = 0.0
+random_walk_standard_deviation_c_rad_s(0) = 0.0
+random_walk_standard_deviation_c_rad_s(1) = 0.0
+random_walk_standard_deviation_c_rad_s(2) = 0.0
 
 // Limit of random walk noise[rad/s]
 random_walk_limit_c_rad_s(0) = 0.0
@@ -37,9 +37,9 @@ random_walk_limit_c_rad_s(1) = 0.0
 random_walk_limit_c_rad_s(2) = 0.0
 
 // Standard deviation of normal random noise[rad/s]
-random_walk_standard_deviation_c_rad_s(0) = 1e-3
-random_walk_standard_deviation_c_rad_s(1) = 1e-3
-random_walk_standard_deviation_c_rad_s(2) = 1e-3
+normal_random_standard_deviation_c_rad_s(0) = 1e-3
+normal_random_standard_deviation_c_rad_s(1) = 1e-3
+normal_random_standard_deviation_c_rad_s(2) = 1e-3
 
 // Range [rad/s]
 range_to_constant_rad_s = 5.0  // smaller than Range_to_zero


### PR DESCRIPTION
## Overview
Fix gyro sensor default noise

## Issue
- [Related PR](https://github.com/ut-issl/s2e-core/pull/343)

## Details
上のPRで分散値が設定値と違うように見えたが、初期値が変わっていたことが原因だったのでもとに戻す

##  Validation results

![image](https://user-images.githubusercontent.com/19573779/222266125-68125709-1167-47e1-8d1c-455568cff20e.png)

## Scope of influence
NA

## Supplement
NA

## Note
NA