### PR TITLE
Move to member function in Matrix class

### DIFF
--- a/src/disturbances/geopotential.cpp
+++ b/src/disturbances/geopotential.cpp
@@ -79,7 +79,7 @@ void GeoPotential::Update(const LocalEnvironment &local_environment, const Dynam
 #endif
 
   libra::Matrix<3, 3> trans_eci2ecef_ = local_environment.GetCelestialInformation().GetGlobalInformation().GetEarthRotation().GetDcmJ2000ToXcxf();
-  libra::Matrix<3, 3> trans_ecef2eci = Transpose(trans_eci2ecef_);
+  libra::Matrix<3, 3> trans_ecef2eci = trans_eci2ecef_.Transpose();
   acceleration_i_m_s2_ = trans_ecef2eci * acceleration_ecef_m_s2_;
 }
 

--- a/src/dynamics/attitude/controlled_attitude.cpp
+++ b/src/dynamics/attitude/controlled_attitude.cpp
@@ -96,7 +96,7 @@ void ControlledAttitude::PointingControl(const libra::Vector<3> main_direction_i
   // Calc DCM Target->body
   libra::Matrix<3, 3> dcm_t2b = CalcDcm(main_target_direction_b_, sub_target_direction_b_);
   // Calc DCM ECI->body
-  libra::Matrix<3, 3> dcm_i2b = dcm_t2b * Transpose(dcm_t2i);
+  libra::Matrix<3, 3> dcm_i2b = dcm_t2b * dcm_t2i.Transpose();
   // Convert to Quaternion
   quaternion_i2b_ = libra::Quaternion::ConvertFromDcm(dcm_i2b);
 }

--- a/src/environment/global/celestial_rotation.cpp
+++ b/src/environment/global/celestial_rotation.cpp
@@ -20,7 +20,7 @@
 CelestialRotation::CelestialRotation(const RotationMode rotation_mode, const std::string center_body_name) {
   planet_name_ = "Anonymous";
   rotation_mode_ = Idle;
-  Unitalize(dcm_j2000_to_xcxf_);
+  dcm_j2000_to_xcxf_ = libra::MakeIdentityMatrix<3>();
   dcm_teme_to_xcxf_ = dcm_j2000_to_xcxf_;
   if (center_body_name == "EARTH") {
     InitCelestialRotationAsEarth(rotation_mode, center_body_name);
@@ -115,12 +115,12 @@ void CelestialRotation::InitCelestialRotationAsEarth(const RotationMode rotation
     } else {
       // If the rotation mode is neither Simple nor Full, disable the rotation calculation and make the DCM a unit matrix
       rotation_mode_ = Idle;
-      Unitalize(dcm_j2000_to_xcxf_);
+      dcm_j2000_to_xcxf_ = libra::MakeIdentityMatrix<3>();
     }
   } else {
     // If the center object is not the Earth, disable the Earth's rotation calculation and make the DCM a unit matrix
     rotation_mode_ = Idle;
-    Unitalize(dcm_j2000_to_xcxf_);
+    dcm_j2000_to_xcxf_ = libra::MakeIdentityMatrix<3>();
   }
 }
 

--- a/src/library/math/matrix.hpp
+++ b/src/library/math/matrix.hpp
@@ -47,6 +47,13 @@ class Matrix {
   inline size_t GetColumnLength() const { return C; }
 
   /**
+   * @fn FillUp
+   * @brief Fill up all elements with same value
+   * @param [in] t: Scalar value to fill up
+   */
+  void FillUp(const T& t);
+
+  /**
    * @fn Cast operator to directly access the elements
    * @brief Operator to access the elements similar with the 2D-array using `[]`
    * @return Pointer to the data storing array
@@ -138,15 +145,6 @@ class Matrix {
    */
   inline bool IsValidRange(size_t row, size_t column) { return (row < R && column < C); }
 };
-
-/**
- * @fn FillUp
- * @brief Fill up all elements with same value
- * @param [in] m: Target matrix
- * @param [in] t: Scalar value to fill up
- */
-template <size_t R, size_t C, typename T>
-void FillUp(Matrix<R, C, T>& m, const T& t);
 
 /**
  * @fn CalcTrace

--- a/src/library/math/matrix.hpp
+++ b/src/library/math/matrix.hpp
@@ -69,6 +69,13 @@ class Matrix {
   void Print(char delimiter = '\t', std::ostream& stream = std::cout);
 
   /**
+   * @fn Transpose
+   * @brief Calculate and return transposed matrix
+   * @return Result of transposed matrix
+   */
+  const Matrix<C, R, T> Transpose() const;
+
+  /**
    * @fn Cast operator to directly access the elements
    * @brief Operator to access the elements similar with the 2D-array using `[]`
    * @return Pointer to the data storing array
@@ -200,15 +207,6 @@ const Matrix<R, C, T> operator*(const T& lhs, const Matrix<R, C, T>& rhs);
  */
 template <size_t R, size_t C1, size_t C2, typename T>
 const Matrix<R, C2, T> operator*(const Matrix<R, C1, T>& lhs, const Matrix<C1, C2, T>& rhs);
-
-/**
- * @fn Transpose
- * @brief Calculate and return transposed matrix
- * @param [in] m: Target matrix
- * @return Result of transposed matrix
- */
-template <size_t R, size_t C, typename T>
-const Matrix<C, R, T> Transpose(const Matrix<R, C, T>& m);
 
 /**
  * @fn Unitalize

--- a/src/library/math/matrix.hpp
+++ b/src/library/math/matrix.hpp
@@ -67,7 +67,7 @@ class Matrix {
    * @param [in] delimiter: Delimiter (Default: tab)
    * @param [out] stream: Output target(Default: cout)
    */
-  void Print(char delimiter = '\t', std::ostream& stream = std::cout);
+  void Print(char delimiter = '\t', std::ostream& stream = std::cout) const;
 
   /**
    * @fn Transpose

--- a/src/library/math/matrix.hpp
+++ b/src/library/math/matrix.hpp
@@ -57,6 +57,7 @@ class Matrix {
    * @fn CalcTrace
    * @brief Calculate and return the trace of matrix
    * @return Trace of the matrix
+   * @note When the matrix is not a square matrix, 0.0 is returned
    */
   T CalcTrace() const;
 

--- a/src/library/math/matrix.hpp
+++ b/src/library/math/matrix.hpp
@@ -209,16 +209,6 @@ template <size_t R, size_t C1, size_t C2, typename T>
 const Matrix<R, C2, T> operator*(const Matrix<R, C1, T>& lhs, const Matrix<C1, C2, T>& rhs);
 
 /**
- * @fn Unitalize
- * @brief Rewrite the input matrix as the identity matrix
- * @note Warning: m is overwritten.
- * @param [in/out] m: Target matrix
- * @return The identity matrix
- */
-template <size_t R, typename T>
-Matrix<R, R, T>& Unitalize(Matrix<R, R, T>& m);
-
-/**
  * @fn MakeIdentityMatrix
  * @brief Generate identity matrix
  * @return The identity matrix

--- a/src/library/math/matrix.hpp
+++ b/src/library/math/matrix.hpp
@@ -61,6 +61,14 @@ class Matrix {
   T CalcTrace() const;
 
   /**
+   * @fn Print
+   * @brief Generate all elements to outstream
+   * @param [in] delimiter: Delimiter (Default: tab)
+   * @param [out] stream: Output target(Default: cout)
+   */
+  void Print(char delimiter = '\t', std::ostream& stream = std::cout);
+
+  /**
    * @fn Cast operator to directly access the elements
    * @brief Operator to access the elements similar with the 2D-array using `[]`
    * @return Pointer to the data storing array
@@ -152,16 +160,6 @@ class Matrix {
    */
   inline bool IsValidRange(size_t row, size_t column) { return (row < R && column < C); }
 };
-
-/**
- * @fn print
- * @brief Generate all elements to outstream
- * @param [in] m: Target matrix
- * @param [in] delimiter: Delimiter (Default: tab)
- * @param [out] stream: Output target(Default: cout)
- */
-template <size_t R, size_t C, typename T>
-void Print(const Matrix<R, C, T>& m, char delimiter = '\t', std::ostream& stream = std::cout);
 
 /**
  * @fn operator +

--- a/src/library/math/matrix.hpp
+++ b/src/library/math/matrix.hpp
@@ -54,6 +54,13 @@ class Matrix {
   void FillUp(const T& t);
 
   /**
+   * @fn CalcTrace
+   * @brief Calculate and return the trace of matrix
+   * @return Trace of the matrix
+   */
+  T CalcTrace() const;
+
+  /**
    * @fn Cast operator to directly access the elements
    * @brief Operator to access the elements similar with the 2D-array using `[]`
    * @return Pointer to the data storing array
@@ -145,15 +152,6 @@ class Matrix {
    */
   inline bool IsValidRange(size_t row, size_t column) { return (row < R && column < C); }
 };
-
-/**
- * @fn CalcTrace
- * @brief Calculate and return the trace of matrix
- * @param [in] m: Target matrix
- * @return Trace of the matrix
- */
-template <size_t N, typename T>
-T CalcTrace(const Matrix<N, N, T>& m);
 
 /**
  * @fn print

--- a/src/library/math/matrix_template_functions.hpp
+++ b/src/library/math/matrix_template_functions.hpp
@@ -77,7 +77,7 @@ T Matrix<R, C, T>::CalcTrace() const {
 }
 
 template <size_t R, size_t C, typename T>
-void Matrix<R, C, T>::Print(char delimiter, std::ostream& stream) {
+void Matrix<R, C, T>::Print(char delimiter, std::ostream& stream) const {
   for (size_t i = 0; i < R; ++i) {
     stream << matrix_[i][0];
     for (size_t j = 1; j < C; ++j) {

--- a/src/library/math/matrix_template_functions.hpp
+++ b/src/library/math/matrix_template_functions.hpp
@@ -56,10 +56,10 @@ const Matrix<R, C, T>& Matrix<R, C, T>::operator-=(const Matrix<R, C, T>& m) {
 }
 
 template <size_t R, size_t C, typename T>
-void FillUp(Matrix<R, C, T>& m, const T& t) {
+void Matrix<R, C, T>::FillUp(const T& t) {
   for (size_t i = 0; i < R; ++i) {
     for (size_t j = 0; j < C; ++j) {
-      m[i][j] = t;
+      matrix_[i][j] = t;
     }
   }
 }
@@ -143,7 +143,7 @@ const Matrix<C, R, T> Transpose(const Matrix<R, C, T>& m) {
 
 template <size_t R, typename T>
 Matrix<R, R, T>& Unitalize(Matrix<R, R, T>& m) {
-  FillUp(m, 0.0);
+  m.FillUp(0.0);
   for (size_t i = 0; i < R; ++i) {
     m[i][i] = 1.0;
   }

--- a/src/library/math/matrix_template_functions.hpp
+++ b/src/library/math/matrix_template_functions.hpp
@@ -134,11 +134,11 @@ const Matrix<R, C2, T> operator*(const Matrix<R, C1, T>& lhs, const Matrix<C1, C
 }
 
 template <size_t R, size_t C, typename T>
-const Matrix<C, R, T> Transpose(const Matrix<R, C, T>& m) {
+const Matrix<C, R, T> Matrix<R, C, T>::Transpose() const {
   Matrix<C, R, T> temp;
   for (size_t i = 0; i < R; ++i) {
     for (size_t j = 0; j < C; ++j) {
-      temp[j][i] = m[i][j];
+      temp[j][i] = matrix_[i][j];
     }
   }
   return temp;

--- a/src/library/math/matrix_template_functions.hpp
+++ b/src/library/math/matrix_template_functions.hpp
@@ -77,11 +77,11 @@ T Matrix<R, C, T>::CalcTrace() const {
 }
 
 template <size_t R, size_t C, typename T>
-void Print(const Matrix<R, C, T>& m, char delimiter, std::ostream& stream) {
+void Matrix<R, C, T>::Print(char delimiter, std::ostream& stream) {
   for (size_t i = 0; i < R; ++i) {
-    stream << m[i][0];
+    stream << matrix_[i][0];
     for (size_t j = 1; j < C; ++j) {
-      stream << delimiter << m[i][j];
+      stream << delimiter << matrix_[i][j];
     }
     stream << std::endl;
   }

--- a/src/library/math/matrix_template_functions.hpp
+++ b/src/library/math/matrix_template_functions.hpp
@@ -64,11 +64,14 @@ void Matrix<R, C, T>::FillUp(const T& t) {
   }
 }
 
-template <size_t N, typename T>
-T CalcTrace(const Matrix<N, N, T>& m) {
+template <size_t R, size_t C, typename T>
+T Matrix<R, C, T>::CalcTrace() const {
   T trace = 0.0;
-  for (size_t i = 0; i < N; ++i) {
-    trace += m[i][i];
+
+  if (R != C) return trace;
+
+  for (size_t i = 0; i < R; ++i) {
+    trace += matrix_[i][i];
   }
   return trace;
 }

--- a/src/library/math/matrix_template_functions.hpp
+++ b/src/library/math/matrix_template_functions.hpp
@@ -145,8 +145,8 @@ const Matrix<C, R, T> Matrix<R, C, T>::Transpose() const {
 }
 
 template <size_t R, typename T>
-Matrix<R, R, T>& Unitalize(Matrix<R, R, T>& m) {
-  m.FillUp(0.0);
+Matrix<R, R, T> MakeIdentityMatrix() {
+  Matrix<R, R, T> m(0.0);
   for (size_t i = 0; i < R; ++i) {
     m[i][i] = 1.0;
   }
@@ -154,16 +154,9 @@ Matrix<R, R, T>& Unitalize(Matrix<R, R, T>& m) {
 }
 
 template <size_t R, typename T>
-Matrix<R, R, T> MakeIdentityMatrix() {
-  Matrix<R, R, T> m;
-  Unitalize(m);
-  return m;
-}
-
-template <size_t R, typename T>
 Matrix<R, R, T> MakeRotationMatrixX(const double& theta_rad) {
-  Matrix<R, R, T> m;
-  Unitalize(m);
+  Matrix<R, R, T> m = MakeIdentityMatrix<R, T>();
+
   m[1][1] = cos(theta_rad);
   m[1][2] = sin(theta_rad);
   m[2][1] = -sin(theta_rad);
@@ -173,8 +166,8 @@ Matrix<R, R, T> MakeRotationMatrixX(const double& theta_rad) {
 
 template <size_t R, typename T>
 Matrix<R, R, T> MakeRotationMatrixY(const double& theta_rad) {
-  Matrix<R, R, T> m;
-  Unitalize(m);
+  Matrix<R, R, T> m = MakeIdentityMatrix<R, T>();
+
   m[0][0] = cos(theta_rad);
   m[0][2] = -sin(theta_rad);
   m[2][0] = sin(theta_rad);
@@ -184,8 +177,8 @@ Matrix<R, R, T> MakeRotationMatrixY(const double& theta_rad) {
 
 template <size_t R, typename T>
 Matrix<R, R, T> MakeRotationMatrixZ(const double& theta_rad) {
-  Matrix<R, R, T> m;
-  Unitalize(m);
+  Matrix<R, R, T> m = MakeIdentityMatrix<R, T>();
+
   m[0][0] = cos(theta_rad);
   m[0][1] = sin(theta_rad);
   m[1][0] = -sin(theta_rad);

--- a/src/library/math/test_matrix.cpp
+++ b/src/library/math/test_matrix.cpp
@@ -154,7 +154,7 @@ TEST(Matrix, FillUp) {
 
   libra::Matrix<R, C> m;
 
-  FillUp(m, value);
+  m.FillUp(value);
 
   for (size_t r = 0; r < R; r++) {
     for (size_t c = 0; c < C; c++) {
@@ -177,7 +177,7 @@ TEST(Matrix, CalcTrace) {
     }
   }
 
-  double trace = CalcTrace(m);
+  double trace = m.CalcTrace();
 
   // Check nondestructive
   for (size_t r = 0; r < N; r++) {
@@ -326,7 +326,7 @@ TEST(Matrix, Transpose) {
     }
   }
 
-  libra::Matrix<C, R> transposed = Transpose(m);
+  libra::Matrix<C, R> transposed = m.Transpose();
 
   for (size_t r = 0; r < R; r++) {
     for (size_t c = 0; c < C; c++) {
@@ -334,39 +334,6 @@ TEST(Matrix, Transpose) {
       EXPECT_DOUBLE_EQ(r * c, m[r][c]);
       // Check result
       EXPECT_DOUBLE_EQ(r * c, transposed[c][r]);
-    }
-  }
-}
-
-/**
- * @brief Test for Unitalize
- */
-TEST(Matrix, Unitalize) {
-  const size_t N = 6;
-
-  libra::Matrix<N, N> m;
-  for (size_t r = 0; r < N; r++) {
-    for (size_t c = 0; c < N; c++) {
-      m[r][c] = r * c;
-    }
-  }
-
-  libra::Matrix<N, N> unitalized = Unitalize(m);
-
-  for (size_t r = 0; r < N; r++) {
-    for (size_t c = 0; c < N; c++) {
-      // Check nondestructive (Currently, this is destructive)
-      if (r == c) {
-        EXPECT_DOUBLE_EQ(1.0, m[r][c]);
-      } else {
-        EXPECT_DOUBLE_EQ(0.0, m[r][c]);
-      }
-      // Check result
-      if (r == c) {
-        EXPECT_DOUBLE_EQ(1.0, unitalized[r][c]);
-      } else {
-        EXPECT_DOUBLE_EQ(0.0, unitalized[r][c]);
-      }
     }
   }
 }

--- a/src/simulation/ground_station/ground_station.cpp
+++ b/src/simulation/ground_station/ground_station.cpp
@@ -46,7 +46,7 @@ void GroundStation::Initialize(const SimulationConfiguration* configuration, con
 void GroundStation::LogSetup(Logger& logger) { logger.AddLogList(this); }
 
 void GroundStation::Update(const CelestialRotation& celestial_rotation, const Spacecraft& spacecraft) {
-  libra::Matrix<3, 3> dcm_ecef2eci = Transpose(celestial_rotation.GetDcmJ2000ToXcxf());
+  libra::Matrix<3, 3> dcm_ecef2eci = celestial_rotation.GetDcmJ2000ToXcxf().Transpose();
   position_i_m_ = dcm_ecef2eci * position_ecef_m_;
 
   is_visible_[spacecraft.GetSpacecraftId()] = CalcIsVisible(spacecraft.GetDynamics().GetOrbit().GetPosition_ecef_m());


### PR DESCRIPTION
## Overview
Move to member function in Matrix class

## Issue
#333 

## Details
The following functions for Matrix class were moved to the member functions.
- FillUp
- CalcTrace
- Print
- Transpose

The `Unitalize` function was deleted and changed to use MakeIdentityMatrix.


##  Validation results
see CI

## Scope of influence
NA

## Supplement
NA

## Note
Review and Merge after https://github.com/ut-issl/s2e-core/pull/356

We need to change test codes in [this PR](https://github.com/ut-issl/s2e-core/pull/340).