### PR TITLE
Update link margin analysis

### DIFF
--- a/data/sample/initialize_files/components/ground_station_antenna.ini
+++ b/data/sample/initialize_files/components/ground_station_antenna.ini
@@ -30,7 +30,7 @@ tx_loss_pointing_dB = 0.0
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-tx_antenna_gain_model = ISOTROPIC
+tx_antenna_gain_model = kIsotropic
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis
@@ -58,7 +58,7 @@ rx_system_noise_temperature_K = 230
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-rx_antenna_gain_model = ISOTROPIC
+rx_antenna_gain_model = kIsotropic
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis

--- a/data/sample/initialize_files/components/ground_station_antenna.ini
+++ b/data/sample/initialize_files/components/ground_station_antenna.ini
@@ -15,7 +15,7 @@ is_receiver = 1
 frequency_MHz = 8200.0
 
 // bitrate [bps]
-tx_bitrate = 10000
+tx_bitrate_bps = 10000
 
 // Parameters for transmitter
 // RF output power [W]

--- a/data/sample/initialize_files/components/ground_station_antenna.ini
+++ b/data/sample/initialize_files/components/ground_station_antenna.ini
@@ -14,6 +14,9 @@ is_receiver = 1
 // frequency [MHz]
 frequency_MHz = 8200.0
 
+// bitrate [bps]
+tx_bitrate = 10000
+
 // Parameters for transmitter
 // RF output power [W]
 tx_output_W = 1.0

--- a/data/sample/initialize_files/components/ground_station_antenna.ini
+++ b/data/sample/initialize_files/components/ground_station_antenna.ini
@@ -30,7 +30,7 @@ tx_loss_pointing_dB = 0.0
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-tx_antenna_gain_model = kIsotropic
+tx_antenna_gain_model = ISOTROPIC
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis
@@ -58,7 +58,7 @@ rx_system_noise_temperature_K = 230
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-rx_antenna_gain_model = kIsotropic
+rx_antenna_gain_model = ISOTROPIC
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis

--- a/data/sample/initialize_files/components/spacecraft_antenna.ini
+++ b/data/sample/initialize_files/components/spacecraft_antenna.ini
@@ -15,7 +15,7 @@ is_receiver = 1
 frequency_MHz = 8200.0
 
 // bitrate [bps]
-tx_bitrate = 100000
+tx_bitrate_bps = 100000
 
 // Parameters for transmitter
 // RF output power [W]

--- a/data/sample/initialize_files/components/spacecraft_antenna.ini
+++ b/data/sample/initialize_files/components/spacecraft_antenna.ini
@@ -14,6 +14,9 @@ is_receiver = 1
 // frequency [MHz]
 frequency_MHz = 8200.0
 
+// bitrate [bps]
+tx_bitrate = 100000
+
 // Parameters for transmitter
 // RF output power [W]
 tx_output_W = 1.0

--- a/data/sample/initialize_files/components/spacecraft_antenna.ini
+++ b/data/sample/initialize_files/components/spacecraft_antenna.ini
@@ -30,7 +30,7 @@ tx_loss_pointing_dB = 0.0
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-tx_antenna_gain_model = RADIATION_PATTERN_CSV
+tx_antenna_gain_model = kRadiationPatternCsv
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis
@@ -58,7 +58,7 @@ rx_system_noise_temperature_K = 230
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-rx_antenna_gain_model = RADIATION_PATTERN_CSV
+rx_antenna_gain_model = kRadiationPatternCsv
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis

--- a/data/sample/initialize_files/components/spacecraft_antenna.ini
+++ b/data/sample/initialize_files/components/spacecraft_antenna.ini
@@ -30,7 +30,7 @@ tx_loss_pointing_dB = 0.0
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-tx_antenna_gain_model = kRadiationPatternCsv
+tx_antenna_gain_model = RADIATION_PATTERN_CSV
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis
@@ -58,7 +58,7 @@ rx_system_noise_temperature_K = 230
 // Antenna gain model
 // ISOTROPIC: Ideal isotropic antenna
 // RADIATION_PATTERN_CSV: Radiation pattern obtained by CSV files
-rx_antenna_gain_model = kRadiationPatternCsv
+rx_antenna_gain_model = RADIATION_PATTERN_CSV
 
 // Gain for ISOTROPIC mode [dBi]
 // Generally, it is zero but users can set any value for ideal analysis

--- a/src/components/real/communication/antenna.cpp
+++ b/src/components/real/communication/antenna.cpp
@@ -93,9 +93,9 @@ double Antenna::CalcRxGt_dB_K(const double theta_rad, const double phi_rad) cons
 }
 
 AntennaGainModel SetAntennaGainModel(const std::string gain_model_name) {
-  if (gain_model_name == "ISOTROPIC") {
+  if (gain_model_name == "kIsotropic") {
     return AntennaGainModel::kIsotropic;
-  } else if (gain_model_name == "RADIATION_PATTERN_CSV") {
+  } else if (gain_model_name == "kRadiationPatternCsv") {
     return AntennaGainModel::kRadiationPatternCsv;
   } else {
     return AntennaGainModel::kIsotropic;

--- a/src/components/real/communication/antenna.cpp
+++ b/src/components/real/communication/antenna.cpp
@@ -93,9 +93,9 @@ double Antenna::CalcRxGt_dB_K(const double theta_rad, const double phi_rad) cons
 }
 
 AntennaGainModel SetAntennaGainModel(const std::string gain_model_name) {
-  if (gain_model_name == "kIsotropic") {
+  if (gain_model_name == "ISOTROPIC") {
     return AntennaGainModel::kIsotropic;
-  } else if (gain_model_name == "kRadiationPatternCsv") {
+  } else if (gain_model_name == "RADIATION_PATTERN_CSV") {
     return AntennaGainModel::kRadiationPatternCsv;
   } else {
     return AntennaGainModel::kIsotropic;

--- a/src/components/real/communication/antenna.cpp
+++ b/src/components/real/communication/antenna.cpp
@@ -9,7 +9,7 @@
 #include <library/utilities/macros.hpp>
 
 Antenna::Antenna(const int component_id, const libra::Quaternion& quaternion_b2c, const bool is_transmitter, const bool is_receiver,
-                 const double frequency_MHz, const Vector<4> tx_parameters, const Vector<4> rx_parameters)
+                 const double frequency_MHz, const Vector<5> tx_parameters, const Vector<4> rx_parameters)
     : component_id_(component_id), is_transmitter_(is_transmitter), is_receiver_(is_receiver), frequency_MHz_(frequency_MHz) {
   quaternion_b2c_ = quaternion_b2c;
 
@@ -18,6 +18,7 @@ Antenna::Antenna(const int component_id, const libra::Quaternion& quaternion_b2c
   tx_parameters_.gain_dBi_ = tx_parameters[1];
   tx_parameters_.loss_feeder_dB_ = tx_parameters[2];
   tx_parameters_.loss_pointing_dB_ = tx_parameters[3];
+  tx_bitrate_bps_ = tx_parameters[4];
 
   rx_parameters_.gain_dBi_ = rx_parameters[0];
   rx_parameters_.loss_feeder_dB_ = rx_parameters[1];
@@ -42,13 +43,14 @@ Antenna::Antenna(const int component_id, const libra::Quaternion& quaternion_b2c
 }
 
 Antenna::Antenna(const int component_id, const libra::Quaternion& quaternion_b2c, const bool is_transmitter, const bool is_receiver,
-                 const double frequency_MHz, const double tx_output_power_W, const AntennaParameters tx_parameters,
+                 const double tx_bitrate_bps, const double frequency_MHz, const double tx_output_power_W, const AntennaParameters tx_parameters,
                  const double rx_system_noise_temperature_K, const AntennaParameters rx_parameters)
     : component_id_(component_id),
       quaternion_b2c_(quaternion_b2c),
       is_transmitter_(is_transmitter),
       is_receiver_(is_receiver),
       frequency_MHz_(frequency_MHz),
+      tx_bitrate_bps_(tx_bitrate_bps),
       tx_output_power_W_(tx_output_power_W),
       tx_parameters_(tx_parameters),
       rx_system_noise_temperature_K_(rx_system_noise_temperature_K),

--- a/src/components/real/communication/antenna.cpp
+++ b/src/components/real/communication/antenna.cpp
@@ -43,7 +43,7 @@ Antenna::Antenna(const int component_id, const libra::Quaternion& quaternion_b2c
 }
 
 Antenna::Antenna(const int component_id, const libra::Quaternion& quaternion_b2c, const bool is_transmitter, const bool is_receiver,
-                 const double tx_bitrate_bps, const double frequency_MHz, const double tx_output_power_W, const AntennaParameters tx_parameters,
+                 const double frequency_MHz, const double tx_bitrate_bps, const double tx_output_power_W, const AntennaParameters tx_parameters,
                  const double rx_system_noise_temperature_K, const AntennaParameters rx_parameters)
     : component_id_(component_id),
       quaternion_b2c_(quaternion_b2c),

--- a/src/components/real/communication/antenna.hpp
+++ b/src/components/real/communication/antenna.hpp
@@ -55,7 +55,7 @@ class Antenna {
    * @param [in] rx_parameters: gain, loss_feeder, loss_pointing, system_temperature for RX
    */
   Antenna(const int component_id, const libra::Quaternion& quaternion_b2c, const bool is_transmitter, const bool is_receiver,
-          const double frequency_MHz, const Vector<4> tx_parameters, const Vector<4> rx_parameters);
+          const double frequency_MHz, const Vector<5> tx_parameters, const Vector<4> rx_parameters);
 
   /**
    * @fn Antenna
@@ -65,13 +65,14 @@ class Antenna {
    * @param [in] is_transmitter: Antenna for transmitter or not
    * @param [in] is_receiver: Antenna for receiver or not
    * @param [in] frequency_MHz: Center Frequency [MHz]
+   * @param [in] tx_bitrate_bps: Transmit bitrate [bps]
    * @param [in] tx_output_power_W: Transmit output power [W]
    * @param [in] tx_parameters: TX antenna parameters
    * @param [in] rx_system_noise_temperature_K: Receive system noise temperature [K]
    * @param [in] rx_parameters: RX antenna parameters
    */
   Antenna(const int component_id, const libra::Quaternion& quaternion_b2c, const bool is_transmitter, const bool is_receiver,
-          const double frequency_MHz, const double tx_output_power_W, const AntennaParameters tx_parameters,
+          const double frequency_MHz, const double tx_bitrate_bps, const double tx_output_power_W, const AntennaParameters tx_parameters,
           const double rx_system_noise_temperature_K, const AntennaParameters rx_parameters);
   /**
    * @fn ~Antenna
@@ -103,6 +104,12 @@ class Antenna {
    */
   inline double GetFrequency_MHz() const { return frequency_MHz_; }
   /**
+   * @fn GetBitrate
+   * @brief Return bitrate [bps]
+   */
+  inline double GetBitrate() const { return tx_bitrate_bps_; }
+  /**
+   *
    * @fn GetQuaternion_b2c
    * @brief Return quaternion from body to component
    */
@@ -128,6 +135,7 @@ class Antenna {
   double frequency_MHz_;       //!< Center Frequency [MHz]
 
   // Tx info
+  double tx_bitrate_bps_;            //!< Transmit bitrate [bps]
   double tx_output_power_W_;         //!< Transmit output power [W]
   AntennaParameters tx_parameters_;  //!< Tx parameters
   double tx_eirp_dBW_;               //!< Transmit EIRP(Equivalent Isotropic Radiated Power) [dBW]

--- a/src/components/real/communication/antenna.hpp
+++ b/src/components/real/communication/antenna.hpp
@@ -107,7 +107,7 @@ class Antenna {
    * @fn GetBitrate
    * @brief Return bitrate [bps]
    */
-  inline double GetBitrate() const { return tx_bitrate_bps_; }
+  inline double GetBitrate_bps() const { return tx_bitrate_bps_; }
   /**
    *
    * @fn GetQuaternion_b2c

--- a/src/components/real/communication/ground_station_calculator.cpp
+++ b/src/components/real/communication/ground_station_calculator.cpp
@@ -26,12 +26,12 @@ GroundStationCalculator::GroundStationCalculator(const double loss_polarization_
 
 GroundStationCalculator::~GroundStationCalculator() {}
 
-void GroundStationCalculator::Update(const Spacecraft& spacecraft, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
-                                     const Antenna& ground_station_antenna) {
+void GroundStationCalculator::Update(const Spacecraft& spacecraft, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
+                                     const Antenna& ground_station_rx_antenna) {
   bool is_visible = ground_station.IsVisible(spacecraft.GetSpacecraftId());
   if (is_visible) {
-    max_bitrate_Mbps_ = CalcMaxBitrate(spacecraft.GetDynamics(), spacecraft_antenna, ground_station, ground_station_antenna);
-    receive_margin_dB_ = CalcReceiveMarginOnGs(spacecraft.GetDynamics(), spacecraft_antenna, ground_station, ground_station_antenna);
+    max_bitrate_Mbps_ = CalcMaxBitrate(spacecraft.GetDynamics(), spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
+    receive_margin_dB_ = CalcReceiveMarginOnGs(spacecraft.GetDynamics(), spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
   } else {
     max_bitrate_Mbps_ = 0.0;
     receive_margin_dB_ = -10000.0;  // FIXME: which value is suitable?
@@ -39,9 +39,9 @@ void GroundStationCalculator::Update(const Spacecraft& spacecraft, const Antenna
 }
 
 // Private functions
-double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
-                                               const Antenna& ground_station_antenna) {
-  double cn0_dBHz = CalcCn0OnGs(dynamics, spacecraft_antenna, ground_station, ground_station_antenna);
+double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
+                                               const Antenna& ground_station_rx_antenna) {
+  double cn0_dBHz = CalcCn0OnGs(dynamics, spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
 
   double margin_for_bitrate_dB = cn0_dBHz - (ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_) - margin_requirement_dB_;
 
@@ -52,25 +52,25 @@ double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const A
   }
 }
 
-double GroundStationCalculator::CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna,
-                                                      const GroundStation& ground_station, const Antenna& ground_station_antenna) {
-  double cn0_dB = CalcCn0OnGs(dynamics, spacecraft_antenna, ground_station, ground_station_antenna);
-  double cn0_requirement_dB = ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_ + 10.0 * log10(spacecraft_antenna.GetBitrate_bps());
+double GroundStationCalculator::CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna,
+                                                      const GroundStation& ground_station, const Antenna& ground_station_rx_antenna) {
+  double cn0_dB = CalcCn0OnGs(dynamics, spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
+  double cn0_requirement_dB = ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_ + 10.0 * log10(spacecraft_tx_antenna.GetBitrate_bps());
   return cn0_dB - cn0_requirement_dB;
 }
 
-double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
-                                            const Antenna& ground_station_antenna) {
+double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
+                                            const Antenna& ground_station_rx_antenna) {
   // Free space path loss
   Vector<3> sc_pos_i = dynamics.GetOrbit().GetPosition_i_m();
   Vector<3> gs_pos_i = ground_station.GetPosition_i_m();
   double dist_sc_gs_km = CalcNorm(sc_pos_i - gs_pos_i) / 1000.0;
-  double loss_space_dB = -20.0 * log10(4.0 * libra::pi * dist_sc_gs_km / (300.0 / spacecraft_antenna.GetFrequency_MHz() / 1000.0));
+  double loss_space_dB = -20.0 * log10(4.0 * libra::pi * dist_sc_gs_km / (300.0 / spacecraft_tx_antenna.GetFrequency_MHz() / 1000.0));
 
   // GS direction on SC TX antenna frame
   Vector<3> sc_to_gs_i = gs_pos_i - sc_pos_i;
   sc_to_gs_i = libra::Normalize(sc_to_gs_i);
-  Quaternion q_i_to_sc_ant = spacecraft_antenna.GetQuaternion_b2c() * dynamics.GetAttitude().GetQuaternion_i2b();
+  Quaternion q_i_to_sc_ant = spacecraft_tx_antenna.GetQuaternion_b2c() * dynamics.GetAttitude().GetQuaternion_i2b();
   Vector<3> gs_direction_on_sc_frame = q_i_to_sc_ant.FrameConversion(sc_to_gs_i);
   double theta_on_sc_antenna_rad = acos(gs_direction_on_sc_frame[2]);
   double phi_on_sc_antenna_rad = atan2(gs_direction_on_sc_frame[1], gs_direction_on_sc_frame[0]);
@@ -78,23 +78,23 @@ double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Ante
   // SC direction on GS RX antenna frame
   Vector<3> gs_to_sc_ecef = dynamics.GetOrbit().GetPosition_ecef_m() - ground_station.GetPosition_ecef_m();
   gs_to_sc_ecef = libra::Normalize(gs_to_sc_ecef);
-  Quaternion q_ecef_to_gs_ant = ground_station_antenna.GetQuaternion_b2c() * ground_station.GetGeodeticPosition().GetQuaternionXcxfToLtc();
+  Quaternion q_ecef_to_gs_ant = ground_station_rx_antenna.GetQuaternion_b2c() * ground_station.GetGeodeticPosition().GetQuaternionXcxfToLtc();
   Vector<3> sc_direction_on_gs_frame = q_ecef_to_gs_ant.FrameConversion(gs_to_sc_ecef);
   double theta_on_gs_antenna_rad = acos(sc_direction_on_gs_frame[2]);
   double phi_on_gs_antenna_rad = atan2(sc_direction_on_gs_frame[1], sc_direction_on_gs_frame[0]);
 
-  if (spacecraft_antenna.IsTransmitter()) {
+  if (spacecraft_tx_antenna.IsTransmitter()) {
     // Calc CN0
-    double cn0_dBHz = spacecraft_antenna.CalcTxEirp_dBW(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
+    double cn0_dBHz = spacecraft_tx_antenna.CalcTxEirp_dBW(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
                       loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
-                      ground_station_antenna.CalcRxGt_dB_K(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) -
+                      ground_station_rx_antenna.CalcRxGt_dB_K(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) -
                       10.0 * log10(environment::boltzmann_constant_J_K);
     return cn0_dBHz;
   } else {
     // Calc CN0
-    double cn0_dBHz = ground_station_antenna.CalcTxEirp_dBW(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
-                      loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
-                      spacecraft_antenna.CalcRxGt_dB_K(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) -
+    double cn0_dBHz = ground_station_rx_antenna.CalcTxEirp_dBW(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) + loss_space_dB +
+                      loss_polarization_dB_ + loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
+                      spacecraft_tx_antenna.CalcRxGt_dB_K(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) -
                       10.0 * log10(environment::boltzmann_constant_J_K);
     return cn0_dBHz;
   }

--- a/src/components/real/communication/ground_station_calculator.cpp
+++ b/src/components/real/communication/ground_station_calculator.cpp
@@ -92,8 +92,6 @@ double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Ante
     return cn0_dBHz;
   } else {
     // Calc CN0
-    double testA = ground_station_antenna.CalcTxEirp_dBW(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad);
-    double testB = spacecraft_antenna.CalcRxGt_dB_K(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad);
     double cn0_dBHz = ground_station_antenna.CalcTxEirp_dBW(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
                       loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
                       spacecraft_antenna.CalcRxGt_dB_K(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) -

--- a/src/components/real/communication/ground_station_calculator.cpp
+++ b/src/components/real/communication/ground_station_calculator.cpp
@@ -26,12 +26,12 @@ GroundStationCalculator::GroundStationCalculator(const double loss_polarization_
 
 GroundStationCalculator::~GroundStationCalculator() {}
 
-void GroundStationCalculator::Update(const Spacecraft& spacecraft, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
-                                     const Antenna& ground_station_rx_antenna) {
+void GroundStationCalculator::Update(const Spacecraft& spacecraft, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
+                                     const Antenna& ground_station_antenna) {
   bool is_visible = ground_station.IsVisible(spacecraft.GetSpacecraftId());
   if (is_visible) {
-    max_bitrate_Mbps_ = CalcMaxBitrate(spacecraft.GetDynamics(), spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
-    receive_margin_dB_ = CalcReceiveMarginOnGs(spacecraft.GetDynamics(), spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
+    max_bitrate_Mbps_ = CalcMaxBitrate(spacecraft.GetDynamics(), spacecraft_antenna, ground_station, ground_station_antenna);
+    receive_margin_dB_ = CalcReceiveMarginOnGs(spacecraft.GetDynamics(), spacecraft_antenna, ground_station, ground_station_antenna);
   } else {
     max_bitrate_Mbps_ = 0.0;
     receive_margin_dB_ = -10000.0;  // FIXME: which value is suitable?
@@ -39,9 +39,9 @@ void GroundStationCalculator::Update(const Spacecraft& spacecraft, const Antenna
 }
 
 // Private functions
-double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
-                                               const Antenna& ground_station_rx_antenna) {
-  double cn0_dBHz = CalcCn0OnGs(dynamics, spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
+double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
+                                               const Antenna& ground_station_antenna) {
+  double cn0_dBHz = CalcCn0OnGs(dynamics, spacecraft_antenna, ground_station, ground_station_antenna);
 
   double margin_for_bitrate_dB = cn0_dBHz - (ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_) - margin_requirement_dB_;
 
@@ -52,16 +52,16 @@ double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const A
   }
 }
 
-double GroundStationCalculator::CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna,
-                                                      const GroundStation& ground_station, const Antenna& ground_station_rx_antenna) {
-  double cn0_dB = CalcCn0OnGs(dynamics, spacecraft_tx_antenna, ground_station, ground_station_rx_antenna);
+double GroundStationCalculator::CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna,
+                                                      const GroundStation& ground_station, const Antenna& ground_station_antenna) {
+  double cn0_dB = CalcCn0OnGs(dynamics, spacecraft_antenna, ground_station, ground_station_antenna);
   double cn0_requirement_dB = ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_ + 10.0 * log10(downlink_bitrate_bps_);
   return cn0_dB - cn0_requirement_dB;
 }
 
-double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
-                                            const Antenna& ground_station_rx_antenna) {
-  if (!spacecraft_tx_antenna.IsTransmitter() || !ground_station_rx_antenna.IsReceiver()) {
+double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
+                                            const Antenna& ground_station_antenna) {
+  if (!spacecraft_antenna.IsTransmitter() || !ground_station_antenna.IsReceiver()) {
     // Check compatibility of transmitter and receiver
     return 0.0f;
   }
@@ -70,30 +70,39 @@ double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Ante
   Vector<3> sc_pos_i = dynamics.GetOrbit().GetPosition_i_m();
   Vector<3> gs_pos_i = ground_station.GetPosition_i_m();
   double dist_sc_gs_km = CalcNorm(sc_pos_i - gs_pos_i) / 1000.0;
-  double loss_space_dB = -20.0 * log10(4.0 * libra::pi * dist_sc_gs_km / (300.0 / spacecraft_tx_antenna.GetFrequency_MHz() / 1000.0));
+  double loss_space_dB = -20.0 * log10(4.0 * libra::pi * dist_sc_gs_km / (300.0 / spacecraft_antenna.GetFrequency_MHz() / 1000.0));
 
   // GS direction on SC TX antenna frame
   Vector<3> sc_to_gs_i = gs_pos_i - sc_pos_i;
   sc_to_gs_i = libra::Normalize(sc_to_gs_i);
-  Quaternion q_i_to_sc_ant = spacecraft_tx_antenna.GetQuaternion_b2c() * dynamics.GetAttitude().GetQuaternion_i2b();
+  Quaternion q_i_to_sc_ant = spacecraft_antenna.GetQuaternion_b2c() * dynamics.GetAttitude().GetQuaternion_i2b();
   Vector<3> gs_direction_on_sc_frame = q_i_to_sc_ant.FrameConversion(sc_to_gs_i);
   double theta_on_sc_antenna_rad = acos(gs_direction_on_sc_frame[2]);
-  double phi_on_sc_antenna_rad = acos(gs_direction_on_sc_frame[0] / sin(theta_on_sc_antenna_rad));
+  double phi_on_sc_antenna_rad = atan2(gs_direction_on_sc_frame[1], gs_direction_on_sc_frame[0]);
 
   // SC direction on GS RX antenna frame
   Vector<3> gs_to_sc_ecef = dynamics.GetOrbit().GetPosition_ecef_m() - ground_station.GetPosition_ecef_m();
   gs_to_sc_ecef = libra::Normalize(gs_to_sc_ecef);
-  Quaternion q_ecef_to_gs_ant = ground_station_rx_antenna.GetQuaternion_b2c() * ground_station.GetGeodeticPosition().GetQuaternionXcxfToLtc();
+  Quaternion q_ecef_to_gs_ant = ground_station_antenna.GetQuaternion_b2c() * ground_station.GetGeodeticPosition().GetQuaternionXcxfToLtc();
   Vector<3> sc_direction_on_gs_frame = q_ecef_to_gs_ant.FrameConversion(gs_to_sc_ecef);
   double theta_on_gs_antenna_rad = acos(sc_direction_on_gs_frame[2]);
-  double phi_on_gs_antenna_rad = acos(sc_direction_on_gs_frame[0] / sin(theta_on_gs_antenna_rad));
+  double phi_on_gs_antenna_rad = atan2(sc_direction_on_gs_frame[1], sc_direction_on_gs_frame[0]);
 
-  // Calc CN0
-  double cn0_dBHz = spacecraft_tx_antenna.CalcTxEirp_dBW(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
-                    loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
-                    ground_station_rx_antenna.CalcRxGt_dB_K(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) -
-                    10.0 * log10(environment::boltzmann_constant_J_K);
-  return cn0_dBHz;
+  if (spacecraft_antenna.IsTransmitter()) {
+    // Calc CN0
+    double cn0_dBHz = spacecraft_antenna.CalcTxEirp_dBW(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
+                      loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
+                      ground_station_antenna.CalcRxGt_dB_K(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) -
+                      10.0 * log10(environment::boltzmann_constant_J_K);
+    return cn0_dBHz;
+  } else {
+    // Calc CN0
+    double cn0_dBHz = ground_station_antenna.CalcTxEirp_dBW(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
+                      loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
+                      spacecraft_antenna.CalcRxGt_dB_K(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) -
+                      10.0 * log10(environment::boltzmann_constant_J_K);
+    return cn0_dBHz;
+  }
 }
 
 std::string GroundStationCalculator::GetLogHeader() const {

--- a/src/components/real/communication/ground_station_calculator.cpp
+++ b/src/components/real/communication/ground_station_calculator.cpp
@@ -61,11 +61,6 @@ double GroundStationCalculator::CalcReceiveMarginOnGs(const Dynamics& dynamics, 
 
 double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
                                             const Antenna& ground_station_antenna) {
-  if (!spacecraft_antenna.IsTransmitter() || !ground_station_antenna.IsReceiver()) {
-    // Check compatibility of transmitter and receiver
-    return 0.0f;
-  }
-
   // Free space path loss
   Vector<3> sc_pos_i = dynamics.GetOrbit().GetPosition_i_m();
   Vector<3> gs_pos_i = ground_station.GetPosition_i_m();
@@ -97,6 +92,8 @@ double GroundStationCalculator::CalcCn0OnGs(const Dynamics& dynamics, const Ante
     return cn0_dBHz;
   } else {
     // Calc CN0
+    double testA = ground_station_antenna.CalcTxEirp_dBW(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad);
+    double testB = spacecraft_antenna.CalcRxGt_dB_K(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad);
     double cn0_dBHz = ground_station_antenna.CalcTxEirp_dBW(theta_on_gs_antenna_rad, phi_on_gs_antenna_rad) + loss_space_dB + loss_polarization_dB_ +
                       loss_atmosphere_dB_ + loss_rainfall_dB_ + loss_others_dB_ +
                       spacecraft_antenna.CalcRxGt_dB_K(theta_on_sc_antenna_rad, phi_on_sc_antenna_rad) -

--- a/src/components/real/communication/ground_station_calculator.cpp
+++ b/src/components/real/communication/ground_station_calculator.cpp
@@ -55,7 +55,7 @@ double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const A
 double GroundStationCalculator::CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna,
                                                       const GroundStation& ground_station, const Antenna& ground_station_antenna) {
   double cn0_dB = CalcCn0OnGs(dynamics, spacecraft_antenna, ground_station, ground_station_antenna);
-  double cn0_requirement_dB = ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_ + 10.0 * log10(downlink_bitrate_bps_);
+  double cn0_requirement_dB = ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_ + 10.0 * log10(spacecraft_antenna.GetBitrate());
   return cn0_dB - cn0_requirement_dB;
 }
 

--- a/src/components/real/communication/ground_station_calculator.cpp
+++ b/src/components/real/communication/ground_station_calculator.cpp
@@ -55,7 +55,7 @@ double GroundStationCalculator::CalcMaxBitrate(const Dynamics& dynamics, const A
 double GroundStationCalculator::CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna,
                                                       const GroundStation& ground_station, const Antenna& ground_station_antenna) {
   double cn0_dB = CalcCn0OnGs(dynamics, spacecraft_antenna, ground_station, ground_station_antenna);
-  double cn0_requirement_dB = ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_ + 10.0 * log10(spacecraft_antenna.GetBitrate());
+  double cn0_requirement_dB = ebn0_dB_ + hardware_deterioration_dB_ + coding_gain_dB_ + 10.0 * log10(spacecraft_antenna.GetBitrate_bps());
   return cn0_dB - cn0_requirement_dB;
 }
 

--- a/src/components/real/communication/ground_station_calculator.hpp
+++ b/src/components/real/communication/ground_station_calculator.hpp
@@ -45,12 +45,12 @@ class GroundStationCalculator : public ILoggable {
    * @fn Update
    * @brief Update maximum bitrate calculation
    * @param [in] spacecraft: Spacecraft information
-   * @param [in] spacecraft_tx_antenna: Antenna mounted on spacecraft
+   * @param [in] spacecraft_antenna: Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_rx_antenna: Antenna mounted on ground station
+   * @param [in] ground_station_antenna: Antenna mounted on ground station
    */
-  void Update(const Spacecraft& spacecraft, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
-              const Antenna& ground_station_rx_antenna);
+  void Update(const Spacecraft& spacecraft, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
+              const Antenna& ground_station_antenna);
 
   // Override ILoggable TODO: Maybe we don't need logabble, and this class should be used as library.
   /**
@@ -104,36 +104,36 @@ class GroundStationCalculator : public ILoggable {
    * @fn CalcMaxBitrate
    * @brief Calculate the maximum bitrate
    * @param [in] dynamics: Spacecraft dynamics information
-   * @param [in] spacecraft_tx_antenna: Tx Antenna mounted on spacecraft
+   * @param [in] spacecraft_antenna: Tx Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_rx_antenna: Rx Antenna mounted on ground station
+   * @param [in] ground_station_antenna: Rx Antenna mounted on ground station
    * @return Max bitrate [Mbps]
    */
-  double CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
-                        const Antenna& ground_station_rx_antenna);
+  double CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
+                        const Antenna& ground_station_antenna);
   /**
    * @fn CalcReceiveMarginOnGs
    * @brief Calculate receive margin at the ground station
    * @param [in] dynamics: Spacecraft dynamics information
-   * @param [in] spacecraft_tx_antenna: Tx Antenna mounted on spacecraft
+   * @param [in] spacecraft_antenna: Tx Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_rx_antenna: Rx Antenna mounted on ground station
+   * @param [in] ground_station_antenna: Rx Antenna mounted on ground station
    * @return Receive margin [dB]
    */
-  double CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
-                               const Antenna& ground_station_rx_antenna);
+  double CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
+                               const Antenna& ground_station_antenna);
 
   /**
    * @fn CalcCn0
    * @brief Calculate CN0 (Carrier to Noise density ratio) of received signal at the ground station
    * @param [in] dynamics: Spacecraft dynamics information
-   * @param [in] spacecraft_tx_antenna: Tx Antenna mounted on spacecraft
+   * @param [in] spacecraft_antenna: Tx Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_rx_antenna: Rx Antenna mounted on ground station
+   * @param [in] ground_station_antenna: Rx Antenna mounted on ground station
    * @return CN0 [dB]
    */
-  double CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
-                     const Antenna& ground_station_rx_antenna);
+  double CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
+                     const Antenna& ground_station_antenna);
 };
 
 #endif  // S2E_COMPONENTS_REAL_COMMUNICATION_GROUND_STATION_CALCULATOR_HPP_

--- a/src/components/real/communication/ground_station_calculator.hpp
+++ b/src/components/real/communication/ground_station_calculator.hpp
@@ -45,12 +45,12 @@ class GroundStationCalculator : public ILoggable {
    * @fn Update
    * @brief Update maximum bitrate calculation
    * @param [in] spacecraft: Spacecraft information
-   * @param [in] spacecraft_antenna: Antenna mounted on spacecraft
+   * @param [in] spacecraft_tx_antenna: Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_antenna: Antenna mounted on ground station
+   * @param [in] ground_station_rx_antenna: Antenna mounted on ground station
    */
-  void Update(const Spacecraft& spacecraft, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
-              const Antenna& ground_station_antenna);
+  void Update(const Spacecraft& spacecraft, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
+              const Antenna& ground_station_rx_antenna);
 
   // Override ILoggable TODO: Maybe we don't need logabble, and this class should be used as library.
   /**
@@ -104,36 +104,36 @@ class GroundStationCalculator : public ILoggable {
    * @fn CalcMaxBitrate
    * @brief Calculate the maximum bitrate
    * @param [in] dynamics: Spacecraft dynamics information
-   * @param [in] spacecraft_antenna: Tx Antenna mounted on spacecraft
+   * @param [in] spacecraft_tx_antenna: Tx Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_antenna: Rx Antenna mounted on ground station
+   * @param [in] ground_station_rx_antenna: Rx Antenna mounted on ground station
    * @return Max bitrate [Mbps]
    */
-  double CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
-                        const Antenna& ground_station_antenna);
+  double CalcMaxBitrate(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
+                        const Antenna& ground_station_rx_antenna);
   /**
    * @fn CalcReceiveMarginOnGs
    * @brief Calculate receive margin at the ground station
    * @param [in] dynamics: Spacecraft dynamics information
-   * @param [in] spacecraft_antenna: Tx Antenna mounted on spacecraft
+   * @param [in] spacecraft_tx_antenna: Tx Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_antenna: Rx Antenna mounted on ground station
+   * @param [in] ground_station_rx_antenna: Rx Antenna mounted on ground station
    * @return Receive margin [dB]
    */
-  double CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
-                               const Antenna& ground_station_antenna);
+  double CalcReceiveMarginOnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
+                               const Antenna& ground_station_rx_antenna);
 
   /**
    * @fn CalcCn0
    * @brief Calculate CN0 (Carrier to Noise density ratio) of received signal at the ground station
    * @param [in] dynamics: Spacecraft dynamics information
-   * @param [in] spacecraft_antenna: Tx Antenna mounted on spacecraft
+   * @param [in] spacecraft_tx_antenna: Tx Antenna mounted on spacecraft
    * @param [in] ground_station: Ground station information
-   * @param [in] ground_station_antenna: Rx Antenna mounted on ground station
+   * @param [in] ground_station_rx_antenna: Rx Antenna mounted on ground station
    * @return CN0 [dB]
    */
-  double CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_antenna, const GroundStation& ground_station,
-                     const Antenna& ground_station_antenna);
+  double CalcCn0OnGs(const Dynamics& dynamics, const Antenna& spacecraft_tx_antenna, const GroundStation& ground_station,
+                     const Antenna& ground_station_rx_antenna);
 };
 
 #endif  // S2E_COMPONENTS_REAL_COMMUNICATION_GROUND_STATION_CALCULATOR_HPP_

--- a/src/components/real/communication/initialize_antenna.cpp
+++ b/src/components/real/communication/initialize_antenna.cpp
@@ -30,6 +30,7 @@ Antenna InitAntenna(const int antenna_id, const std::string file_name) {
   bool is_receiver = antenna_conf.ReadBoolean(Section, "is_receiver");
   double frequency_MHz = antenna_conf.ReadDouble(Section, "frequency_MHz");
 
+  double tx_bitrate_bps = antenna_conf.ReadDouble(Section, "tx_bitrate_bps");
   double tx_output_power_W = antenna_conf.ReadDouble(Section, "tx_output_W");
   double rx_system_noise_temperature_K = antenna_conf.ReadDouble(Section, "rx_system_noise_temperature_K");
 
@@ -72,7 +73,7 @@ Antenna InitAntenna(const int antenna_id, const std::string file_name) {
     rx_parameters.antenna_gain_model = AntennaGainModel::kIsotropic;
   }
 
-  Antenna antenna(antenna_id, quaternion_b2c, is_transmitter, is_receiver, frequency_MHz, tx_output_power_W, tx_parameters,
+  Antenna antenna(antenna_id, quaternion_b2c, is_transmitter, is_receiver, frequency_MHz, tx_bitrate_bps, tx_output_power_W, tx_parameters,
                   rx_system_noise_temperature_K, rx_parameters);
   return antenna;
 }

--- a/src/simulation/ground_station/ground_station.cpp
+++ b/src/simulation/ground_station/ground_station.cpp
@@ -77,6 +77,7 @@ std::string GroundStation::GetLogHeader() const {
     std::string legend = head + "sc" + std::to_string(i) + "_visible_flag";
     str_tmp += WriteScalar(legend);
   }
+  str_tmp += WriteVector("gs_pos", "eci", "m", 3);
   return str_tmp;
 }
 
@@ -86,5 +87,6 @@ std::string GroundStation::GetLogValue() const {
   for (unsigned int i = 0; i < number_of_spacecraft_; i++) {
     str_tmp += WriteScalar(is_visible_.at(i));
   }
+  str_tmp += WriteVector(position_i_m_);
   return str_tmp;
 }

--- a/src/simulation/ground_station/ground_station.cpp
+++ b/src/simulation/ground_station/ground_station.cpp
@@ -77,7 +77,7 @@ std::string GroundStation::GetLogHeader() const {
     std::string legend = head + "sc" + std::to_string(i) + "_visible_flag";
     str_tmp += WriteScalar(legend);
   }
-  str_tmp += WriteVector("gs_pos", "eci", "m", 3);
+  str_tmp += WriteVector("ground_station_position", "eci", "m", 3);
   return str_tmp;
 }
 


### PR DESCRIPTION
## Overview
Update link margin analysis

## Details
- update functions related to link margin analysis to simulate uplink margin analysis and downlink margin analysis simultaneously.

##  Validation results
compare the Python simulation result and S2E simulation result shown in the following figure.
![test_sdown](https://user-images.githubusercontent.com/56018919/225494287-2db73ed7-c733-4afd-81ef-6450683cc348.png)
![test_sup](https://user-images.githubusercontent.com/56018919/225494404-57c97532-79d5-4148-acbf-497a97e45092.png)



## Scope of influence
eg. The behavior of XX will be change

## Supplement
Only for communication and ground station analysis.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
