### PR TITLE
Fix Visual Studio warnings

### DIFF
--- a/src/components/examples/example_serial_communication_with_obc.cpp
+++ b/src/components/examples/example_serial_communication_with_obc.cpp
@@ -51,6 +51,6 @@ void ExampleSerialCommunicationWithObc::MainRoutine(const int time_count) {
   SendTelemetry(0);
 }
 
-void ExampleSerialCommunicationWithObc::GpioStateChanged(int port_id, bool is_positive_edge) {
+void ExampleSerialCommunicationWithObc::GpioStateChanged(const int port_id, const bool is_positive_edge) {
   printf("interrupted. portid = %d, isPosedge = %d./n", port_id, is_positive_edge);
 }

--- a/src/components/examples/example_serial_communication_with_obc.hpp
+++ b/src/components/examples/example_serial_communication_with_obc.hpp
@@ -64,7 +64,7 @@ class ExampleSerialCommunicationWithObc : public Component, public UartCommunica
    * @fn GpioStateChanged
    * @brief Interrupt function for GPIO
    */
-  void GpioStateChanged(int port_id, bool is_positive_edge);
+  void GpioStateChanged(const int port_id, const bool is_positive_edge);
 
  private:
   const static int kMaxMemoryLength = 100;  //!< Maximum memory length

--- a/src/components/real/cdh/on_board_computer.hpp
+++ b/src/components/real/cdh/on_board_computer.hpp
@@ -199,7 +199,7 @@ class OnBoardComputer : public Component {
    * @brief Main routine to execute flight software
    * @note Users need to write flight software
    */
-  virtual void MainRoutine(int time_count);
+  virtual void MainRoutine(const int time_count);
 
  private:
   std::map<int, UartPort*> uart_ports_;  //!< UART ports

--- a/src/components/real/mission/telescope.cpp
+++ b/src/components/real/mission/telescope.cpp
@@ -56,8 +56,8 @@ Telescope::Telescope(ClockGenerator* clock_generator, const libra::Quaternion& q
 
 Telescope::~Telescope() {}
 
-void Telescope::MainRoutine(int count) {
-  UNUSED(count);
+void Telescope::MainRoutine(const int time_count) {
+  UNUSED(time_count);
   // Check forbidden angle
   is_sun_in_forbidden_angle = JudgeForbiddenAngle(local_celestial_information_->GetPositionFromSpacecraft_b_m("SUN"), sun_forbidden_angle_rad_);
   is_earth_in_forbidden_angle = JudgeForbiddenAngle(local_celestial_information_->GetPositionFromSpacecraft_b_m("EARTH"), earth_forbidden_angle_rad_);

--- a/src/components/real/mission/telescope.hpp
+++ b/src/components/real/mission/telescope.hpp
@@ -103,7 +103,7 @@ class Telescope : public Component, public ILoggable {
    * @fn MainRoutine
    * @brief Main routine to calculate force generation
    */
-  void MainRoutine(int count);
+  void MainRoutine(const int time_count);
 
   /**
    * @fn Observe

--- a/src/dynamics/orbit/encke_orbit_propagation.cpp
+++ b/src/dynamics/orbit/encke_orbit_propagation.cpp
@@ -24,7 +24,7 @@ EnckeOrbitPropagation::EnckeOrbitPropagation(const CelestialInformation* celesti
 EnckeOrbitPropagation::~EnckeOrbitPropagation() {}
 
 // Functions for Orbit
-void EnckeOrbitPropagation::Propagate(double end_time_s, double current_time_jd) {
+void EnckeOrbitPropagation::Propagate(const double end_time_s, const double current_time_jd) {
   if (!is_calc_enabled_) return;
 
   // Rectification

--- a/src/dynamics/orbit/kepler_orbit_propagation.cpp
+++ b/src/dynamics/orbit/kepler_orbit_propagation.cpp
@@ -16,7 +16,7 @@ KeplerOrbitPropagation::KeplerOrbitPropagation(const CelestialInformation* celes
 
 KeplerOrbitPropagation::~KeplerOrbitPropagation() {}
 
-void KeplerOrbitPropagation::Propagate(double end_time_s, double current_time_jd) {
+void KeplerOrbitPropagation::Propagate(const double end_time_s, const double current_time_jd) {
   UNUSED(end_time_s);
 
   if (!is_calc_enabled_) return;

--- a/src/dynamics/orbit/kepler_orbit_propagation.hpp
+++ b/src/dynamics/orbit/kepler_orbit_propagation.hpp
@@ -37,7 +37,7 @@ class KeplerOrbitPropagation : public Orbit, public KeplerOrbit {
    * @param [in] end_time_s: End time of simulation [sec]
    * @param [in] current_time_jd: Current Julian day [day]
    */
-  virtual void Propagate(double end_time_s, double current_time_jd);
+  virtual void Propagate(const double end_time_s, const double current_time_jd);
 
  private:
   /**

--- a/src/dynamics/orbit/relative_orbit.cpp
+++ b/src/dynamics/orbit/relative_orbit.cpp
@@ -94,7 +94,7 @@ void RelativeOrbit::CalculateStm(StmModel stm_model_type, const Orbit* reference
   }
 }
 
-void RelativeOrbit::Propagate(double end_time_s, double current_time_jd) {
+void RelativeOrbit::Propagate(const double end_time_s, const double current_time_jd) {
   UNUSED(current_time_jd);
 
   if (!is_calc_enabled_) return;

--- a/src/dynamics/orbit/relative_orbit.hpp
+++ b/src/dynamics/orbit/relative_orbit.hpp
@@ -55,7 +55,7 @@ class RelativeOrbit : public Orbit, public libra::OrdinaryDifferentialEquation<6
    * @param [in] end_time_s: End time of simulation [sec]
    * @param [in] current_time_jd: Current Julian day [day]
    */
-  virtual void Propagate(double end_time_s, double current_time_jd);
+  virtual void Propagate(const double end_time_s, const double current_time_jd);
 
   // Override OrdinaryDifferentialEquation
   /**

--- a/src/dynamics/orbit/rk4_orbit_propagation.cpp
+++ b/src/dynamics/orbit/rk4_orbit_propagation.cpp
@@ -62,7 +62,7 @@ void Rk4OrbitPropagation::Initialize(libra::Vector<3> position_i_m, libra::Vecto
   TransformEcefToGeodetic();
 }
 
-void Rk4OrbitPropagation::Propagate(double end_time_s, double current_time_jd) {
+void Rk4OrbitPropagation::Propagate(const double end_time_s, const double current_time_jd) {
   UNUSED(current_time_jd);
 
   if (!is_calc_enabled_) return;

--- a/src/dynamics/orbit/rk4_orbit_propagation.hpp
+++ b/src/dynamics/orbit/rk4_orbit_propagation.hpp
@@ -52,7 +52,7 @@ class Rk4OrbitPropagation : public Orbit, public libra::OrdinaryDifferentialEqua
    * @param [in] end_time_s: End time of simulation [sec]
    * @param [in] current_time_jd: Current Julian day [day]
    */
-  virtual void Propagate(double end_time_s, double current_time_jd);
+  virtual void Propagate(const double end_time_s, const double current_time_jd);
 
  private:
   double gravity_constant_m3_s2_;  //!< Gravity constant [m3/s2]

--- a/src/dynamics/orbit/sgp4_orbit_propagation.cpp
+++ b/src/dynamics/orbit/sgp4_orbit_propagation.cpp
@@ -35,7 +35,7 @@ Sgp4OrbitPropagation::Sgp4OrbitPropagation(const CelestialInformation* celestial
   is_calc_enabled_ = false;
 }
 
-void Sgp4OrbitPropagation::Propagate(double end_time_s, double current_time_jd) {
+void Sgp4OrbitPropagation::Propagate(const double end_time_s, const double current_time_jd) {
   UNUSED(end_time_s);
 
   if (!is_calc_enabled_) return;

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -156,7 +156,10 @@ std::string CelestialInformation::GetLogHeader() const {
     // Acquisition of body name from id
     bodc2n_c(planet_id, kMaxNameLength, name_buffer, (SpiceBoolean*)&found);
     std::string name = name_buffer;
-    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return (char)std::tolower(c); });
+
+    std::locale loc = std::locale::classic();
+    std::transform(name.begin(), name.end(), name.begin(), [loc](char c) { return std::tolower(c, loc); });
+
     std::string body_pos = name + "_position";
     std::string body_vel = name + "_velocity";
 

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -156,7 +156,7 @@ std::string CelestialInformation::GetLogHeader() const {
     // Acquisition of body name from id
     bodc2n_c(planet_id, kMaxNameLength, name_buffer, (SpiceBoolean*)&found);
     std::string name = name_buffer;
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return std::tolower(c); });
     std::string body_pos = name + "_position";
     std::string body_vel = name + "_velocity";
 

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -182,16 +182,15 @@ std::string CelestialInformation::GetLogValue() const {
 void CelestialInformation::GetPlanetOrbit(const char* planet_name, const double et, double orbit[6]) {
   // Add `BARYCENTER` if needed
   const int kMaxNameLength = 100;
-  char planet_name_[kMaxNameLength];
-  strcpy(planet_name_, planet_name);
+  std::string planet_name_string = planet_name;
   if (strcmp(planet_name, "MARS") == 0 || strcmp(planet_name, "JUPITER") == 0 || strcmp(planet_name, "SATURN") == 0 ||
       strcmp(planet_name, "URANUS") == 0 || strcmp(planet_name, "NEPTUNE") == 0 || strcmp(planet_name, "PLUTO") == 0) {
-    strcat(planet_name_, "_BARYCENTER");
+    planet_name_string += "_BARYCENTER";
   }
 
   // Get orbit
   SpiceDouble lt;
-  spkezr_c((ConstSpiceChar*)planet_name_, (SpiceDouble)et, (ConstSpiceChar*)inertial_frame_name_.c_str(),
+  spkezr_c((ConstSpiceChar*)planet_name_string.c_str(), (SpiceDouble)et, (ConstSpiceChar*)inertial_frame_name_.c_str(),
            (ConstSpiceChar*)aberration_correction_setting_.c_str(), (ConstSpiceChar*)center_body_name_.c_str(), (SpiceDouble*)orbit,
            (SpiceDouble*)&lt);
   return;

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -181,7 +181,6 @@ std::string CelestialInformation::GetLogValue() const {
 
 void CelestialInformation::GetPlanetOrbit(const char* planet_name, const double et, double orbit[6]) {
   // Add `BARYCENTER` if needed
-  const int kMaxNameLength = 100;
   std::string planet_name_string = planet_name;
   if (strcmp(planet_name, "MARS") == 0 || strcmp(planet_name, "JUPITER") == 0 || strcmp(planet_name, "SATURN") == 0 ||
       strcmp(planet_name, "URANUS") == 0 || strcmp(planet_name, "NEPTUNE") == 0 || strcmp(planet_name, "PLUTO") == 0) {

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -156,7 +156,7 @@ std::string CelestialInformation::GetLogHeader() const {
     // Acquisition of body name from id
     bodc2n_c(planet_id, kMaxNameLength, name_buffer, (SpiceBoolean*)&found);
     std::string name = name_buffer;
-    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return std::tolower(c); });
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return (char)std::tolower(c); });
     std::string body_pos = name + "_position";
     std::string body_vel = name + "_velocity";
 

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <locale>
 #include <sstream>
 
 #include "library/logger/log_utility.hpp"

--- a/src/environment/local/local_celestial_information.cpp
+++ b/src/environment/local/local_celestial_information.cpp
@@ -172,7 +172,10 @@ std::string LocalCelestialInformation::GetLogHeader() const {
     // Acquisition of body name from id
     bodc2n_c(planet_id, maxlen, namebuf, (SpiceBoolean*)&found);
     std::string name = namebuf;
-    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return (char)std::tolower(c); });
+
+    std::locale loc = std::locale::classic();
+    std::transform(name.begin(), name.end(), name.begin(), [loc](char c) { return std::tolower(c, loc); });
+
     std::string body_pos = name + "_position_from_spacecraft";
     std::string body_vel = name + "_velocity_from_spacecraft";
     str_tmp += WriteVector(body_pos, "b", "m", 3);

--- a/src/environment/local/local_celestial_information.cpp
+++ b/src/environment/local/local_celestial_information.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <locale>
 #include <sstream>
 
 #include "library/logger/log_utility.hpp"

--- a/src/environment/local/local_celestial_information.cpp
+++ b/src/environment/local/local_celestial_information.cpp
@@ -172,7 +172,7 @@ std::string LocalCelestialInformation::GetLogHeader() const {
     // Acquisition of body name from id
     bodc2n_c(planet_id, maxlen, namebuf, (SpiceBoolean*)&found);
     std::string name = namebuf;
-    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return std::tolower(c); });
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return (char)std::tolower(c); });
     std::string body_pos = name + "_position_from_spacecraft";
     std::string body_vel = name + "_velocity_from_spacecraft";
     str_tmp += WriteVector(body_pos, "b", "m", 3);

--- a/src/environment/local/local_celestial_information.cpp
+++ b/src/environment/local/local_celestial_information.cpp
@@ -172,7 +172,7 @@ std::string LocalCelestialInformation::GetLogHeader() const {
     // Acquisition of body name from id
     bodc2n_c(planet_id, maxlen, namebuf, (SpiceBoolean*)&found);
     std::string name = namebuf;
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return std::tolower(c); });
     std::string body_pos = name + "_position_from_spacecraft";
     std::string body_vel = name + "_velocity_from_spacecraft";
     str_tmp += WriteVector(body_pos, "b", "m", 3);


### PR DESCRIPTION
## Overview
Fix Visual Studio warnings

## Issue
- #335 

## Details
The following warnings were fixed
- warnings relate with `strcpy`
  - Replace `char` to `string`
- [C4373](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4373?view=msvc-170) warnings
  - Modify arguments type
- cast error when we use std::transform to convert lower case

##  Validation results
See the result of build with Visual Studio

https://github.com/ut-issl/s2e-core/actions/runs/4467823499/jobs/7847769419?pr=367

## Scope of influence
NA

## Supplement
NA

## Note
NA