### PR TITLE
Modify log output feature for Monte Carlo simulation

### DIFF
--- a/src/library/logger/logger.cpp
+++ b/src/library/logger/logger.cpp
@@ -15,11 +15,11 @@
 
 std::vector<ILoggable *> log_list_;
 
-Logger::Logger(const std::string &file_name, const std::string &data_path, const std::string &ini_file_name, const bool enable_ini_file_save,
-               const bool enable) {
-  is_enabled_ = enable;
+Logger::Logger(const std::string &file_name, const std::string &data_path, const std::string &ini_file_name, const bool is_ini_save_enabled,
+               const bool is_enabled)
+    : is_enabled_(is_enabled), is_ini_save_enabled_(is_ini_save_enabled) {
   is_file_opened_ = false;
-  is_ini_save_enabled_ = enable_ini_file_save;
+  if (is_enabled_ == false) return;
 
   // Get current time to append it to the filename
   time_t timer = time(NULL);

--- a/src/library/logger/logger.cpp
+++ b/src/library/logger/logger.cpp
@@ -14,6 +14,7 @@
 #endif
 
 std::vector<ILoggable *> log_list_;
+bool Logger::is_directory_created_ = false;
 
 Logger::Logger(const std::string &file_name, const std::string &data_path, const std::string &ini_file_name, const bool is_ini_save_enabled,
                const bool is_enabled)
@@ -29,10 +30,11 @@ Logger::Logger(const std::string &file_name, const std::string &data_path, const
   strftime(start_time_c, 64, "%y%m%d_%H%M%S", now);
 
   // Create directory
-  if (is_ini_save_enabled_ == true)
+  if (is_ini_save_enabled_ == true || is_directory_created_ == false) {
     directory_path_ = CreateDirectory(data_path, start_time_c);
-  else
+  } else {
     directory_path_ = data_path;
+  }
   // Create File
   std::stringstream file_path;
   file_path << directory_path_ << start_time_c << "_" << file_name;
@@ -94,6 +96,7 @@ std::string Logger::CreateDirectory(const std::string &data_path, const std::str
     std::cerr << "Error making directory: " << directory_path_tmp_ << std::endl;
     return data_path;
   }
+  is_directory_created_ = true;
   return directory_path_tmp_;
 }
 

--- a/src/library/logger/logger.hpp
+++ b/src/library/logger/logger.hpp
@@ -26,11 +26,11 @@ class Logger {
    * @param [in] file_name: File name of the log output
    * @param [in] data_path: Path to `data` directory
    * @param [in] ini_file_name: Initialize file name
-   * @param [in] enable_ini_file_save: Enable flag to save ini files
-   * @param [in] enable: Enable flag for logging
+   * @param [in] is_ini_save_enabled: Enable flag to save ini files
+   * @param [in] is_enabled: Enable flag for logging
    */
-  Logger(const std::string &file_name, const std::string &data_path, const std::string &ini_file_name, const bool enable_ini_file_save,
-         const bool enable = true);
+  Logger(const std::string &file_name, const std::string &data_path, const std::string &ini_file_name, const bool is_ini_save_enabled,
+         const bool is_enabled = true);
   /**
    * @fn ~Logger
    * @brief Destructor

--- a/src/library/logger/logger.hpp
+++ b/src/library/logger/logger.hpp
@@ -90,6 +90,7 @@ class Logger {
   std::ofstream csv_file_;             //!< CSV file stream
   bool is_enabled_;                    //!< Enable flag for logging
   bool is_file_opened_;                //!< Is the CSV file opened?
+  static bool is_directory_created_;   //!< Is the log output directory is created in the scenario
   std::vector<ILoggable *> log_list_;  //!< Log list
 
   bool is_ini_save_enabled_;    //!< Enable flag to save ini files

--- a/src/simulation/case/simulation_case.cpp
+++ b/src/simulation/case/simulation_case.cpp
@@ -19,13 +19,19 @@ SimulationCase::SimulationCase(const std::string initialize_base_file) {
 
 SimulationCase::SimulationCase(const std::string initialize_base_file, const MonteCarloSimulationExecutor& monte_carlo_simulator,
                                const std::string log_path) {
-  // Initialize Log
-  // Log for Monte Carlo Simulation
-  std::string log_file_name = "default" + std::to_string(monte_carlo_simulator.GetNumberOfExecutionsDone()) + ".csv";
-  // TODO: Consider that `enable_inilog = false` is fine or not?
-  simulation_configuration_.main_logger_ =
-      new Logger(log_file_name, log_path, initialize_base_file, false, monte_carlo_simulator.GetSaveLogHistoryFlag());
+  if (monte_carlo_simulator.IsEnabled() == false) {
+    // Monte Carlo simulation is disabled
+    simulation_configuration_.main_logger_ = InitLog(initialize_base_file);
+  } else {
+    // Monte Carlo Simulation is enabled
+    std::string log_file_name = "default" + std::to_string(monte_carlo_simulator.GetNumberOfExecutionsDone()) + ".csv";
 
+    IniAccess ini_file(initialize_base_file);
+    bool save_ini_files = ini_file.ReadEnable("SIMULATION_SETTINGS", "save_initialize_files");
+
+    simulation_configuration_.main_logger_ =
+        new Logger(log_file_name, log_path, initialize_base_file, save_ini_files, monte_carlo_simulator.GetSaveLogHistoryFlag());
+  }
   // Initialize Simulation Configuration
   InitializeSimulationConfiguration(initialize_base_file);
 }


### PR DESCRIPTION
## Overview
Modify log output feature for Monte Carlo simulation

## Issue
NA

## Details
Depends on the log output setting for Monte Carlo Simulation, the following log output directories and files will be made by this modification.

### When Monte Carlo simulation is enabled.

- `monte_carlo_enable = ENABLE`, `log_enable = ENABLE`, and  `save_initialize_files=DISABLE`

![image](https://user-images.githubusercontent.com/19573779/229827364-fcc5e342-61d6-44d0-ad73-13ba41718dd2.png)

- `monte_carlo_enable = ENABLE`, `log_enable = DISABLE`, and  `save_initialize_files=DISABLE`

![image](https://user-images.githubusercontent.com/19573779/229828389-3a1ebf11-3ee1-474a-bc03-7756992b2fbc.png)

- `monte_carlo_enable = ENABLE`, `log_enable = DISABLE`, and  `save_initialize_files=ENABLE`

![image](https://user-images.githubusercontent.com/19573779/229828661-638ee385-6b94-40e4-96d0-2ca16ba38eed.png)

- `monte_carlo_enable = ENABLE`, `log_enable = ENABLE`, and  `save_initialize_files=ENABLE`

![image](https://user-images.githubusercontent.com/19573779/229829073-45a0f5e6-6a91-4d4a-a84f-6c85a57c2f0d.png)


### When Monte Carlo simulation is disabled, the log output structure is same with the simulation case without the Monte Carlo simulator

-  `monte_carlo_enable = DISABLE`, `log_enable is not cared`, and  `save_initialize_files=DISABLE`

![image](https://user-images.githubusercontent.com/19573779/229827595-b43d0833-3151-4b4f-a83a-74b98ecec66b.png)

-  `monte_carlo_enable = DISABLE`, `log_enable is not cared`, and  `save_initialize_files = ENABLE`

![image](https://user-images.githubusercontent.com/19573779/229827954-d21a961f-f239-4876-aa6b-634eb45b6059.png)


##  Validation results
See above.

## Scope of influence
NA

## Supplement
NA

## Note
NA