### PR TITLE
[HotFix] Add buffer initialize in UART communication

### DIFF
--- a/src/components/base/uart_communication_with_obc.cpp
+++ b/src/components/base/uart_communication_with_obc.cpp
@@ -103,6 +103,8 @@ UartCommunicationWithObc::~UartCommunicationWithObc() {
 }
 
 void UartCommunicationWithObc::InitializeObcComBase() {
+  tx_buffer_.resize(tx_buffer_size_);
+  rx_buffer_.resize(rx_buffer_size_);
   int ret;
   switch (simulation_mode_) {
     case SimulationMode::kError:


### PR DESCRIPTION
## Overview
[HotFix] Add buffer initialize in UART communication.

## Issue
NA

## Details
In the tutorial of C2A communication, I found this bug and fixed it.

##  Validation results
I confirmed that the C2A communication tutorial works well after this modification.

## Scope of influence
Patch

## Supplement
NA

## Note
NA