### PR TITLE
Fix default SpaceWeather file name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_policy(SET CMP0048 NEW)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 6.0.4
+  VERSION 6.0.5
 )
 
 cmake_minimum_required(VERSION 3.13)

--- a/data/sample/initialize_files/sample_local_environment.ini
+++ b/data/sample/initialize_files/sample_local_environment.ini
@@ -19,7 +19,7 @@ logging = ENABLE
 // Atmosphere model
 // STANDARD: Model using scale height, NRLMSISE00: NRLMSISE00 model
 model = STANDARD
-nrlmsise00_table_file = ../../../ExtLibraries/nrlmsise00/table/SpaceWeather.txt
+nrlmsise00_table_file = ../../../ExtLibraries/nrlmsise00/table/SpaceWeather-v1.2.txt
 // Whether using user-defined f10.7 and ap value
 // Ref of f10.7: https://www.swpc.noaa.gov/phenomena/f107-cm-radio-emissions
 // Ref of ap: http://wdc.kugi.kyoto-u.ac.jp/kp/kpexp-j.html


### PR DESCRIPTION
## Overview
Fix default SpaceWeather file name.

## Issue
https://github.com/ut-issl/s2e-documents/pull/77

## Details
Fix default SpaceWeather file name to suit with `ExtLibraries` automatic download script.

##  Validation results
NA

## Scope of influence
NA

## Supplement
NA

## Note
NA