### PR TITLE
Fix bug in STT time delay

### DIFF
--- a/src/components/real/aocs/star_sensor.cpp
+++ b/src/components/real/aocs/star_sensor.cpp
@@ -92,7 +92,7 @@ Quaternion StarSensor::Measure(const LocalCelestialInformation* local_celestial_
   if (update_count_ == 0) {
     int hist = buffer_position_ - output_delay_ - 1;
     if (hist < 0) {
-      hist += max_delay_;
+      hist = max_delay_ - 1;
     }
     measured_quaternion_i2c_ = delay_buffer_[hist];
   }


### PR DESCRIPTION
## Overview
Fix bug in STT time delay

## Issue
- #56 

## Details
We don't consider the time delay when the time delay is shorter than the STT update period.

##  Validation results
![Picture1](https://github.com/ut-issl/s2e-core/assets/19573779/b004cad0-ca63-495b-bff2-c7706552579d)

## Scope of influence
NA

## Supplement
NA

## Note
NA