### PR TITLE
Modify to handle `LocalEnvironment` in dynamics

### DIFF
--- a/src/dynamics/dynamics.cpp
+++ b/src/dynamics/dynamics.cpp
@@ -8,9 +8,10 @@
 #include "../simulation/multiple_spacecraft/relative_information.hpp"
 
 Dynamics::Dynamics(const SimulationConfiguration* simulation_configuration, const SimulationTime* simulation_time,
-                   const LocalCelestialInformation* local_celestial_information, const int spacecraft_id, Structure* structure,
-                   RelativeInformation* relative_information) {
-  Initialize(simulation_configuration, simulation_time, local_celestial_information, spacecraft_id, structure, relative_information);
+                   const LocalEnvironment* local_environment, const int spacecraft_id, Structure* structure,
+                   RelativeInformation* relative_information)
+    : structure_(structure), local_environment_(local_environment) {
+  Initialize(simulation_configuration, simulation_time, spacecraft_id, structure, relative_information);
 }
 
 Dynamics::~Dynamics() {
@@ -19,16 +20,14 @@ Dynamics::~Dynamics() {
   delete temperature_;
 }
 
-void Dynamics::Initialize(const SimulationConfiguration* simulation_configuration, const SimulationTime* simulation_time,
-                          const LocalCelestialInformation* local_celestial_information, const int spacecraft_id, Structure* structure,
-                          RelativeInformation* relative_information) {
-  structure_ = structure;
-
+void Dynamics::Initialize(const SimulationConfiguration* simulation_configuration, const SimulationTime* simulation_time, const int spacecraft_id,
+                          Structure* structure, RelativeInformation* relative_information) {
+  const LocalCelestialInformation& local_celestial_information = local_environment_->GetCelestialInformation();
   // Initialize
-  orbit_ = InitOrbit(&(local_celestial_information->GetGlobalInformation()), simulation_configuration->spacecraft_file_list_[spacecraft_id],
+  orbit_ = InitOrbit(&(local_celestial_information.GetGlobalInformation()), simulation_configuration->spacecraft_file_list_[spacecraft_id],
                      simulation_time->GetOrbitRkStepTime_s(), simulation_time->GetCurrentTime_jd(),
-                     local_celestial_information->GetGlobalInformation().GetCenterBodyGravityConstant_m3_s2(), "ORBIT", relative_information);
-  attitude_ = InitAttitude(simulation_configuration->spacecraft_file_list_[spacecraft_id], orbit_, local_celestial_information,
+                     local_celestial_information.GetGlobalInformation().GetCenterBodyGravityConstant_m3_s2(), "ORBIT", relative_information);
+  attitude_ = InitAttitude(simulation_configuration->spacecraft_file_list_[spacecraft_id], orbit_, &local_celestial_information,
                            simulation_time->GetAttitudeRkStepTime_s(), structure->GetKinematicsParameters().GetInertiaTensor_b_kgm2(), spacecraft_id);
   temperature_ = InitTemperature(simulation_configuration->spacecraft_file_list_[spacecraft_id], simulation_time->GetThermalRkStepTime_s());
 

--- a/src/dynamics/dynamics.hpp
+++ b/src/dynamics/dynamics.hpp
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "../environment/global/simulation_time.hpp"
-#include "../environment/local/local_celestial_information.hpp"
+#include "../environment/local/local_environment.hpp"
 #include "../library/math/vector.hpp"
 #include "../simulation/simulation_configuration.hpp"
 #include "../simulation/spacecraft/structure/structure.hpp"
@@ -18,6 +18,7 @@
 #include "dynamics/thermal/initialize_temperature.hpp"
 
 class RelativeInformation;
+class LocalEnvironment;
 
 /**
  * @class Dynamics
@@ -35,9 +36,8 @@ class Dynamics {
    * @param [in] structure: Structure of the spacecraft
    * @param [in] relative_information: Relative information
    */
-  Dynamics(const SimulationConfiguration* simulation_configuration, const SimulationTime* simulation_time,
-           const LocalCelestialInformation* local_celestial_information, const int spacecraft_id, Structure* structure,
-           RelativeInformation* relative_information = (RelativeInformation*)nullptr);
+  Dynamics(const SimulationConfiguration* simulation_configuration, const SimulationTime* simulation_time, const LocalEnvironment* local_environment,
+           const int spacecraft_id, Structure* structure, RelativeInformation* relative_information = (RelativeInformation*)nullptr);
   /**
    * @fn ~Dynamics
    * @brief Destructor
@@ -107,10 +107,11 @@ class Dynamics {
   inline Attitude& SetAttitude() const { return *attitude_; }
 
  private:
-  Attitude* attitude_;          //!< Attitude dynamics
-  Orbit* orbit_;                //!< Orbit dynamics
-  Temperature* temperature_;    //!< Thermal dynamics
-  const Structure* structure_;  //!< Structure information
+  Attitude* attitude_;                         //!< Attitude dynamics
+  Orbit* orbit_;                               //!< Orbit dynamics
+  Temperature* temperature_;                   //!< Thermal dynamics
+  const Structure* structure_;                 //!< Structure information
+  const LocalEnvironment* local_environment_;  //!< Local environment
 
   /**
    * @fn Initialize
@@ -122,9 +123,8 @@ class Dynamics {
    * @param [in] structure: Structure of the spacecraft
    * @param [in] relative_information: Relative information
    */
-  void Initialize(const SimulationConfiguration* simulation_configuration, const SimulationTime* simulation_time,
-                  const LocalCelestialInformation* local_celestial_information, const int spacecraft_id, Structure* structure,
-                  RelativeInformation* relative_information = (RelativeInformation*)nullptr);
+  void Initialize(const SimulationConfiguration* simulation_configuration, const SimulationTime* simulation_time, const int spacecraft_id,
+                  Structure* structure, RelativeInformation* relative_information = (RelativeInformation*)nullptr);
 };
 
 #endif  // S2E_DYNAMICS_DYNAMICS_HPP_

--- a/src/environment/local/local_environment.hpp
+++ b/src/environment/local/local_environment.hpp
@@ -14,6 +14,8 @@
 #include "simulation/simulation_configuration.hpp"
 #include "solar_radiation_pressure_environment.hpp"
 
+class Dynamics;
+
 /**
  * @class LocalEnvironment
  * @brief Class to manage local environments

--- a/src/simulation/spacecraft/spacecraft.cpp
+++ b/src/simulation/spacecraft/spacecraft.cpp
@@ -30,8 +30,8 @@ void Spacecraft::Initialize(const SimulationConfiguration* simulation_configurat
   clock_generator_.ClearTimerCount();
   structure_ = new Structure(simulation_configuration, spacecraft_id);
   local_environment_ = new LocalEnvironment(simulation_configuration, global_environment, spacecraft_id);
-  dynamics_ = new Dynamics(simulation_configuration, &(global_environment->GetSimulationTime()), &(local_environment_->GetCelestialInformation()),
-                           spacecraft_id, structure_, relative_information);
+  dynamics_ = new Dynamics(simulation_configuration, &(global_environment->GetSimulationTime()), local_environment_, spacecraft_id, structure_,
+                           relative_information);
   disturbances_ = new Disturbances(simulation_configuration, spacecraft_id, structure_, global_environment);
 
   simulation_configuration->main_logger_->CopyFileToLogDirectory(simulation_configuration->spacecraft_file_list_[spacecraft_id]);


### PR DESCRIPTION
## Overview
Modify to handle `LocalEnvironment` in dynamics

## Issue
Related PR is https://github.com/ut-issl/s2e-core/pull/422

## Details
Thermal dynamics requires `SolarRadiationPressure` information.

##  Validation results
See CI

## Scope of influence
No impact for normal user side.

## Supplement
NA

## Note
NA