### PR TITLE
Modify ExtLib settings for Mac users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_64BIT "Build 64bit" OFF)
 option(GOOGLE_TEST "Execute GoogleTest" OFF)
 
 # Mac user setting
-option(APPLE_SILICON "Build with Apple Silicon" ON)
+option(APPLE_SILICON "Build with Apple Silicon" OFF)
 # Force build with 64bit for APPLE
 if(APPLE)
   option(BUILD_64BIT "Build 64bit" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ option(USE_C2A "Use C2A" OFF)
 option(BUILD_64BIT "Build 64bit" OFF)
 option(GOOGLE_TEST "Execute GoogleTest" OFF)
 
+# Mac user setting
+option(APPLE_SILICON "Build with Apple Silicon" ON)
+# Force build with 64bit for APPLE
+if(APPLE)
+  option(BUILD_64BIT "Build 64bit" ON)
+endif()
+
 # preprocessor
 if(WIN32)
   add_definitions(-DWIN32)
@@ -83,7 +90,15 @@ set(SOURCE_FILES
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
 ## cspice library
-if(CYGWIN)
+if(APPLE)
+  if(APPLE_SILICON)  
+    # APPLE Silicon
+    set(CSPICE_LIB_DIR ${CSPICE_DIR}/cspice_apple_silicon64/lib)
+  else()
+    # APPLE Intel
+    set(CSPICE_LIB_DIR ${CSPICE_DIR}/cspice_apple_intel64/lib)
+  endif()
+elseif(CYGWIN)
   SET (CMAKE_FIND_LIBRARY_SUFFIXES ".so" ".a")
   set(CSPICE_LIB_DIR ${CSPICE_DIR}/cspice_cygwin/lib)
 elseif(UNIX)

--- a/ExtLibraries/CMakeLists.txt
+++ b/ExtLibraries/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.18)
 option(BUILD_64BIT "Build 64bit" OFF)
 
 # Mac user setting
-option(APPLE_SILICON "Build with Apple Silicon" ON)
+option(APPLE_SILICON "Build with Apple Silicon" OFF)
 # Force build with 64bit for APPLE
 if(APPLE)
   option(BUILD_64BIT "Build 64bit" ON)

--- a/ExtLibraries/CMakeLists.txt
+++ b/ExtLibraries/CMakeLists.txt
@@ -5,6 +5,13 @@ cmake_minimum_required(VERSION 3.18)
 # build config
 option(BUILD_64BIT "Build 64bit" OFF)
 
+# Mac user setting
+option(APPLE_SILICON "Build with Apple Silicon" ON)
+# Force build with 64bit for APPLE
+if(APPLE)
+  option(BUILD_64BIT "Build 64bit" ON)
+endif()
+
 if(NOT DEFINED EXT_LIB_DIR)
   set(EXT_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../../ExtLibraries/")
 endif()

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -111,9 +111,10 @@ download_generic_kernel(pck pck00010.tpc "59468328349aa730d18bf1f8d7e86efe6e40b7
 download_generic_kernel(spk/planets de430.bsp "6e1b277c5f07135a84950604b83e56b736be696a7f3560bcddb1d4aeb944fca1")
 
 # move generic kernel
-file(RENAME
+configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/generic_kernels/lsk/a_old_versions/naif0010.tls
   ${CMAKE_CURRENT_BINARY_DIR}/generic_kernels/lsk/naif0010.tls
+  COPYONLY
 )
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generic_kernels

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -19,6 +19,19 @@ if(WIN32)
     set(CSPICE_SHA256 "bc566e6a975c888fc5fd89d76554329501446bda88c8bab937c0725faead170f")
     set(CSPICE_BUILD_COMMAND "")
   endif()
+elseif(APPLE)
+  # APPLE
+  if(APPLE_SILICON)  
+    # APPLE Silicon
+    set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit//C/MacM1_OSX_clang_64bit/packages/cspice.tar.Z)
+    set(CSPICE_SHA256 "0deae048443e11ca4d093cac651d9785d4f2594631a183d85a3d58949f4d0aa9")
+    set(CSPICE_BUILD_COMMAND "")
+  else()
+    # APPLE Intel
+    set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit//C/MacIntel_OSX_AppleC_64bit/packages/cspice.tar.Z)
+    set(CSPICE_SHA256 "6f4980445fee4d363dbce6f571819f4a248358d2c1bebca47e0743eedfe9935e")
+    set(CSPICE_BUILD_COMMAND "")
+  endif()
 else()
   # Linux
   if(BUILD_64BIT)
@@ -55,6 +68,15 @@ if(WIN32)
     set(CSPICE_LIB_DEST "cspice_msvs64")
   else()
     set(CSPICE_LIB_DEST "cspice_msvs")
+  endif()
+elseif(APPLE)
+  # APPLE
+  if(APPLE_SILICON)  
+    # APPLE Silicon
+    set(CSPICE_LIB_DEST "cspice_apple_silicon64")
+  else()
+    # APPLE Intel
+    set(CSPICE_LIB_DEST "cspice_apple_intel64")
   endif()
 else()
   # Linux


### PR DESCRIPTION
## Overview
Modify ExtLib settings for Mac users

## Issue
https://github.com/ut-issl/s2e-core/issues/258
の直接解決にはならないが、代替案になる

## Details
MacユーザーでS2Eのみ使う場合は、64bitビルド前提でそれ専用のCSPICEをダウンロードする方が環境構築が楽なので、それができるようなExtLibraries設定を追加した。

##  Validation results
Macでの確認はローカルで実施。他のプラットフォームで影響がないことはCIで確認。

## Scope of influence
Macユーザーのみ

## Supplement
NA

## Note
CMakeがAPPLEという変数だけでなく、Intel MacかApple Siliconかも分離できる変数を持っていたら、もう少し綺麗にできる気がするが、今の所なさそう。

参考: https://cmake.org/cmake/help/v3.13/genindex.html#A