### PR TITLE
Add relative velocity of atmosphere

### DIFF
--- a/src/disturbances/air_drag.cpp
+++ b/src/disturbances/air_drag.cpp
@@ -24,7 +24,12 @@ AirDrag::AirDrag(const std::vector<Surface>& surfaces, const libra::Vector<3>& c
 
 void AirDrag::Update(const LocalEnvironment& local_environment, const Dynamics& dynamics) {
   double air_density_kg_m3 = local_environment.GetAtmosphere().GetAirDensity_kg_m3();
-  Vector<3> velocity_b_m_s = dynamics.GetOrbit().GetVelocity_b_m_s();
+
+  libra::Matrix<3, 3> dcm_ecef2eci =
+      local_environment.GetCelestialInformation().GetGlobalInformation().GetEarthRotation().GetDcmJ2000ToXcxf().Transpose();
+  libra::Vector<3> relative_velocity_wrt_atmosphere_i_m_s = dcm_ecef2eci * dynamics.GetOrbit().GetVelocity_ecef_m_s();
+  libra::Quaternion quaternion_i2b = dynamics.GetAttitude().GetQuaternion_i2b();
+  libra::Vector<3> velocity_b_m_s = quaternion_i2b.FrameConversion(relative_velocity_wrt_atmosphere_i_m_s);
   CalcTorqueForce(velocity_b_m_s, air_density_kg_m3);
 }
 


### PR DESCRIPTION
## Overview
Add relative velocity of atmosphere

## Issue
- NA

## Details
Add relative velocity effect of atmosphere to calculate air drag.

##  Validation results
Difference between old and new air drag forces and torques are shown in the following figure. The effect is small.

![image](https://github.com/ut-issl/s2e-core/assets/19573779/d7bbe88f-fe1d-44a1-abc9-6ff75146d81f)

## Scope of influence
patch

## Supplement
NA

## Note
NA