### PR TITLE
[Hotfix] Fix bug in controlled attitude mode with RW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_policy(SET CMP0048 NEW)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 6.1.0
+  VERSION 6.1.1
 )
 
 cmake_minimum_required(VERSION 3.13)

--- a/src/simulation_sample/spacecraft/sample_components.cpp
+++ b/src/simulation_sample/spacecraft/sample_components.cpp
@@ -70,9 +70,9 @@ SampleComponents::SampleComponents(const Dynamics* dynamics, Structure* structur
   // RW
   file_name = iniAccess.ReadString("COMPONENT_FILES", "rw_file");
   configuration_->main_logger_->CopyFileToLogDirectory(file_name);
-  reaction_wheel_ =
-      new ReactionWheel(InitReactionWheel(clock_generator, pcu_->GetPowerPort(2), 1, file_name, global_environment_->GetSimulationTime().GetAttitudeUpdateInterval_s(),
-                                          global_environment_->GetSimulationTime().GetComponentStepTime_s()));
+  reaction_wheel_ = new ReactionWheel(InitReactionWheel(clock_generator, pcu_->GetPowerPort(2), 1, file_name,
+                                                        global_environment_->GetSimulationTime().GetAttitudeUpdateInterval_s(),
+                                                        global_environment_->GetSimulationTime().GetComponentStepTime_s()));
 
   // Torque Generator
   file_name = iniAccess.ReadString("COMPONENT_FILES", "torque_generator_file");

--- a/src/simulation_sample/spacecraft/sample_components.cpp
+++ b/src/simulation_sample/spacecraft/sample_components.cpp
@@ -71,7 +71,7 @@ SampleComponents::SampleComponents(const Dynamics* dynamics, Structure* structur
   file_name = iniAccess.ReadString("COMPONENT_FILES", "rw_file");
   configuration_->main_logger_->CopyFileToLogDirectory(file_name);
   reaction_wheel_ =
-      new ReactionWheel(InitReactionWheel(clock_generator, pcu_->GetPowerPort(2), 1, file_name, dynamics_->GetAttitude().GetPropStep_s(),
+      new ReactionWheel(InitReactionWheel(clock_generator, pcu_->GetPowerPort(2), 1, file_name, global_environment_->GetSimulationTime().GetAttitudeUpdateInterval_s(),
                                           global_environment_->GetSimulationTime().GetComponentStepTime_s()));
 
   // Torque Generator


### PR DESCRIPTION
## Overview
[Hotfix] Fix bug in controlled attitude mode with RW

## Issue
NA

## Details
The sample code has a infinite loop bug when users choose `CONTROLLED` attitude mode.  
The cause is `RW` refers `Attitude` class's step width, but it is not defined in the `CONTROLLED` mode.  
I modified the reference to `SimulationTime`.

##  Validation results
The bug was removed.

## Scope of influence
Small. Normally, RW and CONTROLLED attitude mode are not use same time.

## Supplement
NA

## Note
NA