### PR TITLE
Add path definition from exe file to use in ini files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ endif()
 set(CSPICE_DIR ${EXT_LIB_DIR}/cspice)
 set(NRLMSISE00_DIR ${EXT_LIB_DIR}/nrlmsise00)
 
+if(NOT DEFINED INI_FILE_DIR)
+  set(INI_FILE_DIR ../../data/sample/initialize_files/)
+endif()
+
 if(NOT DEFINED FLIGHT_SW_DIR)
   set(FLIGHT_SW_DIR ../FlightSW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,12 @@ endif()
 set(CSPICE_DIR ${EXT_LIB_DIR}/cspice)
 set(NRLMSISE00_DIR ${EXT_LIB_DIR}/nrlmsise00)
 
-if(NOT DEFINED INI_FILE_DIR)
-  set(INI_FILE_DIR ../../data/sample/initialize_files/)
+if(NOT DEFINED INI_FILE_DIR_FROM_EXE)
+  set(INI_FILE_DIR_FROM_EXE ../../data/sample/initialize_files)
+endif()
+
+if(NOT DEFINED EXT_LIB_DIR_FROM_EXE)
+  set(EXT_LIB_DIR_FROM_EXE ../../${EXT_LIB_DIR})
 endif()
 
 if(NOT DEFINED FLIGHT_SW_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,14 @@ endif()
 set(CSPICE_DIR ${EXT_LIB_DIR}/cspice)
 set(NRLMSISE00_DIR ${EXT_LIB_DIR}/nrlmsise00)
 
+if(NOT DEFINED FLIGHT_SW_DIR)
+  set(FLIGHT_SW_DIR ../FlightSW)
+endif()
+if(NOT DEFINED C2A_NAME)
+  set(C2A_NAME "c2a_oss")
+endif()
+
+## Directory path for ini files
 if(NOT DEFINED INI_FILE_DIR_FROM_EXE)
   set(INI_FILE_DIR_FROM_EXE ../../data/sample/initialize_files)
 endif()
@@ -40,11 +48,8 @@ if(NOT DEFINED EXT_LIB_DIR_FROM_EXE)
   set(EXT_LIB_DIR_FROM_EXE ../../${EXT_LIB_DIR})
 endif()
 
-if(NOT DEFINED FLIGHT_SW_DIR)
-  set(FLIGHT_SW_DIR ../FlightSW)
-endif()
-if(NOT DEFINED C2A_NAME)
-  set(C2A_NAME "c2a_oss")
+if(NOT DEFINED CORE_DIR_FROM_EXE)
+  set(CORE_DIR_FROM_EXE ../../../s2e-core)
 endif()
 
 ## options to use C2A

--- a/common.cmake
+++ b/common.cmake
@@ -10,6 +10,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 # Compile option
 target_compile_definitions(${PROJECT_NAME} PRIVATE "INI_FILE_DIR_FROM_EXE=\"${INI_FILE_DIR_FROM_EXE}\"")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "EXT_LIB_DIR_FROM_EXE=\"${EXT_LIB_DIR_FROM_EXE}\"")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "CORE_DIR_FROM_EXE=\"${CORE_DIR_FROM_EXE}\"")
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/MP")  # multi process build
 

--- a/common.cmake
+++ b/common.cmake
@@ -8,7 +8,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${S2E_DIR}/src)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Compile option
-target_compile_definitions(${PROJECT_NAME} PRIVATE "INI_FILE_DIR=\"${INI_FILE_DIR}\"")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "INI_FILE_DIR_FROM_EXE=\"${INI_FILE_DIR_FROM_EXE}\"")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "EXT_LIB_DIR_FROM_EXE=\"${EXT_LIB_DIR_FROM_EXE}\"")
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/MP")  # multi process build
 

--- a/common.cmake
+++ b/common.cmake
@@ -8,6 +8,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${S2E_DIR}/src)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Compile option
+target_compile_definitions(${PROJECT_NAME} PRIVATE "INI_FILE_DIR=\"${INI_FILE_DIR}\"")
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/MP")  # multi process build
 

--- a/common.cmake
+++ b/common.cmake
@@ -7,10 +7,12 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS FALSE)
 target_include_directories(${PROJECT_NAME} PUBLIC ${S2E_DIR}/src)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Compile option
+# Directory path setting
 target_compile_definitions(${PROJECT_NAME} PRIVATE "INI_FILE_DIR_FROM_EXE=\"${INI_FILE_DIR_FROM_EXE}\"")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "EXT_LIB_DIR_FROM_EXE=\"${EXT_LIB_DIR_FROM_EXE}\"")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "CORE_DIR_FROM_EXE=\"${CORE_DIR_FROM_EXE}\"")
+
+# Compile option
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/MP")  # multi process build
 

--- a/data/sample/initialize_files/sample_disturbance.ini
+++ b/data/sample/initialize_files/sample_disturbance.ini
@@ -3,7 +3,7 @@
 calculation = DISABLE
 logging = ENABLE
 degree = 4
-coefficients_file_path = ../../../ExtLibraries/GeoPotential/egm96_to360.ascii
+coefficients_file_path = EXT_LIB_DIR_FROM_EXE/GeoPotential/egm96_to360.ascii
 
 
 [MAGNETIC_DISTURBANCE]

--- a/data/sample/initialize_files/sample_gnss.ini
+++ b/data/sample/initialize_files/sample_gnss.ini
@@ -1,5 +1,5 @@
 [GNSS_SATELLIES]
-directory_path = ../../../ExtLibraries/sp3/
+directory_path = EXT_LIB_DIR_FROM_EXE/sp3/
 calculation = DISABLE
 
 true_position_file_sort = IGS

--- a/data/sample/initialize_files/sample_ground_station.ini
+++ b/data/sample/initialize_files/sample_ground_station.ini
@@ -8,5 +8,5 @@ height_m = 3.4
 elevation_limit_angle_deg = 5.0
 
 [COMPONENT_FILES]
-ground_station_antenna_file = ../../data/sample/initialize_files/components/ground_station_antenna.ini
-ground_station_calculator_file = ../../data/sample/initialize_files/components/ground_station_calculator.ini
+ground_station_antenna_file = INI_FILE_DIR_FROM_EXE/components/ground_station_antenna.ini
+ground_station_calculator_file = INI_FILE_DIR_FROM_EXE/components/ground_station_calculator.ini

--- a/data/sample/initialize_files/sample_local_environment.ini
+++ b/data/sample/initialize_files/sample_local_environment.ini
@@ -1,7 +1,7 @@
 [MAGNETIC_FIELD_ENVIRONMENT]
 calculation = ENABLE
 logging = ENABLE
-coefficient_file = ../../../s2e-core/src/library/external/igrf/igrf13.coef
+coefficient_file = CORE_DIR_FROM_EXE/src/library/external/igrf/igrf13.coef
 magnetic_field_random_walk_standard_deviation_nT = 10.0
 magnetic_field_random_walk_limit_nT = 400.0
 magnetic_field_white_noise_standard_deviation_nT = 50.0

--- a/data/sample/initialize_files/sample_local_environment.ini
+++ b/data/sample/initialize_files/sample_local_environment.ini
@@ -21,7 +21,7 @@ logging = ENABLE
 // NRLMSISE00: NRLMSISE00 model
 // HARRIS_PRIESTER: Harris-Priester model
 model = STANDARD
-nrlmsise00_table_file = ../../../ExtLibraries/nrlmsise00/table/SpaceWeather-v1.2.txt
+nrlmsise00_table_file = EXT_LIB_DIR_FROM_EXE/nrlmsise00/table/SpaceWeather-v1.2.txt
 // Whether using user-defined f10.7 and ap value
 // Ref of f10.7: https://www.swpc.noaa.gov/phenomena/f107-cm-radio-emissions
 // Ref of ap: http://wdc.kugi.kyoto-u.ac.jp/kp/kpexp-j.html

--- a/data/sample/initialize_files/sample_satellite.ini
+++ b/data/sample/initialize_files/sample_satellite.ini
@@ -126,22 +126,22 @@ error_tolerance = 0.0001
 calculation = DISABLE
 debug = DISABLE
 solar_calc_setting = DISABLE
-thermal_file_directory = ../../data/sample/initialize_files/thermal_csv_files/
+thermal_file_directory = INI_FILE_DIR_FROM_EXE/thermal_csv_files/
 
 [SETTING_FILES]
-local_environment_file = ../../data/sample/initialize_files/sample_local_environment.ini
-disturbance_file  = ../../data/sample/initialize_files/sample_disturbance.ini
-structure_file = ../../data/sample/initialize_files/sample_structure.ini
+local_environment_file = INI_FILE_DIR_FROM_EXE/sample_local_environment.ini
+disturbance_file  = INI_FILE_DIR_FROM_EXE/sample_disturbance.ini
+structure_file = INI_FILE_DIR_FROM_EXE/sample_structure.ini
 
 [COMPONENT_FILES]
-gyro_file = ../../data/sample/initialize_files/components/gyro_sensor.ini
-magnetometer_file = ../../data/sample/initialize_files/components/magnetometer.ini
-stt_file = ../../data/sample/initialize_files/components/star_sensor.ini
-ss_file = ../../data/sample/initialize_files/components/sun_sensor.ini
-gnss_file = ../../data/sample/initialize_files/components/gnss_receiver.ini
-magetorquer_file = ../../data/sample/initialize_files/components/magnetorquer.ini
-rw_file = ../../data/sample/initialize_files/components/reaction_wheel.ini
-thruster_file = ../../data/sample/initialize_files/components/thruster.ini
-force_generator_file = ../../data/sample/initialize_files/components/force_generator.ini
-torque_generator_file = ../../data/sample/initialize_files/components/torque_generator.ini
-antenna_file = ../../data/sample/initialize_files/components/spacecraft_antenna.ini
+gyro_file = INI_FILE_DIR_FROM_EXE/components/gyro_sensor.ini
+magnetometer_file = INI_FILE_DIR_FROM_EXE/components/magnetometer.ini
+stt_file = INI_FILE_DIR_FROM_EXE/components/star_sensor.ini
+ss_file = INI_FILE_DIR_FROM_EXE/components/sun_sensor.ini
+gnss_file = INI_FILE_DIR_FROM_EXE/components/gnss_receiver.ini
+magetorquer_file = INI_FILE_DIR_FROM_EXE/components/magnetorquer.ini
+rw_file = INI_FILE_DIR_FROM_EXE/components/reaction_wheel.ini
+thruster_file = INI_FILE_DIR_FROM_EXE/components/thruster.ini
+force_generator_file = INI_FILE_DIR_FROM_EXE/components/force_generator.ini
+torque_generator_file = INI_FILE_DIR_FROM_EXE/components/torque_generator.ini
+antenna_file = INI_FILE_DIR_FROM_EXE/components/spacecraft_antenna.ini

--- a/data/sample/initialize_files/sample_simulation_base.ini
+++ b/data/sample/initialize_files/sample_simulation_base.ini
@@ -134,7 +134,7 @@ save_initialize_files = ENABLE
 // If you want to add a ground station, create the corresponding ground_station.ini, and specify it as ground_station_file(1), ground_station_file(2), ect.
 number_of_simulated_spacecraft = 1
 number_of_simulated_ground_station = 1
-spacecraft_file(0)      = ../../data/sample/initialize_files/sample_satellite.ini
-ground_station_file(0)  = ../../data/sample/initialize_files/sample_ground_station.ini
-gnss_file               = ../../data/sample/initialize_files/sample_gnss.ini
+spacecraft_file(0)      = INI_FILE_DIR/sample_satellite.ini
+ground_station_file(0)  = INI_FILE_DIR/sample_ground_station.ini
+gnss_file               = INI_FILE_DIR/sample_gnss.ini
 log_file_save_directory = ../../data/sample/logs/

--- a/data/sample/initialize_files/sample_simulation_base.ini
+++ b/data/sample/initialize_files/sample_simulation_base.ini
@@ -105,15 +105,15 @@ selected_body_name(10) = PLUTO
 
 [CSPICE_KERNELS]
 // CSPICE Kernel files definition
-tls  = ../../../ExtLibraries/cspice/generic_kernels/lsk/naif0010.tls
-tpc1 = ../../../ExtLibraries/cspice/generic_kernels/pck/de-403-masses.tpc
-tpc2 = ../../../ExtLibraries/cspice/generic_kernels/pck/gm_de431.tpc
-tpc3 = ../../../ExtLibraries/cspice/generic_kernels/pck/pck00010.tpc
-bsp  = ../../../ExtLibraries/cspice/generic_kernels/spk/planets/de430.bsp
+tls  = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/lsk/naif0010.tls
+tpc1 = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/pck/de-403-masses.tpc
+tpc2 = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/pck/gm_de431.tpc
+tpc3 = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/pck/pck00010.tpc
+bsp  = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/spk/planets/de430.bsp
 
 
 [HIPPARCOS_CATALOGUE]
-catalogue_file_path = ../../../ExtLibraries/HipparcosCatalogue/hip_main.csv
+catalogue_file_path = EXT_LIB_DIR_FROM_EXE/HipparcosCatalogue/hip_main.csv
 max_magnitude = 3.0	// Max magnitude to read from Hip catalog
 calculation = DISABLE
 logging = DISABLE
@@ -134,7 +134,7 @@ save_initialize_files = ENABLE
 // If you want to add a ground station, create the corresponding ground_station.ini, and specify it as ground_station_file(1), ground_station_file(2), ect.
 number_of_simulated_spacecraft = 1
 number_of_simulated_ground_station = 1
-spacecraft_file(0)      = INI_FILE_DIR/sample_satellite.ini
-ground_station_file(0)  = INI_FILE_DIR/sample_ground_station.ini
-gnss_file               = INI_FILE_DIR/sample_gnss.ini
+spacecraft_file(0)      = INI_FILE_DIR_FROM_EXE/sample_satellite.ini
+ground_station_file(0)  = INI_FILE_DIR_FROM_EXE/sample_ground_station.ini
+gnss_file               = INI_FILE_DIR_FROM_EXE/sample_gnss.ini
 log_file_save_directory = ../../data/sample/logs/

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cstring>
 #include <limits>
+#include <regex>
 
 #include "../utilities/macros.hpp"
 
@@ -120,14 +121,18 @@ void IniAccess::ReadChar(const char* section_name, const char* key_name, const i
 }
 
 std::string IniAccess::ReadString(const char* section_name, const char* key_name) {
+  std::string value;
 #ifdef WIN32
   char temp[kMaxCharLength];
   ReadChar(section_name, key_name, kMaxCharLength, temp);
-  return std::string(temp);
+  value = std::string(temp);
 #else
-  std::string value = ini_reader_.GetString(section_name, key_name, "NULL");
-  return value;
+  value = ini_reader_.GetString(section_name, key_name, "NULL");
 #endif
+  // Special characters
+  std::string ini_path = INI_FILE_DIR;
+  value = std::regex_replace(value, std::regex("INI_FILE_DIR"), ini_path);
+  return value;
 }
 
 bool IniAccess::ReadEnable(const char* section_name, const char* key_name) {

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -136,6 +136,9 @@ std::string IniAccess::ReadString(const char* section_name, const char* key_name
   // EXT_LIB_DIR
   std::string ext_lib_path = EXT_LIB_DIR_FROM_EXE;
   value = std::regex_replace(value, std::regex("EXT_LIB_DIR_FROM_EXE"), ext_lib_path);
+  // CORE_DIR
+  std::string s2e_core_path = CORE_DIR_FROM_EXE;
+  value = std::regex_replace(value, std::regex("CORE_DIR_FROM_EXE"), s2e_core_path);
 
   return value;
 }

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -161,7 +161,7 @@ std::vector<std::string> IniAccess::ReadStrVector(const char* section_name, cons
 #ifdef WIN32
     if (temp.c_str()[0] == NULL) {
 #else
-    if (!strcmp(temp, "NULL")) {
+    if (!strcmp(temp.c_str(), "NULL")) {
 #endif
       break;
     } else {

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -130,8 +130,13 @@ std::string IniAccess::ReadString(const char* section_name, const char* key_name
   value = ini_reader_.GetString(section_name, key_name, "NULL");
 #endif
   // Special characters
-  std::string ini_path = INI_FILE_DIR;
-  value = std::regex_replace(value, std::regex("INI_FILE_DIR"), ini_path);
+  // INI_FILE_DIR
+  std::string ini_path = INI_FILE_DIR_FROM_EXE;
+  value = std::regex_replace(value, std::regex("INI_FILE_DIR_FROM_EXE"), ini_path);
+  // EXT_LIB_DIR
+  std::string ext_lib_path = EXT_LIB_DIR_FROM_EXE;
+  value = std::regex_replace(value, std::regex("EXT_LIB_DIR_FROM_EXE"), ext_lib_path);
+
   return value;
 }
 

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -152,14 +152,14 @@ bool IniAccess::ReadEnable(const char* section_name, const char* key_name) {
 
 std::vector<std::string> IniAccess::ReadStrVector(const char* section_name, const char* key_name) {
   std::vector<std::string> data;
-  char temp[kMaxCharLength];
+  std::string temp;
   unsigned int i = 0;
   while (true) {
     std::stringstream c_name;
     c_name << key_name << "(" << i << ")";
-    ReadChar(section_name, c_name.str().c_str(), kMaxCharLength, temp);
+    temp = ReadString(section_name, c_name.str().c_str());
 #ifdef WIN32
-    if (temp[0] == NULL) {
+    if (temp.c_str()[0] == NULL) {
 #else
     if (!strcmp(temp, "NULL")) {
 #endif

--- a/src/s2e.cpp
+++ b/src/s2e.cpp
@@ -47,7 +47,8 @@ int main(int argc, char *argv[])
   start = system_clock::now();
 
   std::string data_path = "../../data/";
-  std::string ini_file = "../../data/sample/initialize_files/sample_simulation_base.ini";
+  std::string ini_path = INI_FILE_DIR;
+  std::string ini_file = ini_path + "/sample_simulation_base.ini";
 
   // Parsing arguments:  SatAttSim <data_path> [ini_file]
   if (argc == 0) {

--- a/src/s2e.cpp
+++ b/src/s2e.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   start = system_clock::now();
 
   std::string data_path = "../../data/";
-  std::string ini_path = INI_FILE_DIR;
+  std::string ini_path = INI_FILE_DIR_FROM_EXE;
   std::string ini_file = ini_path + "/sample_simulation_base.ini";
 
   // Parsing arguments:  SatAttSim <data_path> [ini_file]


### PR DESCRIPTION
## Overview
Add path definition from exe file to use in ini files

## Issue
#158 

## Details
iniファイルに書かれている各種相対パスが実行環境やユーザー部の設定の仕方によって変わるという問題に簡単に対処できるよう相対パスを設定できるようにしてみました。

ベストな対応ではないと思いますが、#160 が完了するまでの処置としてはこれでもだいぶ便利になる気がしています。

##  Validation results
See CI

## Scope of influence
Minor update

## Supplement
NA

## Note
NA