### PR TITLE
[hotfix] Fix ini file path for RWs and antenna

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_policy(SET CMP0048 NEW)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 6.2.0
+  VERSION 6.2.1
 )
 
 cmake_minimum_required(VERSION 3.13)

--- a/data/sample/initialize_files/components/ground_station_antenna.ini
+++ b/data/sample/initialize_files/components/ground_station_antenna.ini
@@ -37,7 +37,7 @@ tx_antenna_gain_model = ISOTROPIC
 tx_gain_dBi = 12.0
 
 // Antenna radiation pattern CSV file path
-tx_antenna_radiation_pattern_file = .../../data/sample/initialize_files/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
+tx_antenna_radiation_pattern_file = INI_FILE_DIR_FROM_EXE/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
 // General information of the CSV file
 tx_length_theta = 360
 tx_length_phi = 181
@@ -65,7 +65,7 @@ rx_antenna_gain_model = ISOTROPIC
 rx_gain_dBi = 43.27
 
 // Antenna radiation pattern CSV file path
-rx_antenna_radiation_pattern_file = ../../data/sample/initialize_files/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
+rx_antenna_radiation_pattern_file = INI_FILE_DIR_FROM_EXE/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
 // General information of the CSV file
 rx_length_theta = 360
 rx_length_phi = 181

--- a/data/sample/initialize_files/components/reaction_wheel.ini
+++ b/data/sample/initialize_files/components/reaction_wheel.ini
@@ -52,8 +52,8 @@ initial_angular_velocity_rad_s = 0.0
 //Parameters for calculate RW jitter
 jitter_calculation = DISABLE
 jitter_logging = DISABLE
-radial_force_harmonics_coefficient_file = ../../data/sample/initialize_files/components/rw_disturbance_csv_files/radial_force_harmonics_coefficients.csv
-radial_torque_harmonics_coefficient_file = ../../data/sample/initialize_files/components/rw_disturbance_csv_files/radial_torque_harmonics_coefficients.csv
+radial_force_harmonics_coefficient_file = INI_FILE_DIR_FROM_EXE/components/rw_disturbance_csv_files/radial_force_harmonics_coefficients.csv
+radial_torque_harmonics_coefficient_file = INI_FILE_DIR_FROM_EXE/components/rw_disturbance_csv_files/radial_torque_harmonics_coefficients.csv
 harmonics_degree = 12
 considers_structural_resonance = DISABLE
 structural_resonance_frequency_Hz = 585.0 //[Hz]

--- a/data/sample/initialize_files/components/spacecraft_antenna.ini
+++ b/data/sample/initialize_files/components/spacecraft_antenna.ini
@@ -37,7 +37,7 @@ tx_antenna_gain_model = RADIATION_PATTERN_CSV
 tx_gain_dBi = 8.0
 
 // Antenna radiation pattern CSV file path
-tx_antenna_radiation_pattern_file = ../../data/sample/initialize_files/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
+tx_antenna_radiation_pattern_file = INI_FILE_DIR_FROM_EXE/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
 // General information of the CSV file
 tx_length_theta = 360
 tx_length_phi = 181
@@ -65,7 +65,7 @@ rx_antenna_gain_model = RADIATION_PATTERN_CSV
 rx_gain_dBi = 43.27
 
 // Antenna radiation pattern CSV file path
-rx_antenna_radiation_pattern_file = ../../data/sample/initialize_files/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
+rx_antenna_radiation_pattern_file = INI_FILE_DIR_FROM_EXE/components/antenna_radiation_pattern_csv_files/sample_antenna_radiation_pattern.csv
 // General information of the CSV file
 rx_length_theta = 360
 rx_length_phi = 181


### PR DESCRIPTION
## Overview
Fix ini file path for RWs and antennas

## Issue
NA

## Details
I found ini file paths which don't use `INI_FILE_DIR_FROM_EXE`.

##  Validation results
locally tested.

## Scope of influence
patch

## Supplement
NA

## Note
NA