### PR TITLE
Remove size_t related warnings

### DIFF
--- a/src/components/real/mission/telescope.cpp
+++ b/src/components/real/mission/telescope.cpp
@@ -107,7 +107,7 @@ void Telescope::ObserveStars() {
   Quaternion quaternion_i2b = attitude_->GetQuaternion_i2b();
 
   star_list_in_sight.clear();  // Clear first
-  int count = 0;               // Counter for while loop
+  size_t count = 0;            // Counter for while loop
 
   while (star_list_in_sight.size() < number_of_logged_stars_) {
     libra::Vector<3> target_b = hipparcos_->GetStarDirection_b(count, quaternion_i2b);

--- a/src/disturbances/air_drag.cpp
+++ b/src/disturbances/air_drag.cpp
@@ -17,7 +17,7 @@ AirDrag::AirDrag(const std::vector<Surface>& surfaces, const libra::Vector<3>& c
       wall_temperature_K_(wall_temperature_K),
       molecular_temperature_K_(molecular_temperature_K),
       molecular_weight_g_mol_(molecular_weight_g_mol) {
-  int num = surfaces_.size();
+  size_t num = surfaces_.size();
   ct_.assign(num, 1.0);
   cn_.assign(num, 0.0);
 }

--- a/src/disturbances/surface_force.cpp
+++ b/src/disturbances/surface_force.cpp
@@ -10,7 +10,7 @@
 SurfaceForce::SurfaceForce(const std::vector<Surface>& surfaces, const libra::Vector<3>& center_of_gravity_b_m, const bool is_calculation_enabled)
     : Disturbance(is_calculation_enabled, true), surfaces_(surfaces), center_of_gravity_b_m_(center_of_gravity_b_m) {
   // Initialize vectors
-  int num = surfaces_.size();
+  size_t num = surfaces_.size();
   normal_coefficients_.assign(num, 0.0);
   tangential_coefficients_.assign(num, 0.0);
   cos_theta_.assign(num, 0.0);

--- a/src/dynamics/thermal/initialize_temperature.cpp
+++ b/src/dynamics/thermal/initialize_temperature.cpp
@@ -69,8 +69,8 @@ Temperature* InitTemperature(const std::string file_name, const double rk_prop_s
   vector<vector<string>> node_str_list;      // string vector of node property data
   vector<vector<string>> heater_str_list;    // string vector of heater property data
   vector<vector<string>> heatload_str_list;  // string vector of heatload property data
-  unsigned int node_num = 1;
-  unsigned int heater_num = 1;
+  size_t node_num = 1;
+  size_t heater_num = 1;
 
   bool is_calc_enabled = mainIni.ReadEnable("THERMAL", "calculation");
   if (is_calc_enabled == false) {

--- a/src/environment/global/gnss_satellites.cpp
+++ b/src/environment/global/gnss_satellites.cpp
@@ -84,17 +84,17 @@ double get_unixtime_from_timestamp_line(std::vector<string>& s) {
 template <size_t N>
 libra::Vector<N> GnssSat_coordinate::TrigonometricInterpolation(const vector<double>& time_vector, const vector<libra::Vector<N>>& values,
                                                                 double time) const {
-  int n = time_vector.size();
+  size_t n = time_vector.size();
   double w = libra::tau / (24.0 * 60.0 * 60.0) * 1.03;  // coefficient of a day long
   libra::Vector<N> res(0.0);
 
-  for (int i = 0; i < n; ++i) {
+  for (size_t i = 0; i < n; ++i) {
     double t_k = 1.0;
-    for (int j = 0; j < n; ++j) {
+    for (size_t j = 0; j < n; ++j) {
       if (i == j) continue;
       t_k *= sin(w * (time - time_vector.at(j)) / 2.0) / sin(w * (time_vector.at(i) - time_vector.at(j)) / 2.0);
     }
-    for (int j = 0; j < (int)N; ++j) {
+    for (size_t j = 0; j < (int)N; ++j) {
       res(j) += t_k * values.at(i)(j);
     }
   }
@@ -103,13 +103,13 @@ libra::Vector<N> GnssSat_coordinate::TrigonometricInterpolation(const vector<dou
 }
 
 double GnssSat_coordinate::TrigonometricInterpolation(const vector<double>& time_vector, const vector<double>& values, double time) const {
-  int n = time_vector.size();
+  size_t n = time_vector.size();
   double w = libra::tau / (24.0 * 60.0 * 60.0) * 1.03;  // coefficient of a day long
   double res = 0.0;
 
-  for (int i = 0; i < n; ++i) {
+  for (size_t i = 0; i < n; ++i) {
     double t_k = 1.0;
-    for (int j = 0; j < n; ++j) {
+    for (size_t j = 0; j < n; ++j) {
       if (i == j) continue;
       t_k *= sin(w * (time - time_vector.at(j)) / 2.0) / sin(w * (time_vector.at(i) - time_vector.at(j)) / 2.0);
     }
@@ -140,11 +140,11 @@ libra::Vector<N> GnssSat_coordinate::LagrangeInterpolation(const vector<double>&
 }
 
 double GnssSat_coordinate::LagrangeInterpolation(const vector<double>& time_vector, const vector<double>& values, double time) const {
-  int n = time_vector.size();
+  size_t n = time_vector.size();
   double res = 0.0;
-  for (int i = 0; i < n; ++i) {
+  for (size_t i = 0; i < n; ++i) {
     double l_i = 1.0;
-    for (int j = 0; j < n; ++j) {
+    for (size_t j = 0; j < n; ++j) {
       if (i == j) continue;
       l_i *= (time - time_vector.at(j)) / (time_vector.at(i) - time_vector.at(j));
     }

--- a/src/environment/global/hipparcos_catalogue.cpp
+++ b/src/environment/global/hipparcos_catalogue.cpp
@@ -49,7 +49,7 @@ bool HipparcosCatalogue::ReadContents(const std::string& file_name, const char d
   return true;
 }
 
-libra::Vector<3> HipparcosCatalogue::GetStarDirection_i(int rank) const {
+libra::Vector<3> HipparcosCatalogue::GetStarDirection_i(size_t rank) const {
   libra::Vector<3> direction_i;
   double ra_rad = GetRightAscension_deg(rank) * libra::deg_to_rad;
   double de_rad = GetDeclination_deg(rank) * libra::deg_to_rad;
@@ -61,7 +61,7 @@ libra::Vector<3> HipparcosCatalogue::GetStarDirection_i(int rank) const {
   return direction_i;
 }
 
-libra::Vector<3> HipparcosCatalogue::GetStarDirection_b(int rank, libra::Quaternion quaternion_i2b) const {
+libra::Vector<3> HipparcosCatalogue::GetStarDirection_b(size_t rank, libra::Quaternion quaternion_i2b) const {
   libra::Vector<3> direction_i;
   libra::Vector<3> direction_b;
 

--- a/src/environment/global/hipparcos_catalogue.hpp
+++ b/src/environment/global/hipparcos_catalogue.hpp
@@ -52,7 +52,7 @@ class HipparcosCatalogue : public ILoggable {
    *@fn GetCatalogueSize
    *@brief Return read catalogue size
    */
-  int GetCatalogueSize() const { return hipparcos_catalogue_.size(); }
+  size_t GetCatalogueSize() const { return hipparcos_catalogue_.size(); }
   /**
    *@fn GetHipparcosId
    *@brief Return Hipparcos ID of a star

--- a/src/environment/global/hipparcos_catalogue.hpp
+++ b/src/environment/global/hipparcos_catalogue.hpp
@@ -58,38 +58,38 @@ class HipparcosCatalogue : public ILoggable {
    *@brief Return Hipparcos ID of a star
    *@param [in] rank: Rank of star magnitude in read catalogue
    */
-  int GetHipparcosId(int rank) const { return hipparcos_catalogue_[rank].hipparcos_id; }
+  int GetHipparcosId(size_t rank) const { return hipparcos_catalogue_[rank].hipparcos_id; }
   /**
    *@fn GetVisibleMagnitude
    *@brief Return magnitude in visible wave length of a star
    *@param [in] rank: Rank of star magnitude in read catalogue
    */
-  double GetVisibleMagnitude(int rank) const { return hipparcos_catalogue_[rank].visible_magnitude; }
+  double GetVisibleMagnitude(size_t rank) const { return hipparcos_catalogue_[rank].visible_magnitude; }
   /**
    *@fn GetRightAscension_deg
    *@brief Return right ascension of a star
    *@param [in] rank: Rank of star magnitude in read catalogue
    */
-  double GetRightAscension_deg(int rank) const { return hipparcos_catalogue_[rank].right_ascension_deg; }
+  double GetRightAscension_deg(size_t rank) const { return hipparcos_catalogue_[rank].right_ascension_deg; }
   /**
    *@fn GetDeclination_deg
    *@brief Return declination of a star
    *@param [in] rank: Rank of star magnitude in read catalogue
    */
-  double GetDeclination_deg(int rank) const { return hipparcos_catalogue_[rank].declination_deg; }
+  double GetDeclination_deg(size_t rank) const { return hipparcos_catalogue_[rank].declination_deg; }
   /**
    *@fn GetStarDir_i
    *@brief Return direction vector of a star in the inertial frame
    *@param [in] rank: Rank of star magnitude in read catalogue
    */
-  libra::Vector<3> GetStarDirection_i(int rank) const;
+  libra::Vector<3> GetStarDirection_i(size_t rank) const;
   /**
    *@fn GetStarDir_b
    *@brief Return direction vector of a star in the body-fixed frame
    *@param [in] rank: Rank of star magnitude in read catalogue
    *@param [in] quaternion_i2b: Quaternion from the inertial frame to the body-fixed frame
    */
-  libra::Vector<3> GetStarDirection_b(int rank, libra::Quaternion quaternion_i2b) const;
+  libra::Vector<3> GetStarDirection_b(size_t rank, libra::Quaternion quaternion_i2b) const;
 
   // Override ILoggable
   /**

--- a/src/library/external/nrlmsise00/wrapper_nrlmsise00.cpp
+++ b/src/library/external/nrlmsise00/wrapper_nrlmsise00.cpp
@@ -174,7 +174,7 @@ double CalcNRLMSISE00(double decyear, double latrad, double lonrad, double alt, 
 
   size_t i;
   int date[6];
-  int idx = 0;
+  size_t idx = 0;
 
   /* input values */
   for (i = 0; i < 24; i++) {
@@ -236,7 +236,7 @@ double CalcNRLMSISE00(double decyear, double latrad, double lonrad, double alt, 
 /* ------------------------------------------------------------------- */
 /* -----------------------ReadSpaceWeatherTable----------------------- */
 /* ------------------------------------------------------------------- */
-int GetSpaceWeatherTable_(double decyear, double endsec, const string& filename, vector<nrlmsise_table>& table) {
+size_t GetSpaceWeatherTable_(double decyear, double endsec, const string& filename, vector<nrlmsise_table>& table) {
   ifstream ifs(filename);
 
   if (!ifs.is_open()) {

--- a/src/library/external/nrlmsise00/wrapper_nrlmsise00.hpp
+++ b/src/library/external/nrlmsise00/wrapper_nrlmsise00.hpp
@@ -56,7 +56,7 @@ double CalcNRLMSISE00(double decyear, double latrad, double lonrad, double alt, 
  * @param [out] table: Space weather table
  * @return Size of table
  */
-int GetSpaceWeatherTable_(double decyear, double endsec, const std::string& filename, std::vector<nrlmsise_table>& table);
+size_t GetSpaceWeatherTable_(double decyear, double endsec, const std::string& filename, std::vector<nrlmsise_table>& table);
 
 /* ------------------------------------------------------------------- */
 /* ----------------------- COMPILATION TWEAKS ------------------------ */

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -182,7 +182,7 @@ std::vector<std::string> IniAccess::Split(const std::string& input, const char d
   return result;
 }
 
-void IniAccess::ReadCsvDouble(std::vector<std::vector<double>>& output_value, const int node_num) {
+void IniAccess::ReadCsvDouble(std::vector<std::vector<double>>& output_value, const size_t node_num) {
   std::ifstream ifs(file_path_char_);
   if (!ifs.is_open()) {
     std::cerr << "file open error. filename = " << file_path_char_ << std::endl;
@@ -226,7 +226,7 @@ void IniAccess::ReadCsvDoubleWithHeader(std::vector<std::vector<double>>& output
   }
 }
 
-void IniAccess::ReadCsvString(std::vector<std::vector<std::string>>& output_value, const int node_num) {
+void IniAccess::ReadCsvString(std::vector<std::vector<std::string>>& output_value, const size_t node_num) {
   std::ifstream ifs(file_path_char_);
   if (!ifs.is_open()) {
     std::cerr << "file open error. filename = " << file_path_char_ << std::endl;

--- a/src/library/initialize/initialize_file_access.hpp
+++ b/src/library/initialize/initialize_file_access.hpp
@@ -138,7 +138,7 @@ class IniAccess {
    * @param[out] output_value: Read double matrix value
    * @param[in] node_num: Number of node. When reading n * m matrix, please substitute bigger number.
    */
-  void ReadCsvDouble(std::vector<std::vector<double>>& output_value, const int node_num);
+  void ReadCsvDouble(std::vector<std::vector<double>>& output_value, const size_t node_num);
   /**
    * @fn ReadCsvDoubleWithHeader
    * @brief Read matrix value in CSV file with header
@@ -155,7 +155,7 @@ class IniAccess {
    * @param[out] output_value: Read matrix of string
    * @param[in] node_num: Number of node. When reading n * m matrix, please substitute bigger number.
    */
-  void ReadCsvString(std::vector<std::vector<std::string>>& output_value, const int node_num);
+  void ReadCsvString(std::vector<std::vector<std::string>>& output_value, const size_t node_num);
 
  private:
   static const size_t kMaxCharLength = 1024;

--- a/src/library/math/matrix_vector.hpp
+++ b/src/library/math/matrix_vector.hpp
@@ -39,7 +39,7 @@ Matrix<N, N> CalcInverseMatrix(const Matrix<N, N>& matrix);
  * @return Result of LU decomposed matrix
  */
 template <std::size_t N>
-Matrix<N, N>& LuDecomposition(Matrix<N, N>& matrix, unsigned int index[]);
+Matrix<N, N>& LuDecomposition(Matrix<N, N>& matrix, size_t index[]);
 
 /**
  * @fn SolveLinearSystemWithLu
@@ -50,7 +50,7 @@ Matrix<N, N>& LuDecomposition(Matrix<N, N>& matrix, unsigned int index[]);
  * @return Result vector
  */
 template <std::size_t N>
-Vector<N>& SolveLinearSystemWithLu(const Matrix<N, N>& matrix, const unsigned int index[], Vector<N>& vector);
+Vector<N>& SolveLinearSystemWithLu(const Matrix<N, N>& matrix, const size_t index[], Vector<N>& vector);
 
 }  // namespace libra
 

--- a/src/library/math/matrix_vector_template_functions.hpp
+++ b/src/library/math/matrix_vector_template_functions.hpp
@@ -24,7 +24,7 @@ Vector<R, TC> operator*(const Matrix<R, C, TM>& matrix, const Vector<C, TC>& vec
 template <std::size_t N>
 Matrix<N, N> CalcInverseMatrix(const Matrix<N, N>& matrix) {
   Matrix<N, N> temp(matrix);
-  unsigned int index[N];
+  size_t index[N];
   LuDecomposition(temp, index);
 
   Matrix<N, N> inverse;
@@ -41,7 +41,7 @@ Matrix<N, N> CalcInverseMatrix(const Matrix<N, N>& matrix) {
 }
 
 template <std::size_t N>
-Matrix<N, N>& LuDecomposition(Matrix<N, N>& a, unsigned int index[]) {
+Matrix<N, N>& LuDecomposition(Matrix<N, N>& a, size_t index[]) {
   double coef[N];
   for (size_t i = 0; i < N; ++i) {
     double biggest = 0.0;
@@ -109,12 +109,12 @@ Matrix<N, N>& LuDecomposition(Matrix<N, N>& a, unsigned int index[]) {
 }
 
 template <std::size_t N>
-Vector<N>& SolveLinearSystemWithLu(const Matrix<N, N>& a, const unsigned int index[], Vector<N>& b) {
+Vector<N>& SolveLinearSystemWithLu(const Matrix<N, N>& a, const size_t index[], Vector<N>& b) {
   double sum;
   bool non_zero = false;
-  unsigned int mark = 0;
+  size_t mark = 0;
   for (size_t i = 0; i < N; ++i) {
-    unsigned int ip = index[i];
+    size_t ip = index[i];
     sum = b[ip];
     b[ip] = b[i];
     if (non_zero) {

--- a/src/library/math/ordinary_differential_equation.hpp
+++ b/src/library/math/ordinary_differential_equation.hpp
@@ -95,7 +95,7 @@ class OrdinaryDifferentialEquation {
    * @brief Return element of current state vector
    * @param [in] n: Target element number
    */
-  inline double operator[](int n) const { return state_[n]; }
+  inline double operator[](size_t n) const { return state_[n]; }
 
  protected:
   /**

--- a/src/library/math/ordinary_differential_equation_template_functions.hpp
+++ b/src/library/math/ordinary_differential_equation_template_functions.hpp
@@ -30,13 +30,13 @@ void OrdinaryDifferentialEquation<N>::Update() {
   // 4th order Runge-Kutta method
   Vector<N> k1(derivative_);
   k1 *= step_width_s_;
-  Vector<N> k2(state_.GetLength());
+  Vector<N> k2((double)state_.GetLength());
   DerivativeFunction(independent_variable_ + 0.5 * step_width_s_, state_ + 0.5 * k1, k2);
   k2 *= step_width_s_;
-  Vector<N> k3(state_.GetLength());
+  Vector<N> k3((double)state_.GetLength());
   DerivativeFunction(independent_variable_ + 0.5 * step_width_s_, state_ + 0.5 * k2, k3);
   k3 *= step_width_s_;
-  Vector<N> k4(state_.GetLength());
+  Vector<N> k4((double)state_.GetLength());
   DerivativeFunction(independent_variable_ + step_width_s_, state_ + k3, k4);
   k4 *= step_width_s_;
 

--- a/src/simulation/multiple_spacecraft/relative_information.cpp
+++ b/src/simulation/multiple_spacecraft/relative_information.cpp
@@ -37,12 +37,12 @@ void RelativeInformation::Update() {
   }
 }
 
-void RelativeInformation::RegisterDynamicsInfo(const int spacecraft_id, const Dynamics* dynamics) {
+void RelativeInformation::RegisterDynamicsInfo(const size_t spacecraft_id, const Dynamics* dynamics) {
   dynamics_database_.emplace(spacecraft_id, dynamics);
   ResizeLists();
 }
 
-void RelativeInformation::RemoveDynamicsInfo(const int spacecraft_id) {
+void RelativeInformation::RemoveDynamicsInfo(const size_t spacecraft_id) {
   dynamics_database_.erase(spacecraft_id);
   ResizeLists();
 }
@@ -111,7 +111,7 @@ std::string RelativeInformation::GetLogValue() const {
 
 void RelativeInformation::LogSetup(Logger& logger) { logger.AddLogList(this); }
 
-libra::Quaternion RelativeInformation::CalcRelativeAttitudeQuaternion(const int target_spacecraft_id, const int reference_spacecraft_id) {
+libra::Quaternion RelativeInformation::CalcRelativeAttitudeQuaternion(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) {
   // Observer SC Body frame(obs_sat) -> ECI frame(i)
   libra::Quaternion q_reference_i2b = dynamics_database_.at(reference_spacecraft_id)->GetAttitude().GetQuaternion_i2b();
   libra::Quaternion q_reference_b2i = q_reference_i2b.Conjugate();
@@ -122,7 +122,7 @@ libra::Quaternion RelativeInformation::CalcRelativeAttitudeQuaternion(const int 
   return q_target_i2b * q_reference_b2i;
 }
 
-libra::Vector<3> RelativeInformation::CalcRelativePosition_rtn_m(const int target_spacecraft_id, const int reference_spacecraft_id) {
+libra::Vector<3> RelativeInformation::CalcRelativePosition_rtn_m(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) {
   libra::Vector<3> target_sat_pos_i = dynamics_database_.at(target_spacecraft_id)->GetOrbit().GetPosition_i_m();
   libra::Vector<3> reference_sat_pos_i = dynamics_database_.at(reference_spacecraft_id)->GetOrbit().GetPosition_i_m();
   libra::Vector<3> relative_pos_i = target_sat_pos_i - reference_sat_pos_i;
@@ -134,7 +134,7 @@ libra::Vector<3> RelativeInformation::CalcRelativePosition_rtn_m(const int targe
   return relative_pos_rtn;
 }
 
-libra::Vector<3> RelativeInformation::CalcRelativeVelocity_rtn_m_s(const int target_spacecraft_id, const int reference_spacecraft_id) {
+libra::Vector<3> RelativeInformation::CalcRelativeVelocity_rtn_m_s(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) {
   libra::Vector<3> target_sat_pos_i = dynamics_database_.at(target_spacecraft_id)->GetOrbit().GetPosition_i_m();
   libra::Vector<3> reference_sat_pos_i = dynamics_database_.at(reference_spacecraft_id)->GetOrbit().GetPosition_i_m();
   libra::Vector<3> relative_pos_i = target_sat_pos_i - reference_sat_pos_i;

--- a/src/simulation/multiple_spacecraft/relative_information.hpp
+++ b/src/simulation/multiple_spacecraft/relative_information.hpp
@@ -40,13 +40,13 @@ class RelativeInformation : public ILoggable {
    * @param [in] spacecraft_id: ID of target spacecraft
    * @param [in] dynamics: Dynamics information of the target spacecraft
    */
-  void RegisterDynamicsInfo(const int spacecraft_id, const Dynamics* dynamics);
+  void RegisterDynamicsInfo(const size_t spacecraft_id, const Dynamics* dynamics);
   /**
    * @fn RegisterDynamicsInfo
    * @brief Remove dynamics information of target spacecraft
    * @param [in] spacecraft_id: ID of target spacecraft
    */
-  void RemoveDynamicsInfo(const int spacecraft_id);
+  void RemoveDynamicsInfo(const size_t spacecraft_id);
 
   // Override classes for ILoggable
   /**
@@ -73,7 +73,7 @@ class RelativeInformation : public ILoggable {
    * @param [in] target_spacecraft_id: ID of target spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  inline libra::Quaternion GetRelativeAttitudeQuaternion(const int target_spacecraft_id, const int reference_spacecraft_id) const {
+  inline libra::Quaternion GetRelativeAttitudeQuaternion(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) const {
     return relative_attitude_quaternion_list_[target_spacecraft_id][reference_spacecraft_id];
   }
   /**
@@ -82,7 +82,7 @@ class RelativeInformation : public ILoggable {
    * @param [in] target_spacecraft_id: ID of target spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  inline libra::Vector<3> GetRelativePosition_i_m(const int target_spacecraft_id, const int reference_spacecraft_id) const {
+  inline libra::Vector<3> GetRelativePosition_i_m(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) const {
     return relative_position_list_i_m_[target_spacecraft_id][reference_spacecraft_id];
   }
   /**
@@ -91,7 +91,7 @@ class RelativeInformation : public ILoggable {
    * @param [in] target_spacecraft_id: ID of target spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  inline libra::Vector<3> GetRelativeVelocity_i_m_s(const int target_spacecraft_id, const int reference_spacecraft_id) const {
+  inline libra::Vector<3> GetRelativeVelocity_i_m_s(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) const {
     return relative_velocity_list_i_m_s_[target_spacecraft_id][reference_spacecraft_id];
   }
   /**
@@ -100,7 +100,7 @@ class RelativeInformation : public ILoggable {
    * @param [in] target_spacecraft_id: ID of target spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  inline double GetRelativeDistance_m(const int target_spacecraft_id, const int reference_spacecraft_id) const {
+  inline double GetRelativeDistance_m(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) const {
     return relative_distance_list_m_[target_spacecraft_id][reference_spacecraft_id];
   };
   /**
@@ -109,7 +109,7 @@ class RelativeInformation : public ILoggable {
    * @param [in] target_spacecraft_id: ID of target spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  inline libra::Vector<3> GetRelativePosition_rtn_m(const int target_spacecraft_id, const int reference_spacecraft_id) const {
+  inline libra::Vector<3> GetRelativePosition_rtn_m(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) const {
     return relative_position_list_rtn_m_[target_spacecraft_id][reference_spacecraft_id];
   }
   /**
@@ -118,7 +118,7 @@ class RelativeInformation : public ILoggable {
    * @param [in] target_spacecraft_id: ID of target spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  inline libra::Vector<3> GetRelativeVelocity_rtn_m_s(const int target_spacecraft_id, const int reference_spacecraft_id) const {
+  inline libra::Vector<3> GetRelativeVelocity_rtn_m_s(const size_t target_spacecraft_id, const size_t reference_spacecraft_id) const {
     return relative_velocity_list_rtn_m_s_[target_spacecraft_id][reference_spacecraft_id];
   }
 
@@ -127,10 +127,12 @@ class RelativeInformation : public ILoggable {
    * @brief Return the dynamics information of a spacecraft
    * @param [in] target_spacecraft_id: ID of the spacecraft
    */
-  inline const Dynamics* GetReferenceSatDynamics(const int reference_spacecraft_id) const { return dynamics_database_.at(reference_spacecraft_id); };
+  inline const Dynamics* GetReferenceSatDynamics(const size_t reference_spacecraft_id) const {
+    return dynamics_database_.at(reference_spacecraft_id);
+  };
 
  private:
-  std::map<const int, const Dynamics*> dynamics_database_;  //!< Dynamics database of all spacecraft
+  std::map<const size_t, const Dynamics*> dynamics_database_;  //!< Dynamics database of all spacecraft
 
   std::vector<std::vector<libra::Vector<3>>> relative_position_list_i_m_;          //!< Relative position list in the inertial frame in unit [m]
   std::vector<std::vector<libra::Vector<3>>> relative_velocity_list_i_m_s_;        //!< Relative velocity list in the inertial frame in unit [m/s]
@@ -145,21 +147,21 @@ class RelativeInformation : public ILoggable {
    * @param [in] target_spacecraft_id: ID of the spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  libra::Quaternion CalcRelativeAttitudeQuaternion(const int target_spacecraft_id, const int reference_spacecraft_id);
+  libra::Quaternion CalcRelativeAttitudeQuaternion(const size_t target_spacecraft_id, const size_t reference_spacecraft_id);
   /**
    * @fn CalcRelativePosition_rtn_m
    * @brief Calculate and return the relative position in RTN frame
    * @param [in] target_spacecraft_id: ID of the spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  libra::Vector<3> CalcRelativePosition_rtn_m(const int target_spacecraft_id, const int reference_spacecraft_id);
+  libra::Vector<3> CalcRelativePosition_rtn_m(const size_t target_spacecraft_id, const size_t reference_spacecraft_id);
   /**
    * @fn CalcRelativeVelocity_rtn_m_s
    * @brief Calculate and return the relative velocity in RTN frame
    * @param [in] target_spacecraft_id: ID of the spacecraft
    * @param [in] reference_spacecraft_id: ID of reference spacecraft
    */
-  libra::Vector<3> CalcRelativeVelocity_rtn_m_s(const int target_spacecraft_id, const int reference_spacecraft_id);
+  libra::Vector<3> CalcRelativeVelocity_rtn_m_s(const size_t target_spacecraft_id, const size_t reference_spacecraft_id);
 
   /**
    * @fn ResizeLists


### PR DESCRIPTION
## Overview
Remove size_t related warnings

## Issue
- #435 

## Details
Remove size_t related warnings. The warnings in the `temperature` will be removed in the PR #427 .

gnss_satelliteのwarning除去は根が深くて下手に修正すると動かなくなりそうなので、[こちらのissue](https://github.com/ut-issl/s2e-core/issues/276)で対応する。

##  Validation results
See CI.

## Scope of influence
patch

## Supplement
NA

## Note
NA