### PR TITLE
[Hotfix] Remove bug when center object is not the earth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_policy(SET CMP0048 NEW)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 6.2.1
+  VERSION 6.2.2
 )
 
 cmake_minimum_required(VERSION 3.13)

--- a/src/environment/global/celestial_rotation.cpp
+++ b/src/environment/global/celestial_rotation.cpp
@@ -132,7 +132,7 @@ void CelestialRotation::Update(const double JulianDate) {
   double gmst_rad = gstime(JulianDate);  // It is a bit different with 長沢(Nagasawa)'s algorithm. TODO: Check the correctness
 
   if (rotation_mode_ == RotationMode::kFull) {
-    // Compute Julian date for terestrial time
+    // Compute Julian date for terrestrial time
     double jdTT_day = JulianDate + kDtUt1Utc_ * kSec2Day_;  // TODO: Check the correctness. Problem is that S2E doesn't have Gregorian calendar.
 
     // Compute nth power of julian century for terrestrial time the actual unit of tTT_century is [century^(i+1)], i is the index of the array

--- a/src/environment/global/celestial_rotation.cpp
+++ b/src/environment/global/celestial_rotation.cpp
@@ -149,7 +149,7 @@ void CelestialRotation::Update(const double JulianDate) {
     // Nutation + Precession
     P = Precession(tTT_century);
     N = Nutation(tTT_century);  // epsilon_rad_, d_epsilon_rad_, d_psi_rad_ are
-                                // updated in this proccedure
+                                // updated in this procedure
 
     // Axial Rotation
     double Eq_rad = d_psi_rad_ * cos(epsilon_rad_ + d_epsilon_rad_);  // Equation of equinoxes [rad]

--- a/src/environment/global/celestial_rotation.cpp
+++ b/src/environment/global/celestial_rotation.cpp
@@ -25,7 +25,10 @@ CelestialRotation::CelestialRotation(const RotationMode rotation_mode, const std
   if (center_body_name == "EARTH") {
     InitCelestialRotationAsEarth(rotation_mode, center_body_name);
   } else {
-    // If the center object is not defined rotation calculation and make the DCM a unit matrix
+    // If the center object is not defined for rotation calculation, make the DCM as a unit matrix
+    std::cerr << "WARNINGS: The rotation calculation for the center object " << center_body_name;
+    std::cerr << " is not supported yet." << std::endl;
+    std::cerr << "The rotation matrix is set as a identity matrix" << std::endl;
     rotation_mode_ = RotationMode::kIdle;
     dcm_j2000_to_xcxf_ = libra::MakeIdentityMatrix<3>();
   }

--- a/src/environment/global/celestial_rotation.cpp
+++ b/src/environment/global/celestial_rotation.cpp
@@ -24,6 +24,10 @@ CelestialRotation::CelestialRotation(const RotationMode rotation_mode, const std
   dcm_teme_to_xcxf_ = dcm_j2000_to_xcxf_;
   if (center_body_name == "EARTH") {
     InitCelestialRotationAsEarth(rotation_mode, center_body_name);
+  } else {
+    // If the center object is not defined rotation calculation and make the DCM a unit matrix
+    rotation_mode_ = RotationMode::kIdle;
+    dcm_j2000_to_xcxf_ = libra::MakeIdentityMatrix<3>();
   }
 }
 
@@ -160,6 +164,7 @@ void CelestialRotation::Update(const double JulianDate) {
     dcm_j2000_to_xcxf_ = W * R * N * P;
   } else if (rotation_mode_ == RotationMode::kSimple) {
     // In this case, only Axial Rotation is executed, with its argument replaced from G'A'ST to G'M'ST
+    // FIXME: Not suitable when the center body is not the earth
     dcm_j2000_to_xcxf_ = AxialRotation(gmst_rad);
   } else {
     // Leave the DCM as unit Matrix(diag{1,1,1})

--- a/src/environment/global/celestial_rotation.cpp
+++ b/src/environment/global/celestial_rotation.cpp
@@ -133,7 +133,7 @@ void CelestialRotation::Update(const double JulianDate) {
 
   if (rotation_mode_ == RotationMode::kFull) {
     // Compute Julian date for terestrial time
-    double jdTT_day = JulianDate + kDtUt1Utc_ * kSec2Day_;  // TODO: Check the correctness. Problem is thtat S2E doesn't have Gregorian calendar.
+    double jdTT_day = JulianDate + kDtUt1Utc_ * kSec2Day_;  // TODO: Check the correctness. Problem is that S2E doesn't have Gregorian calendar.
 
     // Compute nth power of julian century for terrestrial time the actual unit of tTT_century is [century^(i+1)], i is the index of the array
     double tTT_century[4];
@@ -153,9 +153,9 @@ void CelestialRotation::Update(const double JulianDate) {
 
     // Axial Rotation
     double Eq_rad = d_psi_rad_ * cos(epsilon_rad_ + d_epsilon_rad_);  // Equation of equinoxes [rad]
-    double gast_rad = gmst_rad + Eq_rad;                              // Greenwitch 'Appearent' Sidereal Time [rad]
+    double gast_rad = gmst_rad + Eq_rad;                              // Greenwitch 'Apparent' Sidereal Time [rad]
     R = AxialRotation(gast_rad);
-    // Polar motion (isnot considered so far, even without polar motion, the result agrees well with the matlab reference)
+    // Polar motion (is not considered so far, even without polar motion, the result agrees well with the matlab reference)
     double Xp = 0.0;
     double Yp = 0.0;
     W = PolarMotion(Xp, Yp);


### PR DESCRIPTION
## Overview
Remove bug when center object is not the earth

## Issue
NA

## Details
When we select the center object as moon or other planets, the calculation was crushed because the center body rotation was not defined.  
I modified to define non-rotation behavior when the center object is not the earth.

##  Validation results
I confirmed that the case of `center_object = MOON` and the bug was removed.

## Scope of influence
patch, for deep space users.

## Supplement
I made a related issue.
https://github.com/ut-issl/s2e-core/issues/462

## Note
NA