### PR TITLE
Fix UTC time tag log output

### DIFF
--- a/src/environment/global/simulation_time.cpp
+++ b/src/environment/global/simulation_time.cpp
@@ -206,8 +206,10 @@ string SimulationTime::GetLogValue() const {
 
   const char kSize = 100;
   char ymdhms[kSize];
-  snprintf(ymdhms, kSize, "%4d/%02d/%02d %02d:%02d:%.3lf,", current_utc_.year, current_utc_.month, current_utc_.day, current_utc_.hour,
-           current_utc_.minute, current_utc_.second);
+  double sec_floor = floor(current_utc_.second * 1e3) / 1e3;
+
+  snprintf(ymdhms, kSize, "%4d/%02d/%02d %02d:%02d:%.3f,", current_utc_.year, current_utc_.month, current_utc_.day, current_utc_.hour,
+           current_utc_.minute, sec_floor);
   str_tmp += ymdhms;
 
   return str_tmp;


### PR DESCRIPTION
## Overview
Fix UTC time tag log output

## Issue
#467 

## Details
原因は、`00分59.99秒`のような時に、秒のみ繰り上げられ、分はそのままという感じになっていることだった。  
表示時に秒を必ず切り捨てるように修正した。  
四捨五入で分やその上まで桁上げするような修正をしても良いかもだが、その辺りはログファイルを解析処理する側でやれば良いことなので一旦これで進める。

##  Validation results
次のような表示になったことを確認した。

<img width="176" alt="image" src="https://github.com/ut-issl/s2e-core/assets/19573779/07971c53-b94b-4532-bde5-e7233d7d083c">

## Scope of influence
NA

## Supplement
NA

## Note
NA