### PR TITLE
Support c2a-core v4 (rename System directory)

### DIFF
--- a/src/components/real/cdh/on_board_computer_with_c2a.cpp
+++ b/src/components/real/cdh/on_board_computer_with_c2a.cpp
@@ -20,9 +20,9 @@
 #include "src_core/System/WatchdogTimer/watchdog_timer.h"
 #else
 #error "c2a-core version is not supported"
-#endif // c2a-core version header
+#endif  // c2a-core version header
 
-#endif // USE_C2A
+#endif  // USE_C2A
 
 std::map<int, UartPort*> ObcWithC2a::com_ports_c2a_;
 std::map<int, I2cPort*> ObcWithC2a::i2c_com_ports_c2a_;

--- a/src/components/real/cdh/on_board_computer_with_c2a.cpp
+++ b/src/components/real/cdh/on_board_computer_with_c2a.cpp
@@ -6,11 +6,23 @@
 #include "on_board_computer_with_c2a.hpp"
 
 #ifdef USE_C2A
+#include "src_core/c2a_core_main.h"
+
+#if C2A_CORE_VER_MAJOR == 4
+// c2a-core v4
+#include "src_core/system/task_manager/task_dispatcher.h"
+#include "src_core/system/time_manager/time_manager.h"
+#include "src_core/system/watchdog_timer/watchdog_timer.h"
+#elif C2A_CORE_VER_MAJOR <= 3
+// c2a-core <= v3
 #include "src_core/System/TaskManager/task_dispatcher.h"
 #include "src_core/System/TimeManager/time_manager.h"
 #include "src_core/System/WatchdogTimer/watchdog_timer.h"
-#include "src_core/c2a_core_main.h"
-#endif
+#else
+#error "c2a-core version is not supported"
+#endif // c2a-core version header
+
+#endif // USE_C2A
 
 std::map<int, UartPort*> ObcWithC2a::com_ports_c2a_;
 std::map<int, I2cPort*> ObcWithC2a::i2c_com_ports_c2a_;


### PR DESCRIPTION
## Overview
Switch include header by c2a-core major version to support c2a-core v4

## Issue / PR
- https://github.com/arkedge/c2a-core/pull/54
- https://github.com/arkedge/c2a-core/pull/55

## Details
c2a-core v4 (being developed experimentally at [arkedge/c2a-core](https://github.com/arkedge/c2a-core)) includes breaking changes such as directory rename and directory naming convention changes.
This breaks the existing SILS-S2E build of C2A, so this PR corresponds to c2a-core v4 in the part that uses the c2a-core API.

##  Validation results
TBD

## Scope of influence
Supports SILS-S2E builds connected to c2a-core v4 based C2A users.
This patch does not break the existing connection with c2a-core v3.