### PR TITLE
Add interference effect to Magnetometers from MTQs

### DIFF
--- a/data/sample/initialize_files/components/component_interference.ini
+++ b/data/sample/initialize_files/components/component_interference.ini
@@ -6,7 +6,7 @@
 // ** measns Hadamard product
 // y = A1 * x + A2 * x ** x + A3 * x ** x ** x ...
 
-polynomial_degree = 2
+polynomial_degree = 1
 
 // We do not have zero coefficients
 

--- a/data/sample/initialize_files/components/component_interference.ini
+++ b/data/sample/initialize_files/components/component_interference.ini
@@ -1,0 +1,33 @@
+[MTQ_MAGNETOMETER_INTERFERENCE]
+
+// x: MTQ output vector at MTQ component frame [Am2]
+// y: Additional bias at magnetometer component frame [nT]
+// A1, A2, ...: Polynomial coefficients defined in this file
+// ** measns Hadamard product
+// y = A1 * x + A2 * x ** x + A3 * x ** x ** x ...
+
+polynomial_degree = 2
+
+// We do not have zero coefficients
+
+// 1st coefficients of additional bias A1 [nT/Am2]
+additional_bias_by_mtq_coefficients_1(0) = 10000.0   // MTQ X -> Mabetometer X
+additional_bias_by_mtq_coefficients_1(1) = -20000.0  // MTQ X -> Mabetometer Y
+additional_bias_by_mtq_coefficients_1(2) = 30000.0   // MTQ X -> Mabetometer Z
+additional_bias_by_mtq_coefficients_1(3) = 40000.0   // MTQ Y -> Mabetometer X
+additional_bias_by_mtq_coefficients_1(4) = -50000.0  // MTQ Y -> Mabetometer Y
+additional_bias_by_mtq_coefficients_1(5) = 60000.0   // MTQ Y -> Mabetometer Z
+additional_bias_by_mtq_coefficients_1(6) = 70000.0   // MTQ Z -> Mabetometer X
+additional_bias_by_mtq_coefficients_1(7) = -80000.0  // MTQ Z -> Mabetometer Y
+additional_bias_by_mtq_coefficients_1(8) = 90000.0   // MTQ Z -> Mabetometer Z
+
+// 2nd coefficients of additional bias A2 [nT/Am2^2]
+additional_bias_by_mtq_coefficients_2(0) = -10000.0   // MTQ X -> Mabetometer X
+additional_bias_by_mtq_coefficients_2(1) = 20000.0    // MTQ X -> Mabetometer Y
+additional_bias_by_mtq_coefficients_2(2) = -30000.0   // MTQ X -> Mabetometer Z
+additional_bias_by_mtq_coefficients_2(3) = -40000.0   // MTQ Y -> Mabetometer X
+additional_bias_by_mtq_coefficients_2(4) = 50000.0    // MTQ Y -> Mabetometer Y
+additional_bias_by_mtq_coefficients_2(5) = -60000.0   // MTQ Y -> Mabetometer Z
+additional_bias_by_mtq_coefficients_2(6) = -70000.0   // MTQ Z -> Mabetometer X
+additional_bias_by_mtq_coefficients_2(7) = 80000.0    // MTQ Z -> Mabetometer Y
+additional_bias_by_mtq_coefficients_2(8) = -90000.0   // MTQ Z -> Mabetometer Z

--- a/data/sample/initialize_files/sample_satellite.ini
+++ b/data/sample/initialize_files/sample_satellite.ini
@@ -145,3 +145,4 @@ thruster_file = INI_FILE_DIR_FROM_EXE/components/thruster.ini
 force_generator_file = INI_FILE_DIR_FROM_EXE/components/force_generator.ini
 torque_generator_file = INI_FILE_DIR_FROM_EXE/components/torque_generator.ini
 antenna_file = INI_FILE_DIR_FROM_EXE/components/spacecraft_antenna.ini
+component_interference_file = INI_FILE_DIR_FROM_EXE/components/component_interference.ini

--- a/src/components/CMakeLists.txt
+++ b/src/components/CMakeLists.txt
@@ -24,6 +24,7 @@ real/aocs/sun_sensor.cpp
 real/aocs/initialize_sun_sensor.cpp
 real/aocs/gnss_receiver.cpp
 real/aocs/initialize_gnss_receiver.cpp
+real/aocs/mtq_magnetometer_interference.cpp
 
 real/cdh/on_board_computer.cpp
 real/cdh/on_board_computer_with_c2a.cpp

--- a/src/components/base/sensor.hpp
+++ b/src/components/base/sensor.hpp
@@ -41,6 +41,8 @@ class Sensor {
   ~Sensor();
 
  protected:
+  libra::Vector<N> bias_noise_c_;  //!< Constant bias noise at the component frame
+
   /**
    * @fn Measure
    * @brief Return the observed data after adding the noise
@@ -53,7 +55,6 @@ class Sensor {
   libra::Matrix<N, N> scale_factor_;            //!< Scale factor matrix
   libra::Vector<N> range_to_const_c_;           //!< Output range limit to be constant output value at the component frame
   libra::Vector<N> range_to_zero_c_;            //!< Output range limit to be zero output value at the component frame
-  libra::Vector<N> bias_noise_c_;               //!< Constant bias noise at the component frame
   libra::NormalRand normal_random_noise_c_[N];  //!< Normal random
   RandomWalk<N> random_walk_noise_c_;           //!< Random Walk
 

--- a/src/components/base/sensor_template_functions.hpp
+++ b/src/components/base/sensor_template_functions.hpp
@@ -13,10 +13,10 @@ Sensor<N>::Sensor(const libra::Matrix<N, N>& scale_factor, const libra::Vector<N
                   const libra::Vector<N>& bias_noise_c, const libra::Vector<N>& normal_random_standard_deviation_c,
                   const double random_walk_step_width_s, const libra::Vector<N>& random_walk_standard_deviation_c,
                   const libra::Vector<N>& random_walk_limit_c)
-    : scale_factor_(scale_factor),
+    : bias_noise_c_(bias_noise_c),
+      scale_factor_(scale_factor),
       range_to_const_c_(range_to_const_c),
       range_to_zero_c_(range_to_zero_c),
-      bias_noise_c_(bias_noise_c),
       random_walk_noise_c_(random_walk_step_width_s, random_walk_standard_deviation_c, random_walk_limit_c) {
   for (size_t i = 0; i < N; i++) {
     normal_random_noise_c_[i].SetParameters(0.0, normal_random_standard_deviation_c[i], global_randomization.MakeSeed());

--- a/src/components/real/aocs/magnetometer.hpp
+++ b/src/components/real/aocs/magnetometer.hpp
@@ -96,7 +96,7 @@ class Magnetometer : public Component, public Sensor<kMagnetometerDimension>, pu
    * @brief Get constant bias noise at component frame [nT]
    */
   inline libra::Vector<kMagnetometerDimension> GetConstantBiasNoise_c_nT() const { return bias_noise_c_; }
-  
+
  protected:
   libra::Vector<kMagnetometerDimension> magnetic_field_c_nT_{0.0};  //!< Observed magnetic field on the component frame [nT]
   unsigned int sensor_id_ = 0;                                      //!< Sensor ID

--- a/src/components/real/aocs/magnetometer.hpp
+++ b/src/components/real/aocs/magnetometer.hpp
@@ -77,6 +77,20 @@ class Magnetometer : public Component, public Sensor<kMagnetometerDimension>, pu
    */
   inline const libra::Vector<kMagnetometerDimension>& GetMeasuredMagneticField_c_nT(void) const { return magnetic_field_c_nT_; }
 
+  /**
+   * @fn SetConstantBiasNoise_c_nT
+   * @brief Set constant bias noise at component frame [nT]
+   * @param [in] constant_noise_c_nT: Constant bias noise at component frame [nT]
+   */
+  inline void SetConstantBiasNoise_c_nT(libra::Vector<kMagnetometerDimension> constant_noise_c_nT) { bias_noise_c_ = constant_noise_c_nT; }
+
+  /**
+   * @fn AddConstantBiasNoise_c_nT
+   * @brief Add constant bias noise at component frame [nT]
+   * @param [in] constant_noise_c_nT: Additional constant bias noise at component frame [nT]
+   */
+  inline void AddConstantBiasNoise_c_nT(libra::Vector<kMagnetometerDimension> constant_noise_c_nT) { bias_noise_c_ += constant_noise_c_nT; }
+
  protected:
   libra::Vector<kMagnetometerDimension> magnetic_field_c_nT_{0.0};  //!< Observed magnetic field on the component frame [nT]
   unsigned int sensor_id_ = 0;                                      //!< Sensor ID

--- a/src/components/real/aocs/magnetometer.hpp
+++ b/src/components/real/aocs/magnetometer.hpp
@@ -91,6 +91,12 @@ class Magnetometer : public Component, public Sensor<kMagnetometerDimension>, pu
    */
   inline void AddConstantBiasNoise_c_nT(libra::Vector<kMagnetometerDimension> constant_noise_c_nT) { bias_noise_c_ += constant_noise_c_nT; }
 
+  /**
+   * @fn GetConstantBiasNoise_c_nT
+   * @brief Get constant bias noise at component frame [nT]
+   */
+  inline libra::Vector<kMagnetometerDimension> GetConstantBiasNoise_c_nT() const { return bias_noise_c_; }
+  
  protected:
   libra::Vector<kMagnetometerDimension> magnetic_field_c_nT_{0.0};  //!< Observed magnetic field on the component frame [nT]
   unsigned int sensor_id_ = 0;                                      //!< Sensor ID

--- a/src/components/real/aocs/magnetorquer.hpp
+++ b/src/components/real/aocs/magnetorquer.hpp
@@ -114,6 +114,12 @@ class Magnetorquer : public Component, public ILoggable {
    */
   inline const libra::Vector<kMtqDimension>& SetOutputMagneticMoment_b_Am2(void) const { return output_magnetic_moment_b_Am2_; };
 
+  /**
+   * @fn GetOutputMagneticMoment_b_Am2
+   * @brief Return output magnetic moment in the body fixed frame [Am2]
+   */
+  inline const libra::Vector<kMtqDimension>& GetOutputMagneticMoment_c_Am2(void) const { return output_magnetic_moment_c_Am2_; };
+
  protected:
   const int component_id_ = 0;                                      //!< Actuator ID
   const double kConvertNanoT2T = 1.0e-9;                            //!< Constant to convert nT to T

--- a/src/components/real/aocs/mtq_magnetometer_interference.cpp
+++ b/src/components/real/aocs/mtq_magnetometer_interference.cpp
@@ -7,7 +7,7 @@
 
 #include "library/initialize/initialize_file_access.hpp"
 
-MtqMagnetorquerInterference::MtqMagnetorquerInterference(const std::string file_name, Magnetometer& magnetometer, const Magnetorquer& magnetorquer)
+MtqMagnetometerInterference::MtqMagnetometerInterference(const std::string file_name, Magnetometer& magnetometer, const Magnetorquer& magnetorquer)
     : magnetometer_(magnetometer), magnetorquer_(magnetorquer) {
   // Read ini file
   IniAccess ini_file(file_name);
@@ -29,7 +29,7 @@ MtqMagnetorquerInterference::MtqMagnetorquerInterference(const std::string file_
   }
 }
 
-void MtqMagnetorquerInterference::UpdateInterference(void) {
+void MtqMagnetometerInterference::UpdateInterference(void) {
   // Subtract previous added bias to avoid double addition
   magnetometer_.AddConstantBiasNoise_c_nT(-1.0 * previous_added_bias_c_nT_);
 

--- a/src/components/real/aocs/mtq_magnetometer_interference.cpp
+++ b/src/components/real/aocs/mtq_magnetometer_interference.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file mtq_magnetometer_interference.cpp
+ * @brief Class for MTQ Magnetometer interference
+ */
+
+#include "mtq_magnetometer_interference.hpp"
+
+#include "library/initialize/initialize_file_access.hpp"
+
+MtqMagnetorquerInterference::MtqMagnetorquerInterference(const std::string file_name, Magnetometer& magnetometer, const Magnetorquer& magnetorquer)
+    : magnetometer_(magnetometer), magnetorquer_(magnetorquer) {
+  // Read ini file
+  IniAccess ini_file(file_name);
+  const char* section = "MTQ_MAGNETOMETER_INTERFERENCE";
+
+  polynomial_degree_ = (size_t)ini_file.ReadInt(section, "polynomial_degree");
+
+  for (size_t degree = 1; degree <= polynomial_degree_; degree++) {
+    const std::string key_name = "additional_bias_by_mtq_coefficients_" + std::to_string(static_cast<long long>(degree));
+    libra::Vector<9> additional_bias_by_mtq_coefficients_vec;
+    libra::Matrix<3, 3> additional_bias_by_mtq_coefficients;
+    ini_file.ReadVector(section, key_name.c_str(), additional_bias_by_mtq_coefficients_vec);
+    for (size_t i = 0; i < 3; i++) {
+      for (size_t j = 0; j < 3; j++) {
+        additional_bias_by_mtq_coefficients[i][j] = additional_bias_by_mtq_coefficients_vec[i * 3 + j];
+      }
+    }
+    additional_bias_by_mtq_coefficients_.push_back(additional_bias_by_mtq_coefficients);
+  }
+}
+
+void MtqMagnetorquerInterference::UpdateInterference(void) {
+  // Subtract previous added bias to avoid double addition
+  magnetometer_.AddConstantBiasNoise_c_nT(-1.0 * previous_added_bias_c_nT_);
+
+  // Calculate bias
+  libra::Vector<3> additional_bias_c_nT{0.0};
+  libra::Vector<3> mtq_output_c_Am2 = magnetorquer_.GetOutputMagneticMoment_c_Am2();
+  for (size_t degree = 1; degree <= polynomial_degree_; degree++) {
+    libra::Vector<3> hadamard_mtq;
+    for (size_t axis = 0; axis < 3; axis++) {
+      hadamard_mtq[axis] = pow(mtq_output_c_Am2[axis], degree);
+    }
+    additional_bias_c_nT = additional_bias_c_nT + additional_bias_by_mtq_coefficients_[degree - 1] * hadamard_mtq;
+  }
+
+  // Add bias
+  magnetometer_.AddConstantBiasNoise_c_nT(additional_bias_c_nT);
+  previous_added_bias_c_nT_ = additional_bias_c_nT;
+}

--- a/src/components/real/aocs/mtq_magnetometer_interference.hpp
+++ b/src/components/real/aocs/mtq_magnetometer_interference.hpp
@@ -1,0 +1,50 @@
+/**
+ * @file mtq_magnetometer_interference.hpp
+ * @brief Class for MTQ Magnetometer interference
+ */
+
+#ifndef S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETORQUER_INTERFERENCE_HPP_
+#define S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETORQUER_INTERFERENCE_HPP_
+
+#include "magnetometer.hpp"
+#include "magnetorquer.hpp"
+
+/**
+ * @enum
+ * @brief
+ */
+enum class MtqPreviousState {
+  kPlus,  //!< Plus output
+  kZero,  //!< Zero output
+  kMinus  //!< Minus output
+};
+
+/**
+ * @class MtqMagnetorquerInterference
+ * @brief Class for MTQ Magnetometer interference
+ */
+class MtqMagnetorquerInterference {
+ public:
+  /**
+   * @fn MtqMagnetorquerInterference
+   * @brief Constructor
+   * @param[in] ini_file: initialize file
+   */
+  MtqMagnetorquerInterference(const std::string file_name, Magnetometer& magnetometer, const Magnetorquer& magnetorquer);
+
+  /**
+   * @fn UpdateInterference
+   * @brief Update MTQ-Magnetometer interference
+   */
+  void UpdateInterference(void);
+
+ protected:
+  size_t polynomial_degree_; //!< Polynomial degree
+  std::vector<libra::Matrix<3, 3>> additional_bias_by_mtq_coefficients_;  //!< Polynomial coefficients of additional bias noise
+  libra::Vector<3> previous_added_bias_c_nT_{0.0};
+
+  Magnetometer& magnetometer_;        //!< Magnetometer
+  const Magnetorquer& magnetorquer_;  //!< Magnetorquer
+};
+
+#endif  // S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETORQUER_INTERFERENCE_HPP_

--- a/src/components/real/aocs/mtq_magnetometer_interference.hpp
+++ b/src/components/real/aocs/mtq_magnetometer_interference.hpp
@@ -3,34 +3,24 @@
  * @brief Class for MTQ Magnetometer interference
  */
 
-#ifndef S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETORQUER_INTERFERENCE_HPP_
-#define S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETORQUER_INTERFERENCE_HPP_
+#ifndef S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETOMETER_INTERFERENCE_HPP_
+#define S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETOMETER_INTERFERENCE_HPP_
 
 #include "magnetometer.hpp"
 #include "magnetorquer.hpp"
 
 /**
- * @enum
- * @brief
- */
-enum class MtqPreviousState {
-  kPlus,  //!< Plus output
-  kZero,  //!< Zero output
-  kMinus  //!< Minus output
-};
-
-/**
- * @class MtqMagnetorquerInterference
+ * @class MtqMagnetometerInterference
  * @brief Class for MTQ Magnetometer interference
  */
-class MtqMagnetorquerInterference {
+class MtqMagnetometerInterference {
  public:
   /**
-   * @fn MtqMagnetorquerInterference
+   * @fn MtqMagnetometerInterference
    * @brief Constructor
    * @param[in] ini_file: initialize file
    */
-  MtqMagnetorquerInterference(const std::string file_name, Magnetometer& magnetometer, const Magnetorquer& magnetorquer);
+  MtqMagnetometerInterference(const std::string file_name, Magnetometer& magnetometer, const Magnetorquer& magnetorquer);
 
   /**
    * @fn UpdateInterference
@@ -47,4 +37,4 @@ class MtqMagnetorquerInterference {
   const Magnetorquer& magnetorquer_;  //!< Magnetorquer
 };
 
-#endif  // S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETORQUER_INTERFERENCE_HPP_
+#endif  // S2E_COMPONENTS_REAL_AOCS_MTQ_MAGNETOMETER_INTERFERENCE_HPP_

--- a/src/components/real/aocs/mtq_magnetometer_interference.hpp
+++ b/src/components/real/aocs/mtq_magnetometer_interference.hpp
@@ -39,7 +39,7 @@ class MtqMagnetorquerInterference {
   void UpdateInterference(void);
 
  protected:
-  size_t polynomial_degree_; //!< Polynomial degree
+  size_t polynomial_degree_;                                              //!< Polynomial degree
   std::vector<libra::Matrix<3, 3>> additional_bias_by_mtq_coefficients_;  //!< Polynomial coefficients of additional bias noise
   libra::Vector<3> previous_added_bias_c_nT_{0.0};
 

--- a/src/simulation/spacecraft/installed_components.hpp
+++ b/src/simulation/spacecraft/installed_components.hpp
@@ -36,6 +36,12 @@ class InstalledComponents {
   virtual libra::Vector<3> GenerateTorque_b_Nm();
 
   /**
+   * @fn ComponentInterference
+   * @brief Handle component interference effect
+   */
+  virtual void ComponentInterference() {}
+
+  /**
    * @fn LogSetup
    * @brief Setup the logger for components
    * @details Users need to override this function to add logger for components

--- a/src/simulation/spacecraft/spacecraft.cpp
+++ b/src/simulation/spacecraft/spacecraft.cpp
@@ -58,6 +58,7 @@ void Spacecraft::Update(const SimulationTime* simulation_time) {
 
   // Update components
   clock_generator_.UpdateComponents(simulation_time);
+  components_->ComponentInterference();
 
   // Add generated force and torque by disturbances
   dynamics_->AddAcceleration_i_m_s2(disturbances_->GetAcceleration_i_m_s2());

--- a/src/simulation_sample/spacecraft/sample_components.cpp
+++ b/src/simulation_sample/spacecraft/sample_components.cpp
@@ -94,6 +94,11 @@ SampleComponents::SampleComponents(const Dynamics* dynamics, Structure* structur
   configuration_->main_logger_->CopyFileToLogDirectory(file_name);
   antenna_ = new Antenna(InitAntenna(1, file_name));
 
+  // Component interference
+  file_name = iniAccess.ReadString("COMPONENT_FILES", "component_interference_file");
+  configuration_->main_logger_->CopyFileToLogDirectory(file_name);
+  mtq_magnetometer_interference_ = new MtqMagnetorquerInterference(file_name, *magnetometer_, *magnetorquer_);
+
   // PCU power port initial control
   pcu_->GetPowerPort(0)->SetVoltage_V(3.3);
   pcu_->GetPowerPort(1)->SetVoltage_V(3.3);
@@ -148,6 +153,7 @@ SampleComponents::~SampleComponents() {
   delete force_generator_;
   delete torque_generator_;
   delete antenna_;
+  delete mtq_magnetometer_interference_;
   // delete change_structure_;
   delete pcu_;
   // delete exp_hils_uart_responder_;
@@ -173,6 +179,8 @@ libra::Vector<3> SampleComponents::GenerateTorque_b_Nm() {
   torque_b_Nm_ += torque_generator_->GetGeneratedTorque_b_Nm();
   return torque_b_Nm_;
 }
+
+void SampleComponents::ComponentInterference() { mtq_magnetometer_interference_->UpdateInterference(); }
 
 void SampleComponents::LogSetup(Logger& logger) {
   logger.AddLogList(gyro_sensor_);

--- a/src/simulation_sample/spacecraft/sample_components.cpp
+++ b/src/simulation_sample/spacecraft/sample_components.cpp
@@ -97,7 +97,7 @@ SampleComponents::SampleComponents(const Dynamics* dynamics, Structure* structur
   // Component interference
   file_name = iniAccess.ReadString("COMPONENT_FILES", "component_interference_file");
   configuration_->main_logger_->CopyFileToLogDirectory(file_name);
-  mtq_magnetometer_interference_ = new MtqMagnetorquerInterference(file_name, *magnetometer_, *magnetorquer_);
+  mtq_magnetometer_interference_ = new MtqMagnetometerInterference(file_name, *magnetometer_, *magnetorquer_);
 
   // PCU power port initial control
   pcu_->GetPowerPort(0)->SetVoltage_V(3.3);

--- a/src/simulation_sample/spacecraft/sample_components.hpp
+++ b/src/simulation_sample/spacecraft/sample_components.hpp
@@ -109,7 +109,7 @@ class SampleComponents : public InstalledComponents {
   Antenna* antenna_;  //!< Antenna
 
   // Component Interference
-  MtqMagnetorquerInterference* mtq_magnetometer_interference_;  //!< Additional Bias noise by MTQ-Magnetometer interference
+  MtqMagnetometerInterference* mtq_magnetometer_interference_;  //!< Additional Bias noise by MTQ-Magnetometer interference
 
   // Examples
   // ExampleChangeStructure* change_structure_;  //!< Change structure

--- a/src/simulation_sample/spacecraft/sample_components.hpp
+++ b/src/simulation_sample/spacecraft/sample_components.hpp
@@ -19,6 +19,7 @@
 #include <components/real/aocs/initialize_reaction_wheel.hpp>
 #include <components/real/aocs/initialize_star_sensor.hpp>
 #include <components/real/aocs/initialize_sun_sensor.hpp>
+#include <components/real/aocs/mtq_magnetometer_interference.hpp>
 #include <components/real/cdh/on_board_computer.hpp>
 #include <components/real/communication/initialize_antenna.hpp>
 #include <components/real/power/power_control_unit.hpp>
@@ -73,6 +74,12 @@ class SampleComponents : public InstalledComponents {
    */
   libra::Vector<3> GenerateTorque_b_Nm();
   /**
+   * @fn ComponentInterference
+   * @brief Handle component interference effect
+   */
+  void ComponentInterference() override;
+
+  /**
    * @fn LogSetup
    * @brief Setup the logger for components
    */
@@ -100,6 +107,9 @@ class SampleComponents : public InstalledComponents {
 
   // CommGs
   Antenna* antenna_;  //!< Antenna
+
+  // Component Interference
+  MtqMagnetorquerInterference* mtq_magnetometer_interference_;  //!< Additional Bias noise by MTQ-Magnetometer interference
 
   // Examples
   // ExampleChangeStructure* change_structure_;  //!< Change structure


### PR DESCRIPTION
## Overview
Add interference effect to Magnetometers from MTQs

## Issue
#390 

## Details
The interference effect was added.

##  Validation results
<img width="706" alt="image" src="https://github.com/ut-issl/s2e-core/assets/19573779/98134b74-2eb6-4c04-84a4-8c0f11833b94">

<img width="517" alt="image" src="https://github.com/ut-issl/s2e-core/assets/19573779/e79b5597-45d0-41ad-87f8-1c14dbb1c916">


## Scope of influence
Minor update for realistic satellite attitude control users.

## Supplement
NA