### PR TITLE
Add Slope initialization in constructor for interpolation

### DIFF
--- a/src/library/numerical_integration/dormand_prince_5_implementation.hpp
+++ b/src/library/numerical_integration/dormand_prince_5_implementation.hpp
@@ -118,6 +118,8 @@ DormandPrince5<N>::DormandPrince5(const double step_width, const InterfaceOde<N>
   coefficients_temp[4] = 106151040.0;
   coefficients_temp = 11.0 / 2467955532.0 * coefficients_temp;
   coefficients_.push_back(coefficients_temp);
+
+  this->CalcSlope();
 }
 
 template <size_t N>

--- a/src/library/numerical_integration/runge_kutta_4.hpp
+++ b/src/library/numerical_integration/runge_kutta_4.hpp
@@ -40,6 +40,8 @@ class RungeKutta4 : public RungeKutta<N> {
 
     this->rk_matrix_[1][0] = this->rk_matrix_[2][1] = 0.5;
     this->rk_matrix_[3][2] = 1.0;
+
+    this->CalcSlope();
   }
 
   // We did not implement the interpolation for RK4

--- a/src/library/numerical_integration/runge_kutta_fehlberg_implementation.hpp
+++ b/src/library/numerical_integration/runge_kutta_fehlberg_implementation.hpp
@@ -59,6 +59,8 @@ RungeKuttaFehlberg<N>::RungeKuttaFehlberg(const double step_width, const Interfa
   this->rk_matrix_[5][2] = -3544.0 / 2565.0;
   this->rk_matrix_[5][3] = 1859.0 / 4104.0;
   this->rk_matrix_[5][4] = -11.0 / 40.0;
+
+  this->CalcSlope();
 }
 
 template <size_t N>


### PR DESCRIPTION
## Overview
Add Slope initialization in constructor for interpolation

## Issue
NA

## Details
We need this modification when we access the interpolated value before the first integration step.

##  Validation results
See Google test result.

## Scope of influence
Patch

## Supplement
NA

## Note
NA