### PR TITLE
Fix for RW initial rotation

### DIFF
--- a/src/components/real/aocs/reaction_wheel.cpp
+++ b/src/components/real/aocs/reaction_wheel.cpp
@@ -78,6 +78,8 @@ ReactionWheel::ReactionWheel(const int prescaler, const int fast_prescaler, Cloc
       is_calculated_jitter_(is_calc_jitter_enabled),
       is_logged_jitter_(is_log_jitter_enabled) {
   Initialize();
+  angular_velocity_rad_s_ = init_velocity_rad_s;
+  angular_velocity_rpm_ = angularVelocity2rpm(angular_velocity_rad_s_);
 }
 
 void ReactionWheel::Initialize() {
@@ -93,8 +95,6 @@ void ReactionWheel::Initialize() {
   acceleration_delay_buffer_.assign(len_buffer, 0.0);
 
   angular_acceleration_rad_s2_ = 0.0;
-  angular_velocity_rpm_ = 0.0;
-  angular_velocity_rad_s_ = 0.0;
 
   // Turn on RW jitter calculation
   if (is_calculated_jitter_) {


### PR DESCRIPTION
## Overview
Fix for RW initial rotation

## Issue
#381 

## Details
The initial rotation speed was used in RW_ODE, but the first log output shows the speed is zero. I fixed to insert the initial value to the source value of the log output.

##  Validation results
- 100 rad/s initial rotation speed and motor drive flag = 0
  - The rotation speed reach to zero due to the friction

![image](https://github.com/ut-issl/s2e-core/assets/19573779/979167b2-c392-433f-a748-2c833ab1355d)

- 100 rad/s initial rotation speed and motor drive flag = 1
  - The rotation speed is kept as 100 rad/s because the RW controls the rotation speed.

![image](https://github.com/ut-issl/s2e-core/assets/19573779/f3025fbf-1a5d-4c2d-81ec-51c3c7d5d5a4)

## Scope of influence
Patch update

## Supplement
NA

## Note
NA