### PR TITLE
Fix ephemeris time handling to improve calculation speed

### DIFF
--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -103,12 +103,7 @@ CelestialInformation::~CelestialInformation() {
   delete earth_rotation_;
 }
 
-void CelestialInformation::UpdateAllObjectsInformation(const double current_time_jd) {
-  // Convert time
-  SpiceDouble ephemeris_time;
-  std::string julian_date = "jd " + std::to_string(current_time_jd);
-  str2et_c(julian_date.c_str(), &ephemeris_time);
-
+void CelestialInformation::UpdateAllObjectsInformation(const SimulationTime& simulation_time) {
   // Update celestial body orbit
   for (unsigned int i = 0; i < number_of_selected_bodies_; i++) {
     SpiceInt planet_id = selected_body_ids_[i];
@@ -121,7 +116,7 @@ void CelestialInformation::UpdateAllObjectsInformation(const double current_time
 
     // Acquisition of position and velocity
     SpiceDouble orbit_buffer_km[6];
-    GetPlanetOrbit(name_buffer, ephemeris_time, (SpiceDouble*)orbit_buffer_km);
+    GetPlanetOrbit(name_buffer, simulation_time.GetCurrentEphemerisTime(), (SpiceDouble*)orbit_buffer_km);
     // Convert unit [km], [km/s] to [m], [m/s]
     for (int j = 0; j < 3; j++) {
       celestial_body_position_from_center_i_m_[i * 3 + j] = orbit_buffer_km[j] * 1000.0;
@@ -130,7 +125,7 @@ void CelestialInformation::UpdateAllObjectsInformation(const double current_time
   }
 
   // Update celestial rotation
-  earth_rotation_->Update(current_time_jd);
+  earth_rotation_->Update(simulation_time.GetCurrentTime_jd());
 }
 
 int CelestialInformation::CalcBodyIdFromName(const char* body_name) const {

--- a/src/environment/global/celestial_information.hpp
+++ b/src/environment/global/celestial_information.hpp
@@ -10,6 +10,7 @@
 #include "celestial_rotation.hpp"
 #include "library/logger/loggable.hpp"
 #include "library/math/vector.hpp"
+#include "simulation_time.hpp"
 
 /**
  * @class CelestialInformation
@@ -56,9 +57,9 @@ class CelestialInformation : public ILoggable {
   /**
    * @fn UpdateAllObjectsInformation
    * @brief Update the information of all selected celestial objects
-   * @param [in] current_time_jd: Current time [Julian day]
+   * @param [in] simulation_time: Simulation Time information
    */
-  void UpdateAllObjectsInformation(const double current_time_jd);
+  void UpdateAllObjectsInformation(const SimulationTime& simulation_time);
 
   // Getters
   // Orbit information

--- a/src/environment/global/global_environment.cpp
+++ b/src/environment/global/global_environment.cpp
@@ -23,19 +23,19 @@ void GlobalEnvironment::Initialize(const SimulationConfiguration* simulation_con
   std::string simulation_time_ini_path = simulation_configuration->initialize_base_file_name_;
 
   // Initialize
-  simulation_time_ = InitSimulationTime(simulation_time_ini_path);
   celestial_information_ = InitCelestialInformation(simulation_configuration->initialize_base_file_name_);
+  simulation_time_ = InitSimulationTime(simulation_time_ini_path);
   hipparcos_catalogue_ = InitHipparcosCatalogue(simulation_configuration->initialize_base_file_name_);
   gnss_satellites_ = InitGnssSatellites(simulation_configuration->gnss_file_);
 
   // Calc initial value
-  celestial_information_->UpdateAllObjectsInformation(simulation_time_->GetCurrentTime_jd());
+  celestial_information_->UpdateAllObjectsInformation(*simulation_time_);
   gnss_satellites_->SetUp(simulation_time_);
 }
 
 void GlobalEnvironment::Update() {
   simulation_time_->UpdateTime();
-  celestial_information_->UpdateAllObjectsInformation(simulation_time_->GetCurrentTime_jd());
+  celestial_information_->UpdateAllObjectsInformation(*simulation_time_);
   gnss_satellites_->Update(simulation_time_);
 }
 

--- a/src/environment/global/simulation_time.cpp
+++ b/src/environment/global/simulation_time.cpp
@@ -6,6 +6,8 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include "simulation_time.hpp"
 
+#include <SpiceUsr.h>
+
 #include <cassert>
 #include <iostream>
 #include <sstream>
@@ -48,6 +50,11 @@ SimulationTime::SimulationTime(const double end_sec, const double step_sec, cons
   AssertTimeStepParams();
   InitializeState();
   SetParameters();
+
+  // Ephemeris time initialize
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(11) << "jd " << start_jd_;
+  str2et_c(stream.str().c_str(), &start_ephemeris_time_);
 }
 
 SimulationTime::~SimulationTime() {}

--- a/src/environment/global/simulation_time.hpp
+++ b/src/environment/global/simulation_time.hpp
@@ -202,6 +202,11 @@ class SimulationTime : public ILoggable {
    *@brief Return current UTC calendar expression
    */
   inline const UTC GetCurrentUtc(void) const { return current_utc_; };
+  /**
+   *@fn GetCurrentEphemerisTime
+   *@brief Return current Ephemeris time
+   */
+  inline double GetCurrentEphemerisTime(void) const { return start_ephemeris_time_ + elapsed_time_sec_; };
 
   /**
    *@fn GetStartYear
@@ -292,13 +297,14 @@ class SimulationTime : public ILoggable {
   double log_output_interval_sec_;        //!< Log output interval [sec]
   double display_period_;                 //!< Display output period [sec]
 
-  double start_jd_;   //!< Simulation start Julian date [day]
-  int start_year_;    //!< Simulation start year
-  int start_month_;   //!< Simulation start month
-  int start_day_;     //!< Simulation start day
-  int start_hour_;    //!< Simulation start hour
-  int start_minute_;  //!< Simulation start minute
-  double start_sec_;  //!< Simulation start seconds
+  double start_ephemeris_time_;  //!< Simulation start Ephemeris Time
+  double start_jd_;              //!< Simulation start Julian date [day]
+  int start_year_;               //!< Simulation start year
+  int start_month_;              //!< Simulation start month
+  int start_day_;                //!< Simulation start day
+  int start_hour_;               //!< Simulation start hour
+  int start_minute_;             //!< Simulation start minute
+  double start_sec_;             //!< Simulation start seconds
 
   double simulation_speed_;  //!< The speed of the simulation relative to real time (if negative, real time is not taken into account)
   double time_exceeds_continuously_limit_sec_;  //!< Maximum duration to allow actual step_sec to be larger than specified continuously


### PR DESCRIPTION
## Overview
Fix ephemeris time handling to improve calculation speed

## Issue
NA

## Details
According to the improvement proposal from @HiroyukiBando, I modified the ephemeris time calculation.
https://github.com/ut-issl/s2e-core/pull/492

The improvement points
- Precision of input Julian day value is improved.
- The Julian day -> Ephemeris time convert function provided by CSPICE is called only the initialize sequence. This improves calculation speed a bit.

##  Validation results
The moon orbit calculation results are same between before and after, and the calculation speed is a bit improved.

![Picture1](https://github.com/ut-issl/s2e-core/assets/19573779/0924ac5a-31b7-499a-8e36-e9348397b7fd)

## Scope of influence
Influence only for celestial body orbit calculation.

## Supplement
Related [PR](https://github.com/ut-issl/s2e-core/pull/492)

## Note
NA
