### PR TITLE
Add new functions for ini read as `std::vector`

### DIFF
--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -36,8 +36,7 @@ IniAccess::IniAccess(const std::string file_path) : file_path_(file_path), ini_r
 }
 #endif
 
-std::vector<unsigned char> IniAccess::ReadVectorUnsignedChar(const char* section_name, const char* key_name, const size_t num)
-{
+std::vector<unsigned char> IniAccess::ReadVectorUnsignedChar(const char* section_name, const char* key_name, const size_t num) {
   std::vector<unsigned char> data;
   for (size_t i = 0; i < num; i++) {
     std::stringstream edited_key_name;
@@ -77,8 +76,7 @@ int IniAccess::ReadInt(const char* section_name, const char* key_name) {
 #endif
 }
 
-std::vector<int> IniAccess::ReadVectorInt(const char* section_name, const char* key_name, const size_t num)
-{
+std::vector<int> IniAccess::ReadVectorInt(const char* section_name, const char* key_name, const size_t num) {
   std::vector<int> data;
   for (size_t i = 0; i < num; i++) {
     std::stringstream edited_key_name;
@@ -110,8 +108,7 @@ void IniAccess::ReadDoubleArray(const char* section_name, const char* key_name, 
   }
 }
 
-std::vector<double> IniAccess::ReadVectorDouble(const char* section_name, const char* key_name, const size_t num)
-{
+std::vector<double> IniAccess::ReadVectorDouble(const char* section_name, const char* key_name, const size_t num) {
   std::vector<double> data;
   for (size_t i = 0; i < num; i++) {
     std::stringstream edited_key_name;

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -65,6 +65,17 @@ int IniAccess::ReadInt(const char* section_name, const char* key_name) {
   return (int)ini_reader_.GetInteger(section_name, key_name, 0);
 #endif
 }
+
+std::vector<int> IniAccess::ReadVectorInt(const char* section_name, const char* key_name, const size_t num)
+{
+  std::vector<int> data;
+  for (size_t i = 0; i < num; i++) {
+    std::stringstream edited_key_name;
+    edited_key_name << key_name << "(" << i << ")";
+    data.push_back(ReadInt(section_name, edited_key_name.str().c_str()));
+  }
+}
+
 bool IniAccess::ReadBoolean(const char* section_name, const char* key_name) {
 #ifdef WIN32
   int temp;

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -99,6 +99,17 @@ void IniAccess::ReadDoubleArray(const char* section_name, const char* key_name, 
   }
 }
 
+std::vector<double> IniAccess::ReadVectorDouble(const char* section_name, const char* key_name, const size_t num)
+{
+  std::vector<double> data;
+  for (size_t i = 0; i < num; i++) {
+    std::stringstream edited_key_name;
+    edited_key_name << key_name << "(" << i << ")";
+    data.push_back(ReadDouble(section_name, edited_key_name.str().c_str()));
+  }
+  return data;
+}
+
 void IniAccess::ReadQuaternion(const char* section_name, const char* key_name, libra::Quaternion& data) {
   libra::Quaternion temp;
   double norm = 0.0;

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -74,6 +74,7 @@ std::vector<int> IniAccess::ReadVectorInt(const char* section_name, const char* 
     edited_key_name << key_name << "(" << i << ")";
     data.push_back(ReadInt(section_name, edited_key_name.str().c_str()));
   }
+  return data;
 }
 
 bool IniAccess::ReadBoolean(const char* section_name, const char* key_name) {

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -36,6 +36,17 @@ IniAccess::IniAccess(const std::string file_path) : file_path_(file_path), ini_r
 }
 #endif
 
+std::vector<unsigned char> IniAccess::ReadVectorUnsignedChar(const char* section_name, const char* key_name, const size_t num)
+{
+  std::vector<unsigned char> data;
+  for (size_t i = 0; i < num; i++) {
+    std::stringstream edited_key_name;
+    edited_key_name << key_name << "(" << i << ")";
+    data.push_back((unsigned char)ReadInt(section_name, edited_key_name.str().c_str()));
+  }
+  return data;
+}
+
 double IniAccess::ReadDouble(const char* section_name, const char* key_name) {
 #ifdef WIN32
   std::stringstream value;

--- a/src/library/initialize/initialize_file_access.hpp
+++ b/src/library/initialize/initialize_file_access.hpp
@@ -85,6 +85,15 @@ class IniAccess {
    */
   void ReadDoubleArray(const char* section_name, const char* key_name, const int id, const int num, double* data);
   /**
+   * @fn ReadVectorDouble
+   * @brief Read a vector number as double type
+   * @param[in] section_name: Section name
+   * @param[in] key_name: Key name
+   * @param[in] num: Number of elements of the array
+   * @return Read number
+   */
+  std::vector<double> ReadVectorDouble(const char* section_name, const char* key_name, const size_t num);
+  /**
    * @fn ReadVector
    * @brief Read Vector type number
    * @param[in] section_name: Section name

--- a/src/library/initialize/initialize_file_access.hpp
+++ b/src/library/initialize/initialize_file_access.hpp
@@ -42,6 +42,15 @@ class IniAccess {
 
   // Read functions
   /**
+   * @fn ReadVectorUnsignedChar
+   * @brief Read a vector number as unsigned char type
+   * @param[in] section_name: Section name
+   * @param[in] key_name: Key name
+   * @param[in] num: Number of elements of the array
+   * @return Read number
+   */
+  std::vector<unsigned char> ReadVectorUnsignedChar(const char* section_name, const char* key_name, const size_t num);
+  /**
    * @fn ReadDouble
    * @brief Read a scalar number as double type
    * @param[in] section_name: Section name

--- a/src/library/initialize/initialize_file_access.hpp
+++ b/src/library/initialize/initialize_file_access.hpp
@@ -58,6 +58,15 @@ class IniAccess {
    */
   int ReadInt(const char* section_name, const char* key_name);
   /**
+   * @fn ReadVectorInt
+   * @brief Read a vector number as integer type
+   * @param[in] section_name: Section name
+   * @param[in] key_name: Key name
+   * @param[in] num: Number of elements of the array
+   * @return Read number
+   */
+  std::vector<int> ReadVectorInt(const char* section_name, const char* key_name, const size_t num);
+  /**
    * @fn ReadBoolean
    * @brief Read boolean
    * @param[in] section_name: Section name


### PR DESCRIPTION
## Related issues
NA

## Description
The following functions are added for ini file read.
- Read `std::vector<int>`
- Read `std::vector<unsigned char>`
- Read `std::vector<double>`

## Test results
s2e-aobcの下記PRに合わせた修正であり、そちらで動作確認済み。  
https://github.com/ut-issl/s2e-aobc/pull/72

## Impact
NA

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
