### PR TITLE
Fix required python version for python-utils

### DIFF
--- a/scripts/Plot/Pipfile.lock
+++ b/scripts/Plot/Pipfile.lock
@@ -615,7 +615,7 @@
                 "sha256:e31c1187168c314c984932e99c2d3f973465443493869ae041dd9e2e18e998aa"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version >= '3.8'",
             "version": "==3.7.0"
         },
         "pytz": {


### PR DESCRIPTION
## Related issues
NA

## Description
To fix error in GitHub actions, I fixed the required python version for python-utils.

## Test results
See CI result.

## Impact
NA

## Supplementary information
Related [PR](https://github.com/ut-issl/s2e-core/pull/503).

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
