### PR TITLE
Refactor celestial rotation

### DIFF
--- a/data/sample/initialize_files/sample_simulation_base.ini
+++ b/data/sample/initialize_files/sample_simulation_base.ini
@@ -86,8 +86,8 @@ center_object = EARTH
 aberration_correction = NONE
 
 // Earth Rotation model
-// Idle:no motion, Simple:rotation only, Full:full-dynamics
-rotation_mode = Simple
+// Idle:no motion, Simple:Z-axis rotation only, Full:full-dynamics
+earth_rotation_mode = Simple
 
 // Definition of calculation celestial bodies
 number_of_selected_body = 3

--- a/src/environment/global/CMakeLists.txt
+++ b/src/environment/global/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(${PROJECT_NAME} STATIC
   gnss_satellites.cpp
   simulation_time.cpp
   clock_generator.cpp
-  celestial_rotation.cpp
+  earth_rotation.cpp
   initialize_gnss_satellites.cpp
 )
 

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -19,7 +19,7 @@
 #include "library/logger/log_utility.hpp"
 
 CelestialInformation::CelestialInformation(const std::string inertial_frame_name, const std::string aberration_correction_setting,
-                                           const std::string center_body_name, const EarthRotationMode rotation_mode,
+                                           const std::string center_body_name, const EarthRotationMode earth_rotation_mode,
                                            const unsigned int number_of_selected_body, int* selected_body_ids)
     : number_of_selected_bodies_(number_of_selected_body),
       selected_body_ids_(selected_body_ids),
@@ -63,7 +63,7 @@ CelestialInformation::CelestialInformation(const std::string inertial_frame_name
   }
 
   // Initialize rotation
-  earth_rotation_ = new EarthRotation(rotation_mode);
+  earth_rotation_ = new EarthRotation(earth_rotation_mode);
 }
 
 CelestialInformation::CelestialInformation(const CelestialInformation& obj)
@@ -231,7 +231,7 @@ CelestialInformation* InitCelestialInformation(std::string file_name) {
 
   // Read Rotation setting
   EarthRotationMode rotation_mode;
-  std::string rotation_mode_temp = ini_file.ReadString(section, "rotation_mode");
+  std::string rotation_mode_temp = ini_file.ReadString(section, "earth_rotation_mode");
   if (rotation_mode_temp == "Idle") {
     rotation_mode = EarthRotationMode::kIdle;
   } else if (rotation_mode_temp == "Simple") {

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -64,7 +64,7 @@ CelestialInformation::CelestialInformation(const std::string inertial_frame_name
   }
 
   // Initialize rotation
-  earth_rotation_ = new CelestialRotation(rotation_mode_, center_body_name_);
+  earth_rotation_ = new EarthRotation(rotation_mode_, center_body_name_);
 }
 
 CelestialInformation::CelestialInformation(const CelestialInformation& obj)

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -25,8 +25,7 @@ CelestialInformation::CelestialInformation(const std::string inertial_frame_name
       selected_body_ids_(selected_body_ids),
       inertial_frame_name_(inertial_frame_name),
       center_body_name_(center_body_name),
-      aberration_correction_setting_(aberration_correction_setting),
-      rotation_mode_(rotation_mode) {
+      aberration_correction_setting_(aberration_correction_setting) {
   // Initialize list
   unsigned int num_of_state = number_of_selected_bodies_ * 3;
   celestial_body_position_from_center_i_m_ = new double[num_of_state];
@@ -64,15 +63,14 @@ CelestialInformation::CelestialInformation(const std::string inertial_frame_name
   }
 
   // Initialize rotation
-  earth_rotation_ = new EarthRotation(rotation_mode_, center_body_name_);
+  earth_rotation_ = new EarthRotation(rotation_mode);
 }
 
 CelestialInformation::CelestialInformation(const CelestialInformation& obj)
     : number_of_selected_bodies_(obj.number_of_selected_bodies_),
       inertial_frame_name_(obj.inertial_frame_name_),
       center_body_name_(obj.center_body_name_),
-      aberration_correction_setting_(obj.aberration_correction_setting_),
-      rotation_mode_(obj.rotation_mode_) {
+      aberration_correction_setting_(obj.aberration_correction_setting_) {
   unsigned int num_of_state = number_of_selected_bodies_ * 3;
 
   selected_body_ids_ = new int[number_of_selected_bodies_];

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -19,7 +19,7 @@
 #include "library/logger/log_utility.hpp"
 
 CelestialInformation::CelestialInformation(const std::string inertial_frame_name, const std::string aberration_correction_setting,
-                                           const std::string center_body_name, const RotationMode rotation_mode,
+                                           const std::string center_body_name, const EarthRotationMode rotation_mode,
                                            const unsigned int number_of_selected_body, int* selected_body_ids)
     : number_of_selected_bodies_(number_of_selected_body),
       selected_body_ids_(selected_body_ids),
@@ -230,17 +230,17 @@ CelestialInformation* InitCelestialInformation(std::string file_name) {
   }
 
   // Read Rotation setting
-  RotationMode rotation_mode;
+  EarthRotationMode rotation_mode;
   std::string rotation_mode_temp = ini_file.ReadString(section, "rotation_mode");
   if (rotation_mode_temp == "Idle") {
-    rotation_mode = RotationMode::kIdle;
+    rotation_mode = EarthRotationMode::kIdle;
   } else if (rotation_mode_temp == "Simple") {
-    rotation_mode = RotationMode::kSimple;
+    rotation_mode = EarthRotationMode::kSimple;
   } else if (rotation_mode_temp == "Full") {
-    rotation_mode = RotationMode::kFull;
+    rotation_mode = EarthRotationMode::kFull;
   } else  // if rotation_mode is neither Idle, Simple, nor Full, set rotation_mode to Idle
   {
-    rotation_mode = RotationMode::kIdle;
+    rotation_mode = EarthRotationMode::kIdle;
   }
 
   CelestialInformation* celestial_info;

--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -124,7 +124,7 @@ void CelestialInformation::UpdateAllObjectsInformation(const SimulationTime& sim
     }
   }
 
-  // Update celestial rotation
+  // Update earth rotation
   earth_rotation_->Update(simulation_time.GetCurrentTime_jd());
 }
 

--- a/src/environment/global/celestial_information.hpp
+++ b/src/environment/global/celestial_information.hpp
@@ -211,7 +211,6 @@ class CelestialInformation : public ILoggable {
 
   // Rotational Motion of each planets
   EarthRotation* earth_rotation_;  //!< Instance of Earth rotation
-  RotationMode rotation_mode_;         //!< Designation of rotation model
 
   /**
    * @fn GetPlanetOrbit

--- a/src/environment/global/celestial_information.hpp
+++ b/src/environment/global/celestial_information.hpp
@@ -7,7 +7,7 @@
 #ifndef S2E_ENVIRONMENT_GLOBAL_CELESTIAL_INFORMATION_HPP_
 #define S2E_ENVIRONMENT_GLOBAL_CELESTIAL_INFORMATION_HPP_
 
-#include "celestial_rotation.hpp"
+#include "earth_rotation.hpp"
 #include "library/logger/loggable.hpp"
 #include "library/math/vector.hpp"
 #include "simulation_time.hpp"

--- a/src/environment/global/celestial_information.hpp
+++ b/src/environment/global/celestial_information.hpp
@@ -25,12 +25,12 @@ class CelestialInformation : public ILoggable {
    * @param [in] inertial_frame_name:  Definition of inertial frame
    * @param [in] aberration_correction_setting: Stellar aberration correction
    * @param [in] center_body_name: Center body name of inertial frame
-   * @param [in] rotation_mode: Designation of rotation model
+   * @param [in] earth_rotation_mode: Designation of rotation model
    * @param [in] number_of_selected_body: Number of selected body
    * @param [in] selected_body_ids: SPICE IDs of selected bodies
    */
   CelestialInformation(const std::string inertial_frame_name, const std::string aberration_correction_setting, const std::string center_body_name,
-                       const EarthRotationMode rotation_mode, const unsigned int number_of_selected_body, int* selected_body_ids);
+                       const EarthRotationMode earth_rotation_mode, const unsigned int number_of_selected_body, int* selected_body_ids);
   /**
    * @fn CelestialInformation
    * @brief Copy constructor

--- a/src/environment/global/celestial_information.hpp
+++ b/src/environment/global/celestial_information.hpp
@@ -30,7 +30,7 @@ class CelestialInformation : public ILoggable {
    * @param [in] selected_body_ids: SPICE IDs of selected bodies
    */
   CelestialInformation(const std::string inertial_frame_name, const std::string aberration_correction_setting, const std::string center_body_name,
-                       const RotationMode rotation_mode, const unsigned int number_of_selected_body, int* selected_body_ids);
+                       const EarthRotationMode rotation_mode, const unsigned int number_of_selected_body, int* selected_body_ids);
   /**
    * @fn CelestialInformation
    * @brief Copy constructor

--- a/src/environment/global/celestial_information.hpp
+++ b/src/environment/global/celestial_information.hpp
@@ -174,7 +174,7 @@ class CelestialInformation : public ILoggable {
    * @fn GetEarthRotation
    * @brief Return EarthRotation information
    */
-  inline CelestialRotation GetEarthRotation(void) const { return *earth_rotation_; };
+  inline EarthRotation GetEarthRotation(void) const { return *earth_rotation_; };
 
   // Calculation
   /**
@@ -210,7 +210,7 @@ class CelestialInformation : public ILoggable {
                                                        // Y-axis equal to the cross product of the unit Z-axis and X-axis vectors
 
   // Rotational Motion of each planets
-  CelestialRotation* earth_rotation_;  //!< Instance of Earth rotation
+  EarthRotation* earth_rotation_;  //!< Instance of Earth rotation
   RotationMode rotation_mode_;         //!< Designation of rotation model
 
   /**

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -1,6 +1,6 @@
 ﻿/**
  * @file earth_rotation.cpp
- * @brief Class to calculate the celestial rotation
+ * @brief Class to calculate the earth rotation
  * @note Support earth rotation only now (TODO: add other planets)
  *       Refs: 福島,"天体の回転運動理論入門講義ノート", 2007 (in Japanese),
  *             長沢,"天体の位置計算(増補版)", 2001 (in Japanese),

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -17,7 +17,7 @@
 #include "library/math/constants.hpp"
 
 // Default constructor
-CelestialRotation::CelestialRotation(const RotationMode rotation_mode, const std::string center_body_name) {
+EarthRotation::EarthRotation(const RotationMode rotation_mode, const std::string center_body_name) {
   planet_name_ = "Anonymous";
   rotation_mode_ = RotationMode::kIdle;
   dcm_j2000_to_xcxf_ = libra::MakeIdentityMatrix<3>();
@@ -34,8 +34,8 @@ CelestialRotation::CelestialRotation(const RotationMode rotation_mode, const std
   }
 }
 
-// Initialize the class CelestialRotation instance as Earth
-void CelestialRotation::InitCelestialRotationAsEarth(const RotationMode rotation_mode, const std::string center_body_name) {
+// Initialize the class EarthRotation instance as Earth
+void EarthRotation::InitCelestialRotationAsEarth(const RotationMode rotation_mode, const std::string center_body_name) {
   planet_name_ = "EARTH";
   if (center_body_name == planet_name_) {
     if (rotation_mode == RotationMode::kSimple) {
@@ -131,7 +131,7 @@ void CelestialRotation::InitCelestialRotationAsEarth(const RotationMode rotation
   }
 }
 
-void CelestialRotation::Update(const double julian_date) {
+void EarthRotation::Update(const double julian_date) {
   double gmst_rad = gstime(julian_date);  // It is a bit different with 長沢(Nagasawa)'s algorithm. TODO: Check the correctness
 
   if (rotation_mode_ == RotationMode::kFull) {
@@ -176,9 +176,9 @@ void CelestialRotation::Update(const double julian_date) {
   }
 }
 
-libra::Matrix<3, 3> CelestialRotation::AxialRotation(const double gast_rad) { return libra::MakeRotationMatrixZ(gast_rad); }
+libra::Matrix<3, 3> EarthRotation::AxialRotation(const double gast_rad) { return libra::MakeRotationMatrixZ(gast_rad); }
 
-libra::Matrix<3, 3> CelestialRotation::Nutation(const double (&t_tt_century)[4]) {
+libra::Matrix<3, 3> EarthRotation::Nutation(const double (&t_tt_century)[4]) {
   // Mean obliquity of the ecliptic
   epsilon_rad_ = c_epsilon_rad_[0];
   for (int i = 0; i < 3; i++) {
@@ -240,7 +240,7 @@ libra::Matrix<3, 3> CelestialRotation::Nutation(const double (&t_tt_century)[4])
   return dcm_nutation;
 }
 
-libra::Matrix<3, 3> CelestialRotation::Precession(const double (&t_tt_century)[4]) {
+libra::Matrix<3, 3> EarthRotation::Precession(const double (&t_tt_century)[4]) {
   // Compute precession angles(zeta, theta, z)
   double zeta_rad = 0.0;
   for (int i = 0; i < 3; i++) {
@@ -266,7 +266,7 @@ libra::Matrix<3, 3> CelestialRotation::Precession(const double (&t_tt_century)[4
   return dcm_precession;
 }
 
-libra::Matrix<3, 3> CelestialRotation::PolarMotion(const double x_p, const double y_p) {
+libra::Matrix<3, 3> EarthRotation::PolarMotion(const double x_p, const double y_p) {
   libra::Matrix<3, 3> dcm_polar_motion;
 
   dcm_polar_motion[0][0] = 1.0;

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -1,5 +1,5 @@
 ﻿/**
- * @file celestial_rotation.cpp
+ * @file earth_rotation.cpp
  * @brief Class to calculate the celestial rotation
  * @note Support earth rotation only now (TODO: add other planets)
  *       Refs: 福島,"天体の回転運動理論入門講義ノート", 2007 (in Japanese),
@@ -7,7 +7,7 @@
  *             IERS Conventions 2003
  */
 
-#include "celestial_rotation.hpp"
+#include "earth_rotation.hpp"
 
 #include <iostream>
 #include <sstream>
@@ -136,7 +136,8 @@ void CelestialRotation::Update(const double julian_date) {
 
   if (rotation_mode_ == RotationMode::kFull) {
     // Compute Julian date for terrestrial time
-    double terrestrial_time_julian_day = julian_date + kDtUt1Utc_ * kSec2Day_;  // TODO: Check the correctness. Problem is that S2E doesn't have Gregorian calendar.
+    double terrestrial_time_julian_day =
+        julian_date + kDtUt1Utc_ * kSec2Day_;  // TODO: Check the correctness. Problem is that S2E doesn't have Gregorian calendar.
 
     // Compute nth power of julian century for terrestrial time.
     // The actual unit of tTT_century is [century^(i+1)], i is the index of the array

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -13,10 +13,10 @@
 #include "library/math/matrix.hpp"
 
 /**
- * @enum RotationMode
+ * @enum EarthRotationMode
  * @brief Definition of calculation mode of earth rotation
  */
-enum class RotationMode {
+enum class EarthRotationMode {
   kIdle,    //!< No Rotation calculation
   kSimple,  //!< Z axis rotation only
   kFull,    //!< Rotation including precession and nutation
@@ -33,7 +33,7 @@ class EarthRotation {
    * @brief Constructor
    * @param [in] rotation_mode: Designation of rotation model
    */
-  EarthRotation(const RotationMode rotation_mode);
+  EarthRotation(const EarthRotationMode rotation_mode = EarthRotationMode::kSimple);
 
   /**
    * @fn Update
@@ -49,7 +49,7 @@ class EarthRotation {
   inline const libra::Matrix<3, 3> GetDcmJ2000ToXcxf() const { return dcm_j2000_to_xcxf_; };
 
   /**
-   * @fn GetDcmJ2000ToXcxf
+   * @fn GetDcmTemeToXcxf
    * @brief Return the DCM between TEME (Inertial frame used in SGP4) and the frame of fixed to the target object X (X-Centered X-Fixed)
    */
   inline const libra::Matrix<3, 3> GetDcmTemeToXcxf() const { return dcm_teme_to_xcxf_; };
@@ -60,7 +60,7 @@ class EarthRotation {
   double epsilon_rad_;                     //!< Mean obliquity of the ecliptic [rad]
   libra::Matrix<3, 3> dcm_j2000_to_xcxf_;  //!< Direction Cosine Matrix J2000 to XCXF(X-Centered X-Fixed)
   libra::Matrix<3, 3> dcm_teme_to_xcxf_;   //!< Direction Cosine Matrix TEME to XCXF(X-Centered X-Fixed)
-  RotationMode rotation_mode_;             //!< Designation of dynamics model
+  EarthRotationMode rotation_mode_;        //!< Designation of dynamics model
 
   // Definitions of coefficients
   // They are handling as constant values
@@ -86,9 +86,8 @@ class EarthRotation {
   /**
    * @fn InitializeParameters
    * @brief Initialize parameters
-   * @param [in] rotation_mode: Designation of rotation model
    */
-  void InitializeParameters(const RotationMode rotation_mode);
+  void InitializeParameters();
 
   /**
    * @fn AxialRotation

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -24,20 +24,20 @@ enum class RotationMode {
 };
 
 /**
- * @class CelestialRotation
+ * @class EarthRotation
  * @brief Class to calculate the celestial rotation
  * @note Support earth rotation only now (TODO: add other planets)
  */
-class CelestialRotation {
+class EarthRotation {
  public:
   // initialize DCM to unit matrix in the default constructor
   /**
-   * @fn CelestialRotation
+   * @fn EarthRotation
    * @brief Constructor
    * @param [in] rotation_mode: Designation of rotation model
    * @param [in] center_body_name: Center object of inertial frame
    */
-  CelestialRotation(const RotationMode rotation_mode, const std::string center_body_name);
+  EarthRotation(const RotationMode rotation_mode, const std::string center_body_name);
 
   /**
    * @fn Update
@@ -91,7 +91,7 @@ class CelestialRotation {
 
   /**
    * @fn InitCelestialRotationAsEarth
-   * @brief Initialize CelestialRotation as earth rotation
+   * @brief Initialize EarthRotation as earth rotation
    * @note TODO: Make functions for other planets?
    * @param [in] rotation_mode: Rotation mode
    * @param [in] center_body_name: Name of center body

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -1,8 +1,7 @@
 ﻿/**
  * @file earth_rotation.hpp
  * @brief Class to calculate the earth rotation
- * @note Support earth rotation only now (TODO: add other planets)
- *       Refs: 福島,"天体の回転運動理論入門講義ノート", 2007 (in Japanese),
+ * @note Refs: 福島,"天体の回転運動理論入門講義ノート", 2007 (in Japanese),
  *             長沢,"天体の位置計算(増補版)", 2001 (in Japanese),
  *             IERS Conventions 2003
  */
@@ -26,18 +25,15 @@ enum class RotationMode {
 /**
  * @class EarthRotation
  * @brief Class to calculate the earth rotation
- * @note Support earth rotation only now (TODO: add other planets)
  */
 class EarthRotation {
  public:
-  // initialize DCM to unit matrix in the default constructor
   /**
    * @fn EarthRotation
    * @brief Constructor
    * @param [in] rotation_mode: Designation of rotation model
-   * @param [in] center_body_name: Center object of inertial frame
    */
-  EarthRotation(const RotationMode rotation_mode, const std::string center_body_name);
+  EarthRotation(const RotationMode rotation_mode);
 
   /**
    * @fn Update
@@ -65,12 +61,10 @@ class EarthRotation {
   libra::Matrix<3, 3> dcm_j2000_to_xcxf_;  //!< Direction Cosine Matrix J2000 to XCXF(X-Centered X-Fixed)
   libra::Matrix<3, 3> dcm_teme_to_xcxf_;   //!< Direction Cosine Matrix TEME to XCXF(X-Centered X-Fixed)
   RotationMode rotation_mode_;             //!< Designation of dynamics model
-  std::string planet_name_;                //!< Designate which solar planet the instance should work as
 
   // Definitions of coefficients
   // They are handling as constant values
   // TODO: Consider to read setting files for these coefficients
-  // TODO: Consider other formats for other planets
   double c_epsilon_rad_[4];  //!< Coefficients to compute mean obliquity of the ecliptic
   double c_lm_rad_[5];       //!< Coefficients to compute Delaunay angle (l=lm: Mean anomaly of the moon)
   double c_ls_rad_[5];       //!< Coefficients to compute Delaunay angle (l'=ls: Mean anomaly of the sun)
@@ -90,13 +84,11 @@ class EarthRotation {
   const double kDayJulianCentury_ = 36525.0;            //!< Conversion constant from Julian century to day [day/century]
 
   /**
-   * @fn InitCelestialRotationAsEarth
-   * @brief Initialize EarthRotation as earth rotation
-   * @note TODO: Make functions for other planets?
-   * @param [in] rotation_mode: Rotation mode
-   * @param [in] center_body_name: Name of center body
+   * @fn InitializeParameters
+   * @brief Initialize parameters
+   * @param [in] rotation_mode: Designation of rotation model
    */
-  void InitCelestialRotationAsEarth(const RotationMode rotation_mode, const std::string center_body_name);
+  void InitializeParameters(const RotationMode rotation_mode);
 
   /**
    * @fn AxialRotation

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -1,5 +1,5 @@
 ﻿/**
- * @file celestial_rotation.hpp
+ * @file earth_rotation.hpp
  * @brief Class to calculate the celestial rotation
  * @note Support earth rotation only now (TODO: add other planets)
  *       Refs: 福島,"天体の回転運動理論入門講義ノート", 2007 (in Japanese),

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -1,21 +1,21 @@
 ﻿/**
  * @file earth_rotation.hpp
- * @brief Class to calculate the celestial rotation
+ * @brief Class to calculate the earth rotation
  * @note Support earth rotation only now (TODO: add other planets)
  *       Refs: 福島,"天体の回転運動理論入門講義ノート", 2007 (in Japanese),
  *             長沢,"天体の位置計算(増補版)", 2001 (in Japanese),
  *             IERS Conventions 2003
  */
 
-#ifndef S2E_ENVIRONMENT_GLOBAL_CELESTIAL_ROTATION_HPP_
-#define S2E_ENVIRONMENT_GLOBAL_CELESTIAL_ROTATION_HPP_
+#ifndef S2E_ENVIRONMENT_GLOBAL_EARTH_ROTATION_HPP_
+#define S2E_ENVIRONMENT_GLOBAL_EARTH_ROTATION_HPP_
 
 #include "library/logger/loggable.hpp"
 #include "library/math/matrix.hpp"
 
 /**
  * @enum RotationMode
- * @brief Definition of calculation mode of celestial rotation
+ * @brief Definition of calculation mode of earth rotation
  */
 enum class RotationMode {
   kIdle,    //!< No Rotation calculation
@@ -25,7 +25,7 @@ enum class RotationMode {
 
 /**
  * @class EarthRotation
- * @brief Class to calculate the celestial rotation
+ * @brief Class to calculate the earth rotation
  * @note Support earth rotation only now (TODO: add other planets)
  */
 class EarthRotation {
@@ -130,4 +130,4 @@ class EarthRotation {
   libra::Matrix<3, 3> PolarMotion(const double x_p, const double y_p);
 };
 
-#endif  // S2E_ENVIRONMENT_GLOBAL_CELESTIAL_ROTATION_HPP_
+#endif  // S2E_ENVIRONMENT_GLOBAL_EARTH_ROTATION_HPP_

--- a/src/simulation/ground_station/ground_station.cpp
+++ b/src/simulation/ground_station/ground_station.cpp
@@ -45,7 +45,7 @@ void GroundStation::Initialize(const SimulationConfiguration* configuration, con
 
 void GroundStation::LogSetup(Logger& logger) { logger.AddLogList(this); }
 
-void GroundStation::Update(const CelestialRotation& celestial_rotation, const Spacecraft& spacecraft) {
+void GroundStation::Update(const EarthRotation& celestial_rotation, const Spacecraft& spacecraft) {
   libra::Matrix<3, 3> dcm_ecef2eci = celestial_rotation.GetDcmJ2000ToXcxf().Transpose();
   position_i_m_ = dcm_ecef2eci * position_ecef_m_;
 

--- a/src/simulation/ground_station/ground_station.hpp
+++ b/src/simulation/ground_station/ground_station.hpp
@@ -43,7 +43,7 @@ class GroundStation : public ILoggable {
    * @fn Update
    * @brief Virtual function of main routine
    */
-  virtual void Update(const CelestialRotation& celestial_rotation, const Spacecraft& spacecraft);
+  virtual void Update(const EarthRotation& celestial_rotation, const Spacecraft& spacecraft);
 
   // Override functions for ILoggable
   /**

--- a/src/simulation/ground_station/ground_station.hpp
+++ b/src/simulation/ground_station/ground_station.hpp
@@ -6,7 +6,6 @@
 #ifndef S2E_SIMULATION_GROUND_STATION_GROUND_STATION_HPP_
 #define S2E_SIMULATION_GROUND_STATION_GROUND_STATION_HPP_
 
-#include <environment/global/celestial_rotation.hpp>
 #include <library/geodesy/geodetic_position.hpp>
 #include <library/math/vector.hpp>
 #include <simulation/spacecraft/spacecraft.hpp>

--- a/src/simulation_sample/ground_station/sample_ground_station.cpp
+++ b/src/simulation_sample/ground_station/sample_ground_station.cpp
@@ -19,7 +19,7 @@ void SampleGroundStation::LogSetup(Logger& logger) {
   components_->CompoLogSetUp(logger);
 }
 
-void SampleGroundStation::Update(const CelestialRotation& celestial_rotation, const SampleSpacecraft& spacecraft) {
+void SampleGroundStation::Update(const EarthRotation& celestial_rotation, const SampleSpacecraft& spacecraft) {
   GroundStation::Update(celestial_rotation, spacecraft);
   components_->GetGsCalculator()->Update(spacecraft, spacecraft.GetInstalledComponents().GetAntenna(), *this, *(components_->GetAntenna()));
 }

--- a/src/simulation_sample/ground_station/sample_ground_station.hpp
+++ b/src/simulation_sample/ground_station/sample_ground_station.hpp
@@ -42,7 +42,7 @@ class SampleGroundStation : public GroundStation {
    * @fn Update
    * @brief Override function of Update in GroundStation class
    */
-  virtual void Update(const CelestialRotation& celestial_rotation, const SampleSpacecraft& spacecraft);
+  virtual void Update(const EarthRotation& celestial_rotation, const SampleSpacecraft& spacecraft);
 
  private:
   using GroundStation::Update;


### PR DESCRIPTION
## Related issues
#164 

## Description
I changed the class name 'CelestialRotation' to 'EarthRotation' because most of the member variables and functions are earth specific.

## Test results
See CI result.

## Impact
No effect for normal users.

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
