### PR TITLE
Fix include c2a-core v4

### DIFF
--- a/src/components/real/cdh/on_board_computer_with_c2a.cpp
+++ b/src/components/real/cdh/on_board_computer_with_c2a.cpp
@@ -10,7 +10,7 @@
 #include "src_core/c2a_core_main.h"
 
 #if !defined(C2A_CORE_VER_MAJOR)
-#error "C2A_CORE_VER_MAJOR is not defined"
+#warning "C2A_CORE_VER_MAJOR is not defined"   # this flag is defined after c2a-core v3.5.0
 #elif C2A_CORE_VER_MAJOR == 4
 // c2a-core v4
 #include "src_core/system/task_manager/task_dispatcher.h"

--- a/src/components/real/cdh/on_board_computer_with_c2a.cpp
+++ b/src/components/real/cdh/on_board_computer_with_c2a.cpp
@@ -9,7 +9,9 @@
 #ifdef USE_C2A
 #include "src_core/c2a_core_main.h"
 
-#if C2A_CORE_VER_MAJOR == 4
+#if !defined(C2A_CORE_VER_MAJOR)
+#error "C2A_CORE_VER_MAJOR is not defined"
+#elif C2A_CORE_VER_MAJOR == 4
 // c2a-core v4
 #include "src_core/system/task_manager/task_dispatcher.h"
 #include "src_core/system/time_manager/time_manager.h"
@@ -22,7 +24,6 @@
 #else
 #error "c2a-core version is not supported"
 #endif  // c2a-core version header
-
 #endif  // USE_C2A
 
 std::map<int, UartPort*> ObcWithC2a::com_ports_c2a_;

--- a/src/components/real/communication/wings_command_sender_to_c2a.cpp
+++ b/src/components/real/communication/wings_command_sender_to_c2a.cpp
@@ -13,7 +13,9 @@
 
 #ifdef USE_C2A
 #include "src_core/c2a_core_main.h"
-#if C2A_CORE_VER_MAJOR == 4
+#if !defined(C2A_CORE_VER_MAJOR)
+#error "C2A_CORE_VER_MAJOR is not defined"
+#elif C2A_CORE_VER_MAJOR == 4
 // c2a-core v4
 #include "src_core/tlm_cmd/common_cmd_packet_util.h"
 #elif C2A_CORE_VER_MAJOR <= 3

--- a/src/components/real/communication/wings_command_sender_to_c2a.cpp
+++ b/src/components/real/communication/wings_command_sender_to_c2a.cpp
@@ -14,7 +14,7 @@
 #ifdef USE_C2A
 #include "src_core/c2a_core_main.h"
 #if !defined(C2A_CORE_VER_MAJOR)
-#error "C2A_CORE_VER_MAJOR is not defined"
+#warning "C2A_CORE_VER_MAJOR is not defined"   # this flag is defined after c2a-core v3.5.0
 #elif C2A_CORE_VER_MAJOR == 4
 // c2a-core v4
 #include "src_core/tlm_cmd/common_cmd_packet_util.h"

--- a/src/components/real/communication/wings_command_sender_to_c2a.cpp
+++ b/src/components/real/communication/wings_command_sender_to_c2a.cpp
@@ -12,6 +12,7 @@
 #include <regex>
 
 #ifdef USE_C2A
+#include "src_core/c2a_core_main.h"
 #if C2A_CORE_VER_MAJOR == 4
 // c2a-core v4
 #include "src_core/tlm_cmd/common_cmd_packet_util.h"


### PR DESCRIPTION
## Related issues
- #477 

## Description
Fixes build issue with c2a-core v4 integration.

- `src/components/real/communication/wings_command_sender_to_c2a.cpp`
  - It missing `#include "src_core/c2a_core_main.h"`
- c2a-core header include
  - These should be check `C2A_CORE_VER_MAJOR` is defined

## Test results
- build fail: https://github.com/arkedge/c2a-core/actions/runs/6517794225/job/17702595240
  - c2a-core: [v4.0.0-beta.4](https://github.com/arkedge/c2a-core/releases/tag/v4.0.0-beta.4)
  - s2e-core: [v7.0.0](https://togithub.com/ut-issl/s2e-core/releases/tag/v7.0.0)
  - s2e-user-for-c2a-core: [ae-v3.0.0](https://github.com/ut-issl/s2e-user-for-c2a-core/releases/tag/ae-v3.0.0)
- added this patch: https://github.com/arkedge/c2a-core/actions/runs/6543168013/job/17767304700?pr=152
  - c2a-core: [v4.0.0-beta.4](https://github.com/arkedge/c2a-core/releases/tag/v4.0.0-beta.4)
  - s2e-user-for-c2a-core: [ae-v3.0.0](https://github.com/ut-issl/s2e-user-for-c2a-core/releases/tag/ae-v3.0.0)

## Impact


## Supplementary information
N/A
