### PR TITLE
Remove sscanf warnings in VS build

### DIFF
--- a/src/library/gnss/sp3_file_reader.cpp
+++ b/src/library/gnss/sp3_file_reader.cpp
@@ -4,10 +4,9 @@
  * @note Support version: SP3-d
  *       Ref: https://files.igs.org/pub/data/format/sp3d.pdf?_ga=2.115202830.823990648.1664976786-1792483726.1664976785
  */
+#define _CRT_SECURE_NO_WARNINGS  // for sscanf
 
 #include "sp3_file_reader.hpp"
-
-#define _CRT_SECURE_NO_WARNINGS  // for sscanf
 
 #include <fstream>
 #include <iostream>

--- a/src/library/gnss/sp3_file_reader.cpp
+++ b/src/library/gnss/sp3_file_reader.cpp
@@ -7,6 +7,8 @@
 
 #include "sp3_file_reader.hpp"
 
+#define _CRT_SECURE_NO_WARNINGS  // for sscanf
+
 #include <fstream>
 #include <iostream>
 

--- a/src/library/time_system/date_time_format.hpp
+++ b/src/library/time_system/date_time_format.hpp
@@ -6,6 +6,8 @@
 #ifndef S2E_LIBRARY_TIME_SYSTEM_DATE_TIME_FORMAT_HPP_
 #define S2E_LIBRARY_TIME_SYSTEM_DATE_TIME_FORMAT_HPP_
 
+#define _CRT_SECURE_NO_WARNINGS  // for sscanf
+
 #include <string>
 
 /**

--- a/src/library/time_system/date_time_format.hpp
+++ b/src/library/time_system/date_time_format.hpp
@@ -3,10 +3,10 @@
  * @brief Class to handle Gregorian date and time format
  */
 
+#define _CRT_SECURE_NO_WARNINGS  // for sscanf
+
 #ifndef S2E_LIBRARY_TIME_SYSTEM_DATE_TIME_FORMAT_HPP_
 #define S2E_LIBRARY_TIME_SYSTEM_DATE_TIME_FORMAT_HPP_
-
-#define _CRT_SECURE_NO_WARNINGS  // for sscanf
 
 #include <string>
 


### PR DESCRIPTION
## Related issues
NA

## Description
I added the macro to ignore `sscanf` warnings similar with the `simulation_time.cpp`

## Test results
See CI results

## Impact
patch

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
