### PR TITLE
Add GNSS satellite nubmer library

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME} STATIC
   geodesy/geodetic_position.cpp
 
   gnss/sp3_file_reader.cpp
+  gnss/gnss_satellite_number.cpp
 
   initialize/initialize_file_access.cpp
   initialize/c2a_command_database.cpp

--- a/src/library/gnss/gnss_satellite_number.cpp
+++ b/src/library/gnss/gnss_satellite_number.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file gnss_satellite_number.cpp
+ * @brief Manage satellite number defined in RINEX v4
+ */
+
+#include "gnss_satellite_number.hpp"
+
+size_t ConvertSatelliteNumberToIndex(const std::string satellite_number) {
+  switch (satellite_number.front()) {
+    case 'G':
+      return stoi(satellite_number.substr(1)) + kGpsIndexBegin - 1;
+    case 'R':
+      return stoi(satellite_number.substr(1)) + kGlonassIndexBegin - 1;
+    case 'E':
+      return stoi(satellite_number.substr(1)) + kGalileoIndexBegin - 1;
+    case 'C':
+      return stoi(satellite_number.substr(1)) + kBeidouIndexBegin - 1;
+    case 'J':
+      return stoi(satellite_number.substr(1)) + kQzssIndexBegin - 1;
+    case 'I':
+      return stoi(satellite_number.substr(1)) + kNavicIndexBegin - 1;
+    default:
+      return UINT32_MAX;
+      break;
+  }
+}
+
+std::string ConvertIndexToSatelliteNumber(const size_t index) {
+  std::string output;
+  size_t prn_number = 0;
+
+  if (index < kGlonassIndexBegin) {
+    output = 'G';
+    prn_number = index - kGpsIndexBegin + 1;
+  } else if (index < kGalileoIndexBegin) {
+    output = 'R';
+    prn_number = index - kGlonassIndexBegin + 1;
+  } else if (index < kBeidouIndexBegin) {
+    output = 'E';
+    prn_number = index - kGalileoIndexBegin + 1;
+  } else if (index < kQzssIndexBegin) {
+    output = 'C';
+    prn_number = index - kBeidouIndexBegin + 1;
+  } else if (index < kNavicIndexBegin) {
+    output = 'J';
+    prn_number = index - kQzssIndexBegin + 1;
+  } else if (index < kTotalNumberOfGnssSatellite) {
+    output = 'I';
+    prn_number = index - kNavicIndexBegin + 1;
+  } else {
+    return "err";
+  }
+
+  if (prn_number < 10) {
+    output += '0';
+  }
+  output += std::to_string(prn_number);
+
+  return output;
+}

--- a/src/library/gnss/gnss_satellite_number.hpp
+++ b/src/library/gnss/gnss_satellite_number.hpp
@@ -1,0 +1,47 @@
+/**
+ * @file gnss_satellite_number.hpp
+ * @brief Manage satellite number defined in RINEX v4
+ */
+
+#ifndef S2E_LIBRARY_GNSS_GNSS_SATELLITE_NUMBER_HPP_
+#define S2E_LIBRARY_GNSS_GNSS_SATELLITE_NUMBER_HPP_
+
+#include <stdint.h>
+
+#include <string>
+
+// GNSS satellite number definition
+// TODO: Move to initialized file?
+const size_t kNumberOfGpsSatellite = 32;      //!< Number of GPS satellites
+const size_t kNumberOfGlonassSatellite = 26;  //!< Number of GLONASS satellites
+const size_t kNumberOfGalileoSatellite = 28;  //!< Number of Galileo satellites
+const size_t kNumberOfBeidouSatellite = 62;   //!< Number of BeiDou satellites
+const size_t kNumberOfQzssSatellite = 5;      //!< Number of QZSS satellites
+const size_t kNumberOfNavicSatellite = 7;     //!< Number of NavIC satellites
+
+const size_t kTotalNumberOfGnssSatellite = kNumberOfGpsSatellite + kNumberOfGlonassSatellite + kNumberOfGalileoSatellite + kNumberOfBeidouSatellite +
+                                           kNumberOfQzssSatellite + kNumberOfNavicSatellite;  //<! Total number of GNSS satellites
+
+// GNSS satellite index definitions
+const size_t kGpsIndexBegin = 0;                                                   //!< Begin value of index for GPS satellites
+const size_t kGlonassIndexBegin = kGpsIndexBegin + kNumberOfGpsSatellite;          //!< Begin value of index for GLONASS satellites
+const size_t kGalileoIndexBegin = kGlonassIndexBegin + kNumberOfGlonassSatellite;  //!< Begin value of index for Galileo satellites
+const size_t kBeidouIndexBegin = kGalileoIndexBegin + kNumberOfGalileoSatellite;   //!< Begin value of index for BeiDou satellites
+const size_t kQzssIndexBegin = kBeidouIndexBegin + kNumberOfBeidouSatellite;       //!< Begin value of index for QZSS satellites
+const size_t kNavicIndexBegin = kQzssIndexBegin + kNumberOfQzssSatellite;          //!< Begin value of index for NavIC satellites
+
+/**
+ * @fn ConvertSatelliteNumberToIndex
+ * @brief Calculate index of GNSS satellite defined in S2E from GNSS satellite number defined in RINEX v4
+ * @return Index of GNSS satellite defined in this class. or INT32_MAX when the input is wrong.
+ */
+size_t ConvertSatelliteNumberToIndex(const std::string satellite_number);
+
+/**
+ * @fn ConvertIndexToSatelliteNumber
+ * @brief Calculate GNSS satellite number defined in RINEX v4 from index of GNSS satellite defined in this class
+ * @return GNSS satellite number defined in RINEX v4. or err when the input is wrong.
+ */
+std::string ConvertIndexToSatelliteNumber(const size_t index);
+
+#endif  // S2E_LIBRARY_GNSS_GNSS_SATELLITE_NUMBER_HPP_

--- a/src/library/gnss/test_gnss_satellite_number.cpp
+++ b/src/library/gnss/test_gnss_satellite_number.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file test_gnss_satellite_number.cpp
+ * @brief Test functions for GNSS satellite number handling with GoogleTest
+ */
+#include <gtest/gtest.h>
+
+#include "gnss_satellite_number.hpp"
+
+/**
+ * @brief Test satellite number to index
+ */
+TEST(GnssSatelliteNumber, SatelliteNumberToIndex) {
+  EXPECT_EQ(ConvertSatelliteNumberToIndex("G01"), 0);
+  EXPECT_EQ(ConvertSatelliteNumberToIndex("R02"), kGlonassIndexBegin + 1);
+  EXPECT_EQ(ConvertSatelliteNumberToIndex("E10"), kGalileoIndexBegin + 9);
+  EXPECT_EQ(ConvertSatelliteNumberToIndex("C40"), kBeidouIndexBegin + 39);
+  EXPECT_EQ(ConvertSatelliteNumberToIndex("J03"), kQzssIndexBegin + 2);
+  EXPECT_EQ(ConvertSatelliteNumberToIndex("I04"), kNavicIndexBegin + 3);
+  EXPECT_EQ(ConvertSatelliteNumberToIndex("err"), UINT32_MAX);
+}
+
+/**
+ * @brief Test index to satellite number
+ */
+TEST(GnssSatelliteNumber, IndexToSatelliteNumber) {
+  EXPECT_EQ(ConvertIndexToSatelliteNumber(0), "G01");
+  EXPECT_EQ(ConvertIndexToSatelliteNumber(kGlonassIndexBegin + 9), "R10");
+  EXPECT_EQ(ConvertIndexToSatelliteNumber(kGalileoIndexBegin + 21), "E22");
+  EXPECT_EQ(ConvertIndexToSatelliteNumber(kBeidouIndexBegin + 50), "C51");
+  EXPECT_EQ(ConvertIndexToSatelliteNumber(kQzssIndexBegin + 0), "J01");
+  EXPECT_EQ(ConvertIndexToSatelliteNumber(kNavicIndexBegin + 5), "I06");
+  EXPECT_EQ(ConvertIndexToSatelliteNumber(5000), "err");
+}


### PR DESCRIPTION
## Related issues
#276 

## Description
The library of GNSS satellite number was added.  
The original function in `gnss_satellite` will be replaced by this library.

## Test results
See Google test results.

## Impact
The new functions are not used at this moment.

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
