### PR TITLE
Add warning message for TLE epoch

### DIFF
--- a/data/sample/initialize_files/sample_simulation_base.ini
+++ b/data/sample/initialize_files/sample_simulation_base.ini
@@ -1,6 +1,6 @@
 [TIME]
 // Simulation start time [UTC]
-simulation_start_time_utc = 2020/01/01 12:00:00.0
+simulation_start_time_utc = 2020/04/01 12:00:00.0
 
 // Simulation duration [sec]
 simulation_duration_s = 200

--- a/src/dynamics/orbit/sgp4_orbit_propagation.cpp
+++ b/src/dynamics/orbit/sgp4_orbit_propagation.cpp
@@ -27,6 +27,16 @@ Sgp4OrbitPropagation::Sgp4OrbitPropagation(const CelestialInformation* celestial
 
   twoline2rv(tle1, tle2, type_run, type_input, gravity_constant_setting_, start_mfe, stop_mfe, delta_min, sgp4_data_);
 
+  // Epoch check
+  double epoch_difference_jday = (current_time_jd - sgp4_data_.jdsatepoch);
+  if (epoch_difference_jday < 0.0){
+    std::cout << "[WARNING: SGP4] The TLE epoch is newer than the simulation start time." << std::endl;
+  } else if(epoch_difference_jday > 150.0){
+    std::cout << "[WARNING: SGP4] The TLE epoch is 150 days older than the simulation start time." << std::endl;
+    std::cout << "                The orbit calculation result may have significant errors." << std::endl;
+  }
+
+
   spacecraft_acceleration_i_m_s2_ *= 0.0;
 
   // To calculate initial position and velocity

--- a/src/dynamics/orbit/sgp4_orbit_propagation.cpp
+++ b/src/dynamics/orbit/sgp4_orbit_propagation.cpp
@@ -29,13 +29,12 @@ Sgp4OrbitPropagation::Sgp4OrbitPropagation(const CelestialInformation* celestial
 
   // Epoch check
   double epoch_difference_jday = (current_time_jd - sgp4_data_.jdsatepoch);
-  if (epoch_difference_jday < 0.0){
+  if (epoch_difference_jday < 0.0) {
     std::cout << "[WARNING: SGP4] The TLE epoch is newer than the simulation start time." << std::endl;
-  } else if(epoch_difference_jday > 150.0){
+  } else if (epoch_difference_jday > 150.0) {
     std::cout << "[WARNING: SGP4] The TLE epoch is 150 days older than the simulation start time." << std::endl;
     std::cout << "                The orbit calculation result may have significant errors." << std::endl;
   }
-
 
   spacecraft_acceleration_i_m_s2_ *= 0.0;
 


### PR DESCRIPTION
## Related issues
#538 

## Description
I added the warning message for TLE epoch.

## Test results
- TLE epoch: 20076.51604214, Start time: 2021/04/01 12:00:00.0
<img width="572" alt="image" src="https://github.com/ut-issl/s2e-core/assets/19573779/95434f74-ff27-4f4f-b0b0-33c005a78763">

- TLE epoch: 20076.51604214, Start time: 2020/01/01 12:00:00.0
<img width="572" alt="image" src="https://github.com/ut-issl/s2e-core/assets/19573779/42db338c-423e-4b94-9a63-f51b3bbe6215">

- TLE epoch: 20076.51604214, Start time: 2020/04/01 12:00:00.0
<img width="572" alt="image" src="https://github.com/ut-issl/s2e-core/assets/19573779/5ae01a8a-7dec-4dec-9aa3-94c2e678078d">

## Impact
No effect on the simulation.

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
