### PR TITLE
Add low altitude warning messages

### DIFF
--- a/src/dynamics/orbit/orbit.cpp
+++ b/src/dynamics/orbit/orbit.cpp
@@ -40,7 +40,15 @@ void Orbit::TransformEciToEcef(void) {
   spacecraft_velocity_ecef_m_s_ = dcm_i_to_xcxf * velocity_we_cross_r;
 }
 
-void Orbit::TransformEcefToGeodetic(void) { spacecraft_geodetic_position_.UpdateFromEcef(spacecraft_position_ecef_m_); }
+void Orbit::TransformEcefToGeodetic(void) {
+  spacecraft_geodetic_position_.UpdateFromEcef(spacecraft_position_ecef_m_);
+  // Check altitude
+  if (spacecraft_geodetic_position_.GetAltitude_m() < 0.0) {
+    std::cout << "[Error Orbit]: The spacecraft altitude is smaller than zero." << std::endl;
+    std::cout << "               The orbit or disturbance setting may have something wrong." << std::endl;
+    std::exit(1);
+  }
+}
 
 OrbitInitializeMode SetOrbitInitializeMode(const std::string initialize_mode) {
   if (initialize_mode == "DEFAULT") {

--- a/src/environment/local/solar_radiation_pressure_environment.cpp
+++ b/src/environment/local/solar_radiation_pressure_environment.cpp
@@ -93,7 +93,11 @@ void SolarRadiationPressureEnvironment::CalcShadowCoefficient(std::string shadow
     double A = a * a * acos(x / a) + b * b * acos((c - x) / b) - c * y;  // The area of the occulted segment of the apparent solar disk
     shadow_coefficient_ *= 1.0 - A / (libra::pi * a * a);
   } else {  // no occultation takes place
-    assert(c > (a + b));
+    if (c < (a + b)) {
+      std::cout << "[Error SRP Environment]: The calculation error was occurred at the shadow calculation." << std::endl;
+      std::cout << "                         The orbit setting may have something wrong." << std::endl;
+      std::exit(1);
+    }
     shadow_coefficient_ *= 1.0;
   }
 }


### PR DESCRIPTION
## Related issues
#534 

## Description
I added and modified the low altitude warning messages.

## Test results
- Normal case
![image](https://github.com/ut-issl/s2e-core/assets/19573779/222957f1-3942-486c-bfce-bf3ac15bfadb)

- The case of initial orbit altitude is lower than the earth's radius.
![image](https://github.com/ut-issl/s2e-core/assets/19573779/324bd7da-410b-4cc8-802a-f4702aa84084)

## Impact
NA

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
