### PR TITLE
Replace index/satellite-number conversion functions in gnss satellites

### DIFF
--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -117,7 +117,7 @@ void GnssReceiver::CheckAntennaCone(const libra::Vector<3> pos_true_eci_, libra:
 
   for (int i = 0; i < gnss_num; i++) {
     // check if gnss ID is compatible with the receiver
-    std::string id_tmp = ConvertIndexToSatelliteNumber(i);
+    std::string id_tmp = ConvertIndexToGnssSatelliteNumber(i);
     if (gnss_id_.find(id_tmp[0]) == std::string::npos) continue;
 
     // compute direction from sat to gnss in body-fixed frame

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -6,6 +6,7 @@
 #include "gnss_receiver.hpp"
 
 #include <environment/global/physical_constants.hpp>
+#include <library/gnss/gnss_satellite_number.hpp>
 #include <library/initialize/initialize_file_access.hpp>
 #include <library/randomization/global_randomization.hpp>
 #include <string>
@@ -112,11 +113,11 @@ void GnssReceiver::CheckAntennaCone(const libra::Vector<3> pos_true_eci_, libra:
   // initialize
   visible_satellite_number_ = 0;
 
-  int gnss_num = gnss_satellites_->GetNumberOfSatellites();
+  int gnss_num = kTotalNumberOfGnssSatellite;
 
   for (int i = 0; i < gnss_num; i++) {
     // check if gnss ID is compatible with the receiver
-    std::string id_tmp = gnss_satellites_->GetIdFromIndex(i);
+    std::string id_tmp = ConvertIndexToSatelliteNumber(i);
     if (gnss_id_.find(id_tmp[0]) == std::string::npos) continue;
 
     // compute direction from sat to gnss in body-fixed frame

--- a/src/environment/global/gnss_satellites.cpp
+++ b/src/environment/global/gnss_satellites.cpp
@@ -242,7 +242,7 @@ pair<double, double> GnssSatellitePosition::Initialize(vector<vector<string>>& f
           iss >> tmp;
           s.push_back(tmp);
         }
-        int gnss_satellite_id = ConvertSatelliteNumberToIndex(s.front());
+        int gnss_satellite_id = ConvertGnssSatelliteNumberToIndex(s.front());
 
         bool available_flag = true;
         libra::Vector<3> ecef_position_m(0.0);
@@ -509,7 +509,7 @@ void GnssSatelliteClock::Initialize(vector<vector<string>>& file, string file_ex
             iss >> tmp;
             s.push_back(tmp);
           }
-          int gnss_satellite_id = ConvertSatelliteNumberToIndex(s.front());
+          int gnss_satellite_id = ConvertGnssSatelliteNumberToIndex(s.front());
 
           double clock = stod(s.at(4));
           if (std::abs(clock - nan99) < 1.0) continue;
@@ -569,7 +569,7 @@ void GnssSatelliteClock::Initialize(vector<vector<string>>& file, string file_ex
 
         std::free(time_tm);
 
-        int gnss_satellite_id = ConvertSatelliteNumberToIndex(s.at(1));
+        int gnss_satellite_id = ConvertGnssSatelliteNumberToIndex(s.at(1));
         double clock_bias = stod(s.at(9)) * environment::speed_of_light_m_s;  // [s] -> [m]
         if (start_unix_time - unix_time > 1e-4) continue;                     // for the numerical error
         if (end_unix_time - unix_time < 1e-4) break;

--- a/src/environment/global/gnss_satellites.cpp
+++ b/src/environment/global/gnss_satellites.cpp
@@ -142,7 +142,7 @@ double GnssSatelliteBase::LagrangeInterpolation(const vector<double>& time_vecto
   return res;
 }
 
-bool GnssSatelliteBase::GetWhetherValid(int gnss_satellite_id) const {
+bool GnssSatelliteBase::GetWhetherValid(const size_t gnss_satellite_id) const {
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite) return false;
   return validate_.at(gnss_satellite_id);
 }
@@ -298,7 +298,7 @@ void GnssSatellitePosition::SetUp(const double start_unix_time, const double ste
   ecef_.resize(kTotalNumberOfGnssSatellite);
   eci_.resize(kTotalNumberOfGnssSatellite);
 
-  for (int gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
+  for (size_t gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
     if (unix_time_list.at(gnss_satellite_id).empty()) {
       validate_.at(gnss_satellite_id) = false;
       continue;
@@ -359,7 +359,7 @@ void GnssSatellitePosition::SetUp(const double start_unix_time, const double ste
 }
 
 void GnssSatellitePosition::Update(const double current_unix_time) {
-  for (int gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
+  for (size_t gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
     if (unix_time_list.at(gnss_satellite_id).empty()) {
       validate_.at(gnss_satellite_id) = false;
       continue;
@@ -425,12 +425,12 @@ void GnssSatellitePosition::Update(const double current_unix_time) {
   }
 }
 
-libra::Vector<3> GnssSatellitePosition::GetPosition_ecef_m(int gnss_satellite_id) const {
+libra::Vector<3> GnssSatellitePosition::GetPosition_ecef_m(const size_t gnss_satellite_id) const {
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite) return libra::Vector<3>(0.0);
   return position_ecef_m_.at(gnss_satellite_id);
 }
 
-libra::Vector<3> GnssSatellitePosition::GetPosition_eci_m(int gnss_satellite_id) const {
+libra::Vector<3> GnssSatellitePosition::GetPosition_eci_m(const size_t gnss_satellite_id) const {
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite) return libra::Vector<3>(0.0);
   return position_eci_m_.at(gnss_satellite_id);
 }
@@ -599,7 +599,7 @@ void GnssSatelliteClock::SetUp(const double start_unix_time, const double step_w
 
   clock_bias_.resize(kTotalNumberOfGnssSatellite);
 
-  for (int gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
+  for (size_t gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
     if (unix_time_list.at(gnss_satellite_id).empty()) {
       validate_.at(gnss_satellite_id) = false;
       continue;
@@ -656,7 +656,7 @@ void GnssSatelliteClock::SetUp(const double start_unix_time, const double step_w
 }
 
 void GnssSatelliteClock::Update(const double current_unix_time) {
-  for (int gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
+  for (size_t gnss_satellite_id = 0; gnss_satellite_id < kTotalNumberOfGnssSatellite; ++gnss_satellite_id) {
     if (unix_time_list.at(gnss_satellite_id).empty()) {
       validate_.at(gnss_satellite_id) = false;
       continue;
@@ -718,7 +718,7 @@ void GnssSatelliteClock::Update(const double current_unix_time) {
   }
 }
 
-double GnssSatelliteClock::GetSatClock(int gnss_satellite_id) const {
+double GnssSatelliteClock::GetSatClock(const size_t gnss_satellite_id) const {
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite) return 0.0;
   return clock_offset_m_.at(gnss_satellite_id);
 }
@@ -742,20 +742,20 @@ void GnssSatelliteInformation::Update(const double current_unix_time) {
   clock_.Update(current_unix_time);
 }
 
-bool GnssSatelliteInformation::GetWhetherValid(int gnss_satellite_id) const {
+bool GnssSatelliteInformation::GetWhetherValid(const size_t gnss_satellite_id) const {
   if (position_.GetWhetherValid(gnss_satellite_id) && clock_.GetWhetherValid(gnss_satellite_id)) return true;
   return false;
 }
 
-libra::Vector<3> GnssSatelliteInformation::GetSatellitePositionEcef(int gnss_satellite_id) const {
+libra::Vector<3> GnssSatelliteInformation::GetSatellitePositionEcef(const size_t gnss_satellite_id) const {
   return position_.GetPosition_ecef_m(gnss_satellite_id);
 }
 
-libra::Vector<3> GnssSatelliteInformation::GetSatellitePositionEci(int gnss_satellite_id) const {
+libra::Vector<3> GnssSatelliteInformation::GetSatellitePositionEci(const size_t gnss_satellite_id) const {
   return position_.GetPosition_eci_m(gnss_satellite_id);
 }
 
-double GnssSatelliteInformation::GetSatelliteClock(int gnss_satellite_id) const { return clock_.GetSatClock(gnss_satellite_id); }
+double GnssSatelliteInformation::GetSatelliteClock(const size_t gnss_satellite_id) const { return clock_.GetSatClock(gnss_satellite_id); }
 
 // GnssSatellites
 GnssSatellites::GnssSatellites(bool is_calc_enabled) {
@@ -808,7 +808,7 @@ void GnssSatellites::Update(const SimulationTime* simulation_time) {
   return;
 }
 
-bool GnssSatellites::GetWhetherValid(int gnss_satellite_id) const {
+bool GnssSatellites::GetWhetherValid(const size_t gnss_satellite_id) const {
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite) return false;
 
   if (gnss_info_.GetWhetherValid(gnss_satellite_id) && gnss_info_.GetWhetherValid(gnss_satellite_id))
@@ -817,7 +817,7 @@ bool GnssSatellites::GetWhetherValid(int gnss_satellite_id) const {
     return false;
 }
 
-libra::Vector<3> GnssSatellites::GetSatellitePositionEcef(const int gnss_satellite_id) const {
+libra::Vector<3> GnssSatellites::GetSatellitePositionEcef(const size_t gnss_satellite_id) const {
   // gnss_satellite_id is wrong or not valid
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) {
     libra::Vector<3> res(0);
@@ -827,7 +827,7 @@ libra::Vector<3> GnssSatellites::GetSatellitePositionEcef(const int gnss_satelli
   return gnss_info_.GetSatellitePositionEcef(gnss_satellite_id);
 }
 
-libra::Vector<3> GnssSatellites::GetSatellitePositionEci(const int gnss_satellite_id) const {
+libra::Vector<3> GnssSatellites::GetSatellitePositionEci(const size_t gnss_satellite_id) const {
   // gnss_satellite_id is wrong or not valid
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) {
     libra::Vector<3> res(0);
@@ -837,7 +837,7 @@ libra::Vector<3> GnssSatellites::GetSatellitePositionEci(const int gnss_satellit
   return gnss_info_.GetSatellitePositionEci(gnss_satellite_id);
 }
 
-double GnssSatellites::GetSatelliteClock(const int gnss_satellite_id) const {
+double GnssSatellites::GetSatelliteClock(const size_t gnss_satellite_id) const {
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) {
     return 0.0;
   }
@@ -845,7 +845,7 @@ double GnssSatellites::GetSatelliteClock(const int gnss_satellite_id) const {
   return gnss_info_.GetSatelliteClock(gnss_satellite_id);
 }
 
-double GnssSatellites::GetPseudoRangeECEF(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
+double GnssSatellites::GetPseudoRangeECEF(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
                                           const double frequency) const {
   // gnss_satellite_id is wrong or not validate
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) return 0.0;
@@ -868,7 +868,8 @@ double GnssSatellites::GetPseudoRangeECEF(const int gnss_satellite_id, libra::Ve
   return res;
 }
 
-double GnssSatellites::GetPseudoRangeECI(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock, const double frequency) const {
+double GnssSatellites::GetPseudoRangeECI(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
+                                         const double frequency) const {
   // gnss_satellite_id is wrong or not validate
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) return 0.0;
 
@@ -890,7 +891,7 @@ double GnssSatellites::GetPseudoRangeECI(const int gnss_satellite_id, libra::Vec
   return res;
 }
 
-pair<double, double> GnssSatellites::GetCarrierPhaseECEF(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
+pair<double, double> GnssSatellites::GetCarrierPhaseECEF(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
                                                          const double frequency) const {
   // gnss_satellite_id is wrong or not validate
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) return {0.0, 0.0};
@@ -920,7 +921,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseECEF(const int gnss_satellit
   return {cycle, bias};
 }
 
-pair<double, double> GnssSatellites::GetCarrierPhaseECI(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
+pair<double, double> GnssSatellites::GetCarrierPhaseECI(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
                                                         const double frequency) const {
   // gnss_satellite_id is wrong or not validate
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) return {0.0, 0.0};
@@ -951,7 +952,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseECI(const int gnss_satellite
 }
 
 // for Ionospheric delay I[m]
-double GnssSatellites::AddIonosphericDelay(const int gnss_satellite_id, const libra::Vector<3> rec_position, const double frequency,
+double GnssSatellites::AddIonosphericDelay(const size_t gnss_satellite_id, const libra::Vector<3> rec_position, const double frequency,
                                            const GnssFrameDefinition flag) const {
   // gnss_satellite_id is wrong or not validate
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) return 0.0;

--- a/src/environment/global/gnss_satellites.hpp
+++ b/src/environment/global/gnss_satellites.hpp
@@ -53,23 +53,6 @@ enum UltraRapidMode {
 class GnssSatelliteBase {
  public:
   /**
-   * @fn GetIndexFromId
-   * @brief Calculate index of GNSS satellite defined in this class from GNSS satellite number defined in GNSS system
-   * @return Index of GNSS satellite defined in this class
-   */
-  int GetIndexFromId(std::string sat_num) const;
-  /**
-   * @fn GetIdFromIndex
-   * @brief Calculate GNSS satellite number defined in GNSS system from index of GNSS satellite defined in this class
-   * @return GNSS satellite number defined in GNSS system
-   */
-  std::string GetIdFromIndex(int index) const;
-  /**
-   * @fn GetNumberOfSatellites
-   * @brief Return total satellite number in all GNSS system (Constant value)
-   */
-  int GetNumberOfSatellites() const;
-  /**
    * @fn GetWhetherValid
    * @brief Return true the GNSS satellite information is available
    * @param [in] gnss_satellite_id: Index of GNSS satellite
@@ -265,12 +248,6 @@ class GnssSatelliteInformation {
   void Update(const double current_unix_time);
 
   /**
-   * @fn GetNumberOfSatellites
-   * @brief Get total number of GNSS satellite (constant value)
-   * @note TODO: Consider this function is really needed.
-   */
-  int GetNumberOfSatellites() const;
-  /**
    * @fn GetWhetherValid
    * @brief Return true the GNSS satellite information is available for both position and clock information
    * @param [in] gnss_satellite_id: Index of GNSS satellite
@@ -355,26 +332,6 @@ class GnssSatellites : public ILoggable {
    */
   void Update(const SimulationTime* simulation_time);
 
-  /**
-   * @fn GetIndexFromId
-   * @brief Calculate index of GNSS satellite defined in this class from GNSS satellite number defined in GNSS system
-   * @note TODO: Is this function really needed? This is just called other accessible function.
-   * @return Index of GNSS satellite defined in this class
-   */
-  int GetIndexFromId(std::string sat_num) const;
-  /**
-   * @fn GetIdFromIndex
-   * @brief Calculate GNSS satellite number defined in GNSS system from index of GNSS satellite defined in this class
-   * @note TODO: Is this function really needed? This is just called other accessible function.
-   * @return GNSS satellite number defined in GNSS system
-   */
-  std::string GetIdFromIndex(int index) const;
-  /**
-   * @fn GetNumberOfSatellites
-   * @brief Return total number of GNSS satellite
-   * @note TODO: Is this function really needed? This is just called other accessible function.
-   */
-  int GetNumberOfSatellites() const;
   /**
    * @fn GetWhetherValid
    * @brief Return true the GNSS satellite information is available for both position and clock

--- a/src/environment/global/gnss_satellites.hpp
+++ b/src/environment/global/gnss_satellites.hpp
@@ -57,7 +57,7 @@ class GnssSatelliteBase {
    * @brief Return true the GNSS satellite information is available
    * @param [in] gnss_satellite_id: Index of GNSS satellite
    */
-  bool GetWhetherValid(int gnss_satellite_id) const;
+  bool GetWhetherValid(const size_t gnss_satellite_id) const;
 
  protected:
   /**
@@ -138,13 +138,13 @@ class GnssSatellitePosition : public GnssSatelliteBase {
    * @brief Return GNSS satellite position vector in the ECEF frame [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID defined in this class
    */
-  libra::Vector<3> GetPosition_ecef_m(int gnss_satellite_id) const;
+  libra::Vector<3> GetPosition_ecef_m(const size_t gnss_satellite_id) const;
   /**
    * @fn GetPosition_eci_m
    * @brief Return GNSS satellite position vector in the ECI frame [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID defined in this class
    */
-  libra::Vector<3> GetPosition_eci_m(int gnss_satellite_id) const;
+  libra::Vector<3> GetPosition_eci_m(const size_t gnss_satellite_id) const;
 
  private:
   std::vector<libra::Vector<3>> position_ecef_m_;  //!< List of GNSS satellite position at specific time in the ECEF frame [m]
@@ -197,7 +197,7 @@ class GnssSatelliteClock : public GnssSatelliteBase {
    * @brief Return GNSS satellite clock in distance expression [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID defined in this class
    */
-  double GetSatClock(int gnss_satellite_id) const;
+  double GetSatClock(const size_t gnss_satellite_id) const;
 
  private:
   std::vector<double> clock_offset_m_;  //!< List of clock bias of all GNSS satellites at specific time expressed in distance [m]
@@ -252,25 +252,25 @@ class GnssSatelliteInformation {
    * @brief Return true the GNSS satellite information is available for both position and clock information
    * @param [in] gnss_satellite_id: Index of GNSS satellite
    */
-  bool GetWhetherValid(int gnss_satellite_id) const;
+  bool GetWhetherValid(const size_t gnss_satellite_id) const;
   /**
    * @fn GetSatellitePositionEcef
    * @brief Return GNSS satellite position vector in the ECEF frame [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID defined in this class
    */
-  libra::Vector<3> GetSatellitePositionEcef(int gnss_satellite_id) const;
+  libra::Vector<3> GetSatellitePositionEcef(const size_t gnss_satellite_id) const;
   /**
    * @fn GetSatellitePositionEci
    * @brief Return GNSS satellite position vector in the ECEF frame [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID defined in this class
    */
-  libra::Vector<3> GetSatellitePositionEci(int gnss_satellite_id) const;
+  libra::Vector<3> GetSatellitePositionEci(const size_t gnss_satellite_id) const;
   /**
    * @fn GetSatelliteClock
    * @brief Return GNSS satellite clock in distance expression [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID defined in this class
    */
-  double GetSatelliteClock(int gnss_satellite_id) const;
+  double GetSatelliteClock(const size_t gnss_satellite_id) const;
   /**
    * @fn GetGnssSatPos
    * @brief Return GNSS satellite position information class
@@ -337,7 +337,7 @@ class GnssSatellites : public ILoggable {
    * @brief Return true the GNSS satellite information is available for both position and clock
    * @param [in] gnss_satellite_id: Index of GNSS satellite
    */
-  bool GetWhetherValid(int gnss_satellite_id) const;
+  bool GetWhetherValid(const size_t gnss_satellite_id) const;
   /**
    * @fn GetStartUnixTime
    * @brief Return start unix time
@@ -354,19 +354,19 @@ class GnssSatellites : public ILoggable {
    * @brief Return GNSS satellite position in the ECEF frame [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID
    */
-  libra::Vector<3> GetSatellitePositionEcef(const int gnss_satellite_id) const;
+  libra::Vector<3> GetSatellitePositionEcef(const size_t gnss_satellite_id) const;
   /**
    * @fn GetSatellitePositionEci
    * @brief Return GNSS satellite position in the ECI frame [m]
    * @param [in] gnss_satellite_id: GNSS satellite ID
    */
-  libra::Vector<3> GetSatellitePositionEci(const int gnss_satellite_id) const;
+  libra::Vector<3> GetSatellitePositionEci(const size_t gnss_satellite_id) const;
   /**
    * @fn GetSatelliteClock
    * @brief Return GNSS satellite clock
    * @param [in] gnss_satellite_id: GNSS satellite ID
    */
-  double GetSatelliteClock(const int gnss_satellite_id) const;
+  double GetSatelliteClock(const size_t gnss_satellite_id) const;
 
   /**
    * @fn GetPseudoRangeECEF
@@ -377,7 +377,7 @@ class GnssSatellites : public ILoggable {
    * @param [in] frequency: Frequency of the signal [MHz]
    * @return Pseudo range [m]
    */
-  double GetPseudoRangeECEF(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock, const double frequency) const;
+  double GetPseudoRangeECEF(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock, const double frequency) const;
   /**
    * @fn GetPseudoRangeECI
    * @brief Calculate pseudo range between receiver and a GNSS satellite
@@ -387,7 +387,7 @@ class GnssSatellites : public ILoggable {
    * @param [in] frequency: Frequency of the signal [MHz]
    * @return Pseudo range [m]
    */
-  double GetPseudoRangeECI(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock, const double frequency) const;
+  double GetPseudoRangeECI(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock, const double frequency) const;
   /**
    * @fn GetCarrierPhaseECEF
    * @brief Calculate carrier phase observed by a receiver for a GNSS satellite
@@ -397,7 +397,7 @@ class GnssSatellites : public ILoggable {
    * @param [in] frequency: Frequency of the signal [MHz]
    * @return Carrier phase cycle and bias [-]
    */
-  std::pair<double, double> GetCarrierPhaseECEF(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
+  std::pair<double, double> GetCarrierPhaseECEF(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
                                                 const double frequency) const;
   /**
    * @fn GetCarrierPhaseECI
@@ -408,7 +408,7 @@ class GnssSatellites : public ILoggable {
    * @param [in] frequency: Frequency of the signal [MHz]
    * @return Carrier phase cycle and bias [-]
    */
-  std::pair<double, double> GetCarrierPhaseECI(const int gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
+  std::pair<double, double> GetCarrierPhaseECI(const size_t gnss_satellite_id, libra::Vector<3> rec_position, double rec_clock,
                                                const double frequency) const;
 
   // Override ILoggable
@@ -440,7 +440,7 @@ class GnssSatellites : public ILoggable {
    * @param [in] flag: The frame definition of the receiver position (ECI or ECEF)
    * @return Ionospheric delay [m]
    */
-  double AddIonosphericDelay(const int gnss_satellite_id, const libra::Vector<3> rec_position, const double frequency,
+  double AddIonosphericDelay(const size_t gnss_satellite_id, const libra::Vector<3> rec_position, const double frequency,
                              const GnssFrameDefinition flag) const;
 
   bool is_calc_enabled_ = true;         //!< Flag to manage the GNSS satellite position calculation

--- a/src/library/gnss/antex_file_reader.cpp
+++ b/src/library/gnss/antex_file_reader.cpp
@@ -95,7 +95,7 @@ void AntexFileReader::ReadAntexData(std::ifstream& antex_file) {
     if (line.find("TYPE / SERIAL NO") == ANTEX_LINE_TYPE_POSITION) {
       std::string antenna_type = line.substr(0, 20);
       std::string serial_number = line.substr(20, 20);
-      size_t satellite_index = ConvertSatelliteNumberToIndex(serial_number);
+      size_t satellite_index = ConvertGnssSatelliteNumberToIndex(serial_number);
 
       if (satellite_index == UINT32_MAX) {
         // receiver

--- a/src/library/gnss/gnss_satellite_number.cpp
+++ b/src/library/gnss/gnss_satellite_number.cpp
@@ -5,7 +5,7 @@
 
 #include "gnss_satellite_number.hpp"
 
-size_t ConvertSatelliteNumberToIndex(const std::string satellite_number) {
+size_t ConvertGnssSatelliteNumberToIndex(const std::string satellite_number) {
   switch (satellite_number.front()) {
     case 'G':
       return stoi(satellite_number.substr(1)) + kGpsIndexBegin - 1;
@@ -25,7 +25,7 @@ size_t ConvertSatelliteNumberToIndex(const std::string satellite_number) {
   }
 }
 
-std::string ConvertIndexToSatelliteNumber(const size_t index) {
+std::string ConvertIndexToGnssSatelliteNumber(const size_t index) {
   std::string output;
   size_t prn_number = 0;
 

--- a/src/library/gnss/gnss_satellite_number.hpp
+++ b/src/library/gnss/gnss_satellite_number.hpp
@@ -31,17 +31,17 @@ const size_t kQzssIndexBegin = kBeidouIndexBegin + kNumberOfBeidouSatellite;    
 const size_t kNavicIndexBegin = kQzssIndexBegin + kNumberOfQzssSatellite;          //!< Begin value of index for NavIC satellites
 
 /**
- * @fn ConvertSatelliteNumberToIndex
+ * @fn ConvertGnssSatelliteNumberToIndex
  * @brief Calculate index of GNSS satellite defined in S2E from GNSS satellite number defined in RINEX v4
  * @return Index of GNSS satellite defined in this class. or INT32_MAX when the input is wrong.
  */
-size_t ConvertSatelliteNumberToIndex(const std::string satellite_number);
+size_t ConvertGnssSatelliteNumberToIndex(const std::string satellite_number);
 
 /**
- * @fn ConvertIndexToSatelliteNumber
+ * @fn ConvertIndexToGnssSatelliteNumber
  * @brief Calculate GNSS satellite number defined in RINEX v4 from index of GNSS satellite defined in this class
  * @return GNSS satellite number defined in RINEX v4. or err when the input is wrong.
  */
-std::string ConvertIndexToSatelliteNumber(const size_t index);
+std::string ConvertIndexToGnssSatelliteNumber(const size_t index);
 
 #endif  // S2E_LIBRARY_GNSS_GNSS_SATELLITE_NUMBER_HPP_

--- a/src/library/gnss/test_gnss_satellite_number.cpp
+++ b/src/library/gnss/test_gnss_satellite_number.cpp
@@ -10,24 +10,24 @@
  * @brief Test satellite number to index
  */
 TEST(GnssSatelliteNumber, SatelliteNumberToIndex) {
-  EXPECT_EQ(ConvertSatelliteNumberToIndex("G01"), 0);
-  EXPECT_EQ(ConvertSatelliteNumberToIndex("R02"), kGlonassIndexBegin + 1);
-  EXPECT_EQ(ConvertSatelliteNumberToIndex("E10"), kGalileoIndexBegin + 9);
-  EXPECT_EQ(ConvertSatelliteNumberToIndex("C40"), kBeidouIndexBegin + 39);
-  EXPECT_EQ(ConvertSatelliteNumberToIndex("J03"), kQzssIndexBegin + 2);
-  EXPECT_EQ(ConvertSatelliteNumberToIndex("I04"), kNavicIndexBegin + 3);
-  EXPECT_EQ(ConvertSatelliteNumberToIndex("err"), UINT32_MAX);
+  EXPECT_EQ(ConvertGnssSatelliteNumberToIndex("G01"), 0);
+  EXPECT_EQ(ConvertGnssSatelliteNumberToIndex("R02"), kGlonassIndexBegin + 1);
+  EXPECT_EQ(ConvertGnssSatelliteNumberToIndex("E10"), kGalileoIndexBegin + 9);
+  EXPECT_EQ(ConvertGnssSatelliteNumberToIndex("C40"), kBeidouIndexBegin + 39);
+  EXPECT_EQ(ConvertGnssSatelliteNumberToIndex("J03"), kQzssIndexBegin + 2);
+  EXPECT_EQ(ConvertGnssSatelliteNumberToIndex("I04"), kNavicIndexBegin + 3);
+  EXPECT_EQ(ConvertGnssSatelliteNumberToIndex("err"), UINT32_MAX);
 }
 
 /**
  * @brief Test index to satellite number
  */
 TEST(GnssSatelliteNumber, IndexToSatelliteNumber) {
-  EXPECT_EQ(ConvertIndexToSatelliteNumber(0), "G01");
-  EXPECT_EQ(ConvertIndexToSatelliteNumber(kGlonassIndexBegin + 9), "R10");
-  EXPECT_EQ(ConvertIndexToSatelliteNumber(kGalileoIndexBegin + 21), "E22");
-  EXPECT_EQ(ConvertIndexToSatelliteNumber(kBeidouIndexBegin + 50), "C51");
-  EXPECT_EQ(ConvertIndexToSatelliteNumber(kQzssIndexBegin + 0), "J01");
-  EXPECT_EQ(ConvertIndexToSatelliteNumber(kNavicIndexBegin + 5), "I06");
-  EXPECT_EQ(ConvertIndexToSatelliteNumber(5000), "err");
+  EXPECT_EQ(ConvertIndexToGnssSatelliteNumber(0), "G01");
+  EXPECT_EQ(ConvertIndexToGnssSatelliteNumber(kGlonassIndexBegin + 9), "R10");
+  EXPECT_EQ(ConvertIndexToGnssSatelliteNumber(kGalileoIndexBegin + 21), "E22");
+  EXPECT_EQ(ConvertIndexToGnssSatelliteNumber(kBeidouIndexBegin + 50), "C51");
+  EXPECT_EQ(ConvertIndexToGnssSatelliteNumber(kQzssIndexBegin + 0), "J01");
+  EXPECT_EQ(ConvertIndexToGnssSatelliteNumber(kNavicIndexBegin + 5), "I06");
+  EXPECT_EQ(ConvertIndexToGnssSatelliteNumber(5000), "err");
 }


### PR DESCRIPTION
## Related issues
#276 

## Description
The index/satellite-number conversion functions are replaced by the functions in library directory.

## Test results
See CI results.

## Impact
Only for GNSS user

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
