### PR TITLE
[Hotfix] Change default attitude initialize mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 7.2.0
+  VERSION 7.2.1
 )
 
 # build config

--- a/data/sample/initialize_files/sample_satellite.ini
+++ b/data/sample/initialize_files/sample_satellite.ini
@@ -7,7 +7,7 @@ propagate_mode = RK4
 // Initialize Attitude mode
 // MANUAL : Initialize Quaternion_i2b manually below 
 // CONTROLLED : Initialize attitude with given condition. Valid only when Attitude propagation mode is RK4.
-initialize_mode = CONTROLLED
+initialize_mode = MANUAL
 
 // Initial angular velocity at body frame [rad/s]
 initial_angular_velocity_b_rad_s(0) = 0.0


### PR DESCRIPTION
## Related issues
https://github.com/ut-issl/s2e-documents/issues/102

## Description
The s2e-documents is written as the default value of the `ATTITUDE:initialize_mode = MANUAL` so I fixed the default value.

## Test results
NA

## Impact
small

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
