### PR TITLE
[Hotfix] Remove invalid comment in ini file for celestial rotation

### DIFF
--- a/data/sample/initialize_files/sample_simulation_base.ini
+++ b/data/sample/initialize_files/sample_simulation_base.ini
@@ -101,9 +101,11 @@ selected_body_name(10) = PLUTO
 
 // Celestial rotation mode
 // Currently, s2e-core supports Earth and Moon only
-rotation_mode(0) = FULL     // EARTH IDLE:no motion, SIMPLE:Z-axis rotation only, FULL:full-dynamics
+// Setting for Earth:  IDLE:no motion, SIMPLE:Z-axis rotation only, FULL:full-dynamics
+// Setting for Moon:   IDLE:no motion, SIMPLE:Mean Earth and Principal Axis, IAU_MOON: IAU_MOON frame by SPICE
+rotation_mode(0) = FULL
 rotation_mode(1) = DISABLE
-rotation_mode(2) = SIMPLE   // MOON IDLE:no motion, SIMPLE:Mean Earth and Principal Axis, IAU_MOON: IAU_MOON frame by SPICE
+rotation_mode(2) = SIMPLE
 rotation_mode(3) = DISABLE
 rotation_mode(4) = DISABLE
 rotation_mode(5) = DISABLE


### PR DESCRIPTION
## Related issues
N/A

## Description
### Details on Bug

- Rotation mode for the Earth and Moon was not set correctly at `s2e-core v7.2.2` at VS2022 on Windows. 
- As you see in the following figure, `earth_rotation->rotation_mode_` is `kIdle (0)`, though we intend to set `kFull`.
- This problem occurs only at VS2022 on Windows.

![image (1)](https://github.com/ut-issl/s2e-core/assets/93800108/0c2db356-be96-4571-bf7e-fbccc20e7040)

### Cause of Bug

- `IniAccess::ReadVectorString` (in the same way as `IniAccess::ReadString`) cannot identify `//` style comment.
- We cannot use `//` style comment at EOL when `IniAccess::ReadString` and `IniAccess::ReadVectorString` are used as parser.

### Treatment in this PR

- I removed `//` style comment at EOL for the setting of celestial rotation.

## Test results

- earth_rotation->rotation_mode_` is set as `kFull (2)` correctly.

![image (2)](https://github.com/ut-issl/s2e-core/assets/93800108/6664653f-8076-4b04-9805-449ccbb58e6f)


## Impact
Large (Windows user only): We cannot conduct verification related to ECI <--> ECEF transformation.

## Supplementary information
N/A

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
