### PR TITLE
[Hotfix] Remove enhanced comment and preceding whitespace from str…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 7.2.2
+  VERSION 7.2.3
 )
 
 # build config

--- a/src/library/initialize/initialize_file_access.cpp
+++ b/src/library/initialize/initialize_file_access.cpp
@@ -161,6 +161,9 @@ std::string IniAccess::ReadString(const char* section_name, const char* key_name
   value = ini_reader_.GetString(section_name, key_name, "NULL");
 #endif
   // Special characters
+  // Inline comments
+  std::regex inline_comment_pattern("\\s*//.*");
+  value = std::regex_replace(value, inline_comment_pattern, "");
   // INI_FILE_DIR
   std::string ini_path = INI_FILE_DIR_FROM_EXE;
   value = std::regex_replace(value, std::regex("INI_FILE_DIR_FROM_EXE"), ini_path);


### PR DESCRIPTION
## Related issues
- #575 
- #576 

## Description

### Details on Bug & Cause of Bug
- Described in #575

### Treatment in thir PR

- Strings like `some blanc characters(including whitespaces or tabs) + "//" + any characters` are removed in `IniAccess::ReadString` .

## Test results

- `//` styles comments are successfully removed in #575 case

![image (3)](https://github.com/ut-issl/s2e-core/assets/93800108/4c614dac-e7e7-4788-ad30-25bb390f0011)

## Impact
- Large (Windows user only): We cannot conduct verification related to ECI <--> ECEF transformation.

## Supplementary information
- N/A

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
