### PR TITLE
Remove unnecessary enums in GNSS

### DIFF
--- a/src/environment/global/gnss_satellites.cpp
+++ b/src/environment/global/gnss_satellites.cpp
@@ -828,7 +828,7 @@ double GnssSatellites::GetPseudoRangeEcef(const size_t gnss_satellite_id, libra:
   res += receiver_clock_offset_m - gnss_info_.GetClockOffset_m(gnss_satellite_id);
 
   // ionospheric delay
-  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_ecef_m, frequency_MHz, GnssFrameDefinition::kEcef);
+  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_ecef_m, frequency_MHz);
 
   res += ionospheric_delay;
 
@@ -851,7 +851,7 @@ double GnssSatellites::GetPseudoRangeEci(const size_t gnss_satellite_id, libra::
   res += receiver_clock_offset_m - gnss_info_.GetClockOffset_m(gnss_satellite_id);
 
   // ionospheric delay
-  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_eci_m, frequency_MHz, GnssFrameDefinition::kEci);
+  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_eci_m, frequency_MHz);
 
   res += ionospheric_delay;
 
@@ -874,7 +874,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseEcef(const size_t gnss_satel
   res += receiver_clock_offset_m - gnss_info_.GetClockOffset_m(gnss_satellite_id);
 
   // ionospheric delay
-  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_ecef_m, frequency_MHz, GnssFrameDefinition::kEcef);
+  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_ecef_m, frequency_MHz);
 
   res -= ionospheric_delay;
 
@@ -904,7 +904,7 @@ pair<double, double> GnssSatellites::GetCarrierPhaseEci(const size_t gnss_satell
   res += receiver_clock_offset_m - gnss_info_.GetClockOffset_m(gnss_satellite_id);
 
   // ionospheric delay
-  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_eci_m, frequency_MHz, GnssFrameDefinition::kEci);
+  const double ionospheric_delay = AddIonosphericDelay(gnss_satellite_id, receiver_position_eci_m, frequency_MHz);
 
   res -= ionospheric_delay;
 
@@ -919,8 +919,8 @@ pair<double, double> GnssSatellites::GetCarrierPhaseEci(const size_t gnss_satell
 }
 
 // for Ionospheric delay I[m]
-double GnssSatellites::AddIonosphericDelay(const size_t gnss_satellite_id, const libra::Vector<3> receiver_position_m, const double frequency_MHz,
-                                           const GnssFrameDefinition flag) const {
+double GnssSatellites::AddIonosphericDelay(const size_t gnss_satellite_id, const libra::Vector<3> receiver_position_m,
+                                           const double frequency_MHz) const {
   // gnss_satellite_id is wrong or not validate
   if (gnss_satellite_id >= kTotalNumberOfGnssSatellite || !GetWhetherValid(gnss_satellite_id)) return 0.0;
 
@@ -933,10 +933,7 @@ double GnssSatellites::AddIonosphericDelay(const size_t gnss_satellite_id, const
   if (altitude >= 1000.0) return 0.0;                  // there is no Ionosphere above 1000km
 
   libra::Vector<3> gnss_position;
-  if (flag == GnssFrameDefinition::kEcef)
-    gnss_position = gnss_info_.GetPosition_ecef_m(gnss_satellite_id);
-  else if (flag == GnssFrameDefinition::kEci)
-    gnss_position = gnss_info_.GetPosition_eci_m(gnss_satellite_id);
+  gnss_position = gnss_info_.GetPosition_ecef_m(gnss_satellite_id);
 
   double angle_rad = CalcAngleTwoVectors_rad(receiver_position_m, gnss_position - receiver_position_m);
   const double default_delay = 20.0;  //[m] default delay

--- a/src/environment/global/gnss_satellites.hpp
+++ b/src/environment/global/gnss_satellites.hpp
@@ -19,11 +19,6 @@
 
 extern const double nan99;  //!< Not at Number TODO: Should be moved to another place
 
-enum class GnssFrameDefinition {
-  kEcef = 0,  //!< Use ECEF frame for GNSS satellite position frame in Add_IonosphericDelay
-  kEci = 1    //!< Use ECI frame for GNSS satellite position frame in Add_IonosphericDelay
-};
-
 /**
  * @class GnssSatelliteBase
  * @brief A class to summarize basic feature of GNSS position and clock calculation
@@ -410,11 +405,9 @@ class GnssSatellites : public ILoggable {
    * @param [in] gnss_satellite_id: GNSS satellite ID
    * @param [in] receiver_position_m: Receiver position [m]
    * @param [in] frequency_MHz: Frequency [MHz]
-   * @param [in] flag: The frame definition of the receiver position (ECI or ECEF)
    * @return Ionospheric delay [m]
    */
-  double AddIonosphericDelay(const size_t gnss_satellite_id, const libra::Vector<3> receiver_position_m, const double frequency_MHz,
-                             const GnssFrameDefinition flag) const;
+  double AddIonosphericDelay(const size_t gnss_satellite_id, const libra::Vector<3> receiver_position_m, const double frequency_MHz) const;
 
   bool is_calc_enabled_ = true;         //!< Flag to manage the GNSS satellite position calculation
   GnssSatelliteInformation gnss_info_;  //!< GNSS satellites information

--- a/src/environment/global/gnss_satellites.hpp
+++ b/src/environment/global/gnss_satellites.hpp
@@ -25,28 +25,6 @@ enum class GnssFrameDefinition {
 };
 
 /**
- * @enum UltraRapidMode
- * @brief Ultra Rapid mode
- * @details When Using Ultra Rapid ephemerides, decide to use which 6 hours in each observe and predict 24 hours
- * @note TODO: change to enum class
- */
-enum UltraRapidMode {
-  kNotUse,  //!< Don't use ultra rapid
-
-  kObserve1,  //!< the most oldest observe 6 hours (most precise)
-  kObserve2,  //!< the second oldest observe 6 hours (6 ~ 12)
-  kObserve3,
-  kObserve4,
-
-  kPredict1,  //!< the most oldest preserve 6 hours (most precise)
-  kPredict2,
-  kPredict3,
-  kPredict4,
-
-  kUnknown
-};
-
-/**
  * @class GnssSatelliteBase
  * @brief A class to summarize basic feature of GNSS position and clock calculation
  */
@@ -113,11 +91,9 @@ class GnssSatellitePosition : public GnssSatelliteBase {
    * @param[in] file: File path for position calculation
    * @param[in] interpolation_method: Interpolation method for position calculation
    * @param[in] interpolation_number: Interpolation number for position calculation
-   * @param[in] ur_flag: Ultra Rapid flag for position calculation
    * @return Start unix time and end unix time
    */
-  std::pair<double, double> Initialize(std::vector<std::vector<std::string>>& file, int interpolation_method, int interpolation_number,
-                                       UltraRapidMode ur_flag);
+  std::pair<double, double> Initialize(std::vector<std::vector<std::string>>& file, int interpolation_method, int interpolation_number);
 
   /**
    * @fn Setup
@@ -175,9 +151,8 @@ class GnssSatelliteClock : public GnssSatelliteBase {
    * @param[in] file: File path for clock calculation
    * @param[in] file_extension: Extension of the clock file (ex. .sp3, .clk30s)
    * @param[in] interpolation_number: Interpolation number for clock calculation
-   * @param[in] ur_flag: Ultra Rapid flag for clock calculation
    */
-  void Initialize(std::vector<std::vector<std::string>>& file, std::string file_extension, int interpolation_number, UltraRapidMode ur_flag,
+  void Initialize(std::vector<std::vector<std::string>>& file, std::string file_extension, int interpolation_number,
                   std::pair<double, double> unix_time_period);
   /**
    * @fn SetUp
@@ -224,15 +199,12 @@ class GnssSatelliteInformation {
    * @param[in] position_file: File path for position calculation
    * @param[in] position_interpolation_method: Interpolation method for position calculation
    * @param[in] position_interpolation_number: Interpolation number for position calculation
-   * @param[in] position_ur_flag: Ultra Rapid flag for position calculation
    * @param[in] clock_file: File path for clock calculation
    * @param[in] clock_file_extension: Extension of the clock file (ex. .sp3, .clk30s)
    * @param[in] clock_interpolation_number: Interpolation number for clock calculation
-   * @param[in] clock_ur_flag: Ultra Rapid flag for clock calculation
    */
   void Initialize(std::vector<std::vector<std::string>>& position_file, int position_interpolation_method, int position_interpolation_number,
-                  UltraRapidMode position_ur_flag, std::vector<std::vector<std::string>>& clock_file, std::string clock_file_extension,
-                  int clock_interpolation_number, UltraRapidMode clock_ur_flag);
+                  std::vector<std::vector<std::string>>& clock_file, std::string clock_file_extension, int clock_interpolation_number);
   /**
    * @fn SetUp
    * @brief Setup GNSS satellite position and clock information
@@ -311,8 +283,7 @@ class GnssSatellites : public ILoggable {
    * @note Parameters are defined in GNSSSat_Info
    */
   void Initialize(std::vector<std::vector<std::string>>& position_file, int position_interpolation_method, int position_interpolation_number,
-                  UltraRapidMode position_ur_flag, std::vector<std::vector<std::string>>& clock_file, std::string clock_file_extension,
-                  int clock_interpolation_number, UltraRapidMode clock_ur_flag);
+                  std::vector<std::vector<std::string>>& clock_file, std::string clock_file_extension, int clock_interpolation_number);
   /**
    * @fn IsCalcEnabled
    * @brief Return calculated enabled flag

--- a/src/environment/global/initialize_gnss_satellites.cpp
+++ b/src/environment/global/initialize_gnss_satellites.cpp
@@ -85,12 +85,10 @@ void ReadFileContents(std::string directory_path, std::string file_name, std::ve
  *@param [in] first: The first SP3 file name
  *@param [in] last: The last SP3 file name
  *@param [out] file_contents: Generated files as multiple vectors of one line strings
- *@param [out] ur_flag: Ultra rapid flag
  */
 void ReadSp3Files(std::string directory_path, std::string file_sort, std::string first, std::string last,
-                  std::vector<std::vector<std::string>>& file_contents, UltraRapidMode& ur_flag) {
+                  std::vector<std::vector<std::string>>& file_contents) {
   std::string all_directory_path = directory_path + ReturnDirectoryPathWithFileType(file_sort);
-  ur_flag = kNotUse;
 
   if (first.substr(0, 3) == "COD") {
     std::string file_header = "COD0MGXFIN_";
@@ -123,7 +121,6 @@ void ReadSp3Files(std::string directory_path, std::string file_sort, std::string
       ++day;
     }
   } else if (file_sort.substr(0, 3) == "IGU" || file_sort.find("Ultra") != std::string::npos) {  // In case of UR
-    ur_flag = kUnknown;
     std::string file_header, file_footer;
     int gps_week = 0, day = 0;
     int hour = 0;
@@ -299,19 +296,17 @@ GnssSatellites* InitGnssSatellites(std::string file_name) {
 
   // Position
   std::vector<std::vector<std::string>> position_file;
-  UltraRapidMode position_ur_flag = kNotUse;
   ReadSp3Files(directory_path, ini_file.ReadString(section, "position_file_sort"), ini_file.ReadString(section, "position_first"),
-               ini_file.ReadString(section, "position_last"), position_file, position_ur_flag);
+               ini_file.ReadString(section, "position_last"), position_file);
   int position_interpolation_method = ini_file.ReadInt(section, "position_interpolation_method");
   int position_interpolation_number = ini_file.ReadInt(section, "position_interpolation_number");
 
   // Clock
   std::vector<std::vector<std::string>> clock_file;
-  UltraRapidMode clock_ur_flag = kNotUse;
   std::string clock_file_extension = ini_file.ReadString(section, "clock_file_extension");
   if (clock_file_extension == ".sp3") {
     ReadSp3Files(directory_path, ini_file.ReadString(section, "clock_file_sort"), ini_file.ReadString(section, "clock_first"),
-                 ini_file.ReadString(section, "clock_last"), clock_file, clock_ur_flag);
+                 ini_file.ReadString(section, "clock_last"), clock_file);
   } else {
     ReadClockFiles(directory_path, clock_file_extension, ini_file.ReadString(section, "clock_file_sort"), ini_file.ReadString(section, "clock_first"),
                    ini_file.ReadString(section, "clock_last"), clock_file);
@@ -319,8 +314,8 @@ GnssSatellites* InitGnssSatellites(std::string file_name) {
   int clock_interpolation_number = ini_file.ReadInt(section, "clock_interpolation_number");
 
   // Initialize GNSS satellites
-  gnss_satellites->Initialize(position_file, position_interpolation_method, position_interpolation_number, position_ur_flag, clock_file,
-                              clock_file_extension, clock_interpolation_number, clock_ur_flag);
+  gnss_satellites->Initialize(position_file, position_interpolation_method, position_interpolation_number, clock_file, clock_file_extension,
+                              clock_interpolation_number);
 
   return gnss_satellites;
 }


### PR DESCRIPTION
## Related issues
#276 

## Description
I removed unnecessary enum definitions.
- UltraRapidMode
  - Rapid or Ultra rapid mode is used in the estimation phase, not in the true value calculation.
- GnssFrameDefinition
  - GNSS satellite position is commonly defined in ECEF. ECI conversion should be execute in other place by users.

## Test results
NA

## Impact
Only for GNSS.

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
