### PR TITLE
Moodify SP3 file reading for GNSS

### DIFF
--- a/src/environment/global/initialize_gnss_satellites.cpp
+++ b/src/environment/global/initialize_gnss_satellites.cpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <library/gnss/igs_product_name_handling.hpp>
+#include <library/gnss/sp3_file_reader.hpp>
 #include <library/initialize/initialize_file_access.hpp>
 #include <string>
 
@@ -312,12 +313,17 @@ GnssSatellites* InitGnssSatellites(std::string file_name) {
   if (start_date > end_date) {
     std::cout << "[ERROR] GNSS satellite initialize: start_date is larger than the end date." << std::endl;
   }
+
+  // Read all product files
+  std::vector<Sp3FileReader> sp3_file_readers;
+
   size_t read_file_date = start_date;
-  while (read_file_date > end_date) {
+  while (read_file_date <= end_date) {
     std::string sp3_file_name = GetOrbitClockFinalFileName(file_name_header, read_file_date, orbit_data_period);
     std::string sp3_full_file_path = directory_path + "/" + sp3_file_name;
 
     // Read SP3
+    sp3_file_readers.push_back(Sp3FileReader(sp3_full_file_path));
 
     // Read CLK
     if (!use_sp3_for_clock) {
@@ -326,6 +332,7 @@ GnssSatellites* InitGnssSatellites(std::string file_name) {
       std::string clk_full_file_path = directory_path + "/" + clk_file_name;
     }
 
+    // Increment
     read_file_date = IncrementYearDoy(read_file_date);
   }
 

--- a/src/library/gnss/igs_product_name_handling.hpp
+++ b/src/library/gnss/igs_product_name_handling.hpp
@@ -1,6 +1,8 @@
 /**
  * @file igs_product_name_handling.hpp
  * @brief Manage IGS product name handling
+ * @note IGS product: https://igs.org/products/#orbits_clocks
+ *       MGEX product: https://igs.org/mgex/data-products/#orbit_clock
  */
 
 #ifndef S2E_LIBRARY_GNSS_IGS_PRODUCT_NAME_HANDLING_HPP_

--- a/src/library/gnss/igs_product_name_handling.hpp
+++ b/src/library/gnss/igs_product_name_handling.hpp
@@ -1,0 +1,84 @@
+/**
+ * @file igs_product_name_handling.hpp
+ * @brief Manage IGS product name handling
+ */
+
+#ifndef S2E_LIBRARY_GNSS_IGS_PRODUCT_NAME_HANDLING_HPP_
+#define S2E_LIBRARY_GNSS_IGS_PRODUCT_NAME_HANDLING_HPP_
+
+#include <string>
+
+/**
+ * @fn GetOrbitClockFileName
+ * @brief Return IGS orbit and clock final product file name
+ * @param [in] header: Header information (ex. IGS0OPSFIN)
+ * @param [in] year_doy: Merged number of year(YYY) and day of year(DDD) (YYYYDDD)
+ * @param [in] period: Period of the data (ex. 15M = 15 mins.)
+ * @param [in] file_type: File type and extensions (ex. ORB.SP3)
+ * @return: file name
+ */
+std::string GetOrbitClockFinalFileName(const std::string header, const size_t year_doy, const std::string period = "15M",
+                                       const std::string file_type = "ORB.SP3") {
+  std::string file_name = header + "_" + std::to_string(year_doy) + "0000_01D_" + period + "_" + file_type;
+
+  return file_name;
+}
+
+/**
+ * @fn MergeYearDoy
+ * @brief Return Merged number of year(YYY) and day of year(DDD) (YYYYDDD)
+ * @param [in] year: 4-digit Year
+ * @param [in] doy: 3-digit Day of year
+ * @return: Merged number
+ */
+size_t MergeYearDoy(const size_t year, const size_t doy) { return year * 1000 + doy; }
+
+/**
+ * @fn PerseYearFromYearDoy
+ * @brief Return 4-digit year
+ * @param [in] year_doy: Merged number of year(YYY) and day of year(DDD) (YYYYDDD)
+ * @return: year
+ */
+size_t PerseYearFromYearDoy(const size_t year_doy) { return year_doy / 1000; }
+
+/**
+ * @fn PerseDoyFromYearDoy
+ * @brief Return 3-digit day of year
+ * @param [in] year_doy: Merged number of year(YYY) and day of year(DDD) (YYYYDDD)
+ * @return: day of year
+ */
+size_t PerseDoyFromYearDoy(const size_t year_doy) {
+  size_t year = PerseYearFromYearDoy(year_doy);
+  return year_doy - year * 1000;
+}
+
+/**
+ * @fn IncrementYearDoy
+ * @brief Calculate increment value of year_doy considering year update
+ * @param [in] year_doy: Merged number of year(YYY) and day of year(DDD) (YYYYDDD)
+ * @return: Incremented value
+ */
+size_t IncrementYearDoy(const size_t year_doy) {
+  size_t output = year_doy + 1;
+  size_t doy = PerseDoyFromYearDoy(output);
+
+  // Year update
+  if (doy > 365) {
+    size_t year = PerseYearFromYearDoy(output);
+    // Leap year
+    if (year % 4 == 0) {
+      if (doy > 366) {
+        year++;
+        doy = 1;
+      }
+    } else {
+      year++;
+      doy = 1;
+    }
+    output = MergeYearDoy(year, doy);
+  }
+
+  return output;
+}
+
+#endif  // S2E_LIBRARY_GNSS_IGS_PRODUCT_NAME_HANDLING_HPP_

--- a/src/library/gnss/test_igs_product_name_handling.cpp
+++ b/src/library/gnss/test_igs_product_name_handling.cpp
@@ -62,3 +62,24 @@ TEST(IgsProductName, PerseFromYearDoy) {
   EXPECT_EQ(2000, PerseYearFromYearDoy(year_doy));
   EXPECT_EQ(001, PerseDoyFromYearDoy(year_doy));
 }
+
+/**
+ * @brief Test IncrementYearDoy
+ */
+TEST(IgsProductName, IncrementYearDoy) {
+  size_t year_doy = 2024030;
+  year_doy = IncrementYearDoy(year_doy);
+  EXPECT_EQ(2024031, year_doy);
+
+  // Year update
+  year_doy = 2023365;
+  year_doy = IncrementYearDoy(year_doy);
+  EXPECT_EQ(2024001, year_doy);
+
+  // Leap year
+  year_doy = 2024365;
+  year_doy = IncrementYearDoy(year_doy);
+  EXPECT_EQ(2024366, year_doy);
+  year_doy = IncrementYearDoy(year_doy);
+  EXPECT_EQ(2025001, year_doy);
+}

--- a/src/library/gnss/test_igs_product_name_handling.cpp
+++ b/src/library/gnss/test_igs_product_name_handling.cpp
@@ -42,3 +42,23 @@ TEST(IgsProductName, MergeYearDoy) {
 
   EXPECT_EQ(2023190, year_doy);
 }
+
+/**
+ * @brief Test PerseFromYearDoy
+ */
+TEST(IgsProductName, PerseFromYearDoy) {
+  size_t year = 1989;
+  size_t doy = 84;
+  size_t year_doy = MergeYearDoy(year, doy);
+
+  EXPECT_EQ(year, PerseYearFromYearDoy(year_doy));
+  EXPECT_EQ(doy, PerseDoyFromYearDoy(year_doy));
+
+  year_doy = 1989365;
+  EXPECT_EQ(1989, PerseYearFromYearDoy(year_doy));
+  EXPECT_EQ(365, PerseDoyFromYearDoy(year_doy));
+
+  year_doy = 2000001;
+  EXPECT_EQ(2000, PerseYearFromYearDoy(year_doy));
+  EXPECT_EQ(001, PerseDoyFromYearDoy(year_doy));
+}

--- a/src/library/gnss/test_igs_product_name_handling.cpp
+++ b/src/library/gnss/test_igs_product_name_handling.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file test_igs_product_name_handling.cpp
+ * @brief Test functions for IGS product name handling with GoogleTest
+ */
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "igs_product_name_handling.hpp"
+
+/**
+ * @brief Test satellite number to index
+ */
+TEST(IgsProductName, SatelliteNumberToIndex) {
+  std::string header = "IGS0OPSFIN";
+  size_t year_doy = 2023190;
+
+  std::string file_name = GetOrbitClockFinalFileName(header, year_doy);
+  EXPECT_THAT(file_name, ::testing::MatchesRegex("IGS0OPSFIN_20231900000_01D_15M_ORB.SP3"));
+
+  std::string period = "15M";
+  std::string file_type = "ORB.SP3";
+
+  file_name = GetOrbitClockFinalFileName(header, year_doy, period, file_type);
+  EXPECT_THAT(file_name, ::testing::MatchesRegex("IGS0OPSFIN_20231900000_01D_15M_ORB.SP3"));
+
+  header = "IGS0OPSFIN";
+  year_doy = 2023365;
+  period = "30S";
+  file_type = "CLK.CLK";
+
+  file_name = GetOrbitClockFinalFileName(header, year_doy, period, file_type);
+  EXPECT_THAT(file_name, ::testing::MatchesRegex("IGS0OPSFIN_20233650000_01D_30S_CLK.CLK"));
+}

--- a/src/library/gnss/test_igs_product_name_handling.cpp
+++ b/src/library/gnss/test_igs_product_name_handling.cpp
@@ -31,3 +31,14 @@ TEST(IgsProductName, GetOrbitClockFinalFileName) {
   file_name = GetOrbitClockFinalFileName(header, year_doy, period, file_type);
   EXPECT_THAT(file_name, ::testing::MatchesRegex("IGS0OPSFIN_20233650000_01D_30S_CLK.CLK"));
 }
+
+/**
+ * @brief Test MergeYearDoy
+ */
+TEST(IgsProductName, MergeYearDoy) {
+  size_t year = 2023;
+  size_t doy = 190;
+  size_t year_doy = MergeYearDoy(year, doy);
+
+  EXPECT_EQ(2023190, year_doy);
+}

--- a/src/library/gnss/test_igs_product_name_handling.cpp
+++ b/src/library/gnss/test_igs_product_name_handling.cpp
@@ -8,9 +8,9 @@
 #include "igs_product_name_handling.hpp"
 
 /**
- * @brief Test satellite number to index
+ * @brief Test GetOrbitClockFinalFileName
  */
-TEST(IgsProductName, SatelliteNumberToIndex) {
+TEST(IgsProductName, GetOrbitClockFinalFileName) {
   std::string header = "IGS0OPSFIN";
   size_t year_doy = 2023190;
 


### PR DESCRIPTION
## Related issues
#276 

## Description
The old SP3 file reading function was deleted, and new SP3 file reader is used for GNSS satellites.
I also added the IGS file name handling functions.

## Test results
See GoogleTest results.

## Impact
Only for GNSS users.

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
