### PR TITLE
[Hotfix] Add error handling for null data in practical SP3 files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 7.2.3
+  VERSION 7.2.4
 )
 
 # build config

--- a/src/library/gnss/sp3_file_reader.cpp
+++ b/src/library/gnss/sp3_file_reader.cpp
@@ -302,10 +302,18 @@ Sp3PositionClock Sp3FileReader::DecodePositionClockData(std::string line) {
   if (line.size() > 61) {
     libra::Vector<3> position_standard_deviation;
     for (size_t axis = 0; axis < 3; axis++) {
-      position_standard_deviation[axis] = stod(line.substr(61 + axis * 2, 2));
+      try {
+        position_standard_deviation[axis] = stod(line.substr(61 + axis * 3, 2));
+      } catch (const std::invalid_argument&) {
+        position_standard_deviation[axis] = 0.0;
+      }
     }
     position_clock.position_standard_deviation_ = position_standard_deviation;
-    position_clock.clock_standard_deviation_ = stod(line.substr(70, 3));
+    try {
+      position_clock.clock_standard_deviation_ = stod(line.substr(70, 3));
+    } catch (const std::invalid_argument&) {
+      position_clock.clock_standard_deviation_ = 0.0;
+    }
   }
 
   // Flags

--- a/src/library/gnss/sp3_file_reader.cpp
+++ b/src/library/gnss/sp3_file_reader.cpp
@@ -134,7 +134,7 @@ size_t Sp3FileReader::ReadHeader(std::ifstream& sp3_file) {
   // Check SP3 version
   if (line.find("#d") != 0) {
     std::cout << "[Warning] SP3 file version is not supported: " << line << std::endl;
-    return 0;
+    std::cout << "We recommend to use SP3-d. " << std::endl;
   }
   // Read contents
   if (line[2] == 'P') {


### PR DESCRIPTION
## Related issues
NA

## Description
I found that the SP3 reader crashes when the SP3 file has null data as follows.

![image](https://github.com/ut-issl/s2e-core/assets/19573779/85ef7a05-3197-4b65-907d-e866ba2d540f)

To avoid the crash, I modified the code to ignore such null data.

In addition, I modified to accept another version SP3 file because the latest IGS SP3 file uses SP3-c version.

## Test results
I confirmed that it works for the SP3 file with null data.

## Impact
Small

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
