### PR TITLE
Modify GNSS visibility calculation

### DIFF
--- a/data/sample/initialize_files/components/gnss_receiver.ini
+++ b/data/sample/initialize_files/components/gnss_receiver.ini
@@ -18,6 +18,7 @@ quaternion_b2c(3) = 1.0
 // CONE: We calculate the number of GNSS satellites in the antenna,
 //       and the position is observable when more than 4 satellites are in the antenna.
 //       Note : We need to enable the GNSS satellite calculation when we use this mode.
+//              All satellites managed in the GnssSatellite class are used in this model.
 antenna_model = SIMPLE
 
 // Antenna half width [deg]

--- a/data/sample/initialize_files/components/gnss_receiver.ini
+++ b/data/sample/initialize_files/components/gnss_receiver.ini
@@ -23,17 +23,6 @@ antenna_model = SIMPLE
 // Antenna half width [deg]
 antenna_half_width_deg = 60
 
-// Target GNSS system ID 
-// G...GPS
-// R...GLONASS
-// E...Galileo
-// C...Beidou
-// J...QZSS
-// if your receiver is compatible with all kind of gnss satellites : GRECJ
-// if your receiver is compatible with GPS and QZSS : GJ
-// Note: GNSS satellite calculation must includes the target GNSS systems
-gnss_system_id = G
-
 // Random noise for simple position observation
 white_noise_standard_deviation_position_ecef_m(0) = 2000.0
 white_noise_standard_deviation_position_ecef_m(1) = 1000.0

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -120,7 +120,9 @@ void GnssReceiver::CheckAntennaCone(const libra::Vector<3> position_true_eci_m, 
   // initialize
   visible_satellite_number_ = 0;
 
-  for (size_t i = 0; i < kTotalNumberOfGnssSatellite; i++) {
+  size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
+
+  for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
     // check if gnss ID is compatible with the receiver
     std::string gnss_system_id_string = ConvertIndexToGnssSatelliteNumber(i);
     if (gnss_system_id_.find(gnss_system_id_string[0]) == std::string::npos) continue;

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -155,7 +155,7 @@ void GnssReceiver::CheckAntennaCone(const libra::Vector<3> position_true_eci_m, 
     }
   }
 
-  if (visible_satellite_number_ > 0) {
+  if (visible_satellite_number_ >= 4) {
     is_gnss_visible_ = true;
   } else {
     is_gnss_visible_ = false;

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -11,9 +11,9 @@
 #include <library/randomization/global_randomization.hpp>
 #include <string>
 
-GnssReceiver::GnssReceiver(const int prescaler, ClockGenerator* clock_generator, const size_t component_id, const std::string gnss_system_id,
-                           const AntennaModel antenna_model, const libra::Vector<3> antenna_position_b_m, const libra::Quaternion quaternion_b2c,
-                           const double half_width_deg, const libra::Vector<3> position_noise_standard_deviation_ecef_m,
+GnssReceiver::GnssReceiver(const int prescaler, ClockGenerator* clock_generator, const size_t component_id, const AntennaModel antenna_model,
+                           const libra::Vector<3> antenna_position_b_m, const libra::Quaternion quaternion_b2c, const double half_width_deg,
+                           const libra::Vector<3> position_noise_standard_deviation_ecef_m,
                            const libra::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const Dynamics* dynamics,
                            const GnssSatellites* gnss_satellites, const SimulationTime* simulation_time)
     : Component(prescaler, clock_generator),
@@ -21,7 +21,6 @@ GnssReceiver::GnssReceiver(const int prescaler, ClockGenerator* clock_generator,
       antenna_position_b_m_(antenna_position_b_m),
       quaternion_b2c_(quaternion_b2c),
       half_width_deg_(half_width_deg),
-      gnss_system_id_(gnss_system_id),
       antenna_model_(antenna_model),
       dynamics_(dynamics),
       gnss_satellites_(gnss_satellites),
@@ -33,9 +32,8 @@ GnssReceiver::GnssReceiver(const int prescaler, ClockGenerator* clock_generator,
 }
 
 GnssReceiver::GnssReceiver(const int prescaler, ClockGenerator* clock_generator, PowerPort* power_port, const size_t component_id,
-                           const std::string gnss_system_id, const AntennaModel antenna_model, const libra::Vector<3> antenna_position_b_m,
-                           const libra::Quaternion quaternion_b2c, const double half_width_deg,
-                           const libra::Vector<3> position_noise_standard_deviation_ecef_m,
+                           const AntennaModel antenna_model, const libra::Vector<3> antenna_position_b_m, const libra::Quaternion quaternion_b2c,
+                           const double half_width_deg, const libra::Vector<3> position_noise_standard_deviation_ecef_m,
                            const libra::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const Dynamics* dynamics,
                            const GnssSatellites* gnss_satellites, const SimulationTime* simulation_time)
     : Component(prescaler, clock_generator, power_port),
@@ -43,7 +41,6 @@ GnssReceiver::GnssReceiver(const int prescaler, ClockGenerator* clock_generator,
       antenna_position_b_m_(antenna_position_b_m),
       quaternion_b2c_(quaternion_b2c),
       half_width_deg_(half_width_deg),
-      gnss_system_id_(gnss_system_id),
       antenna_model_(antenna_model),
       dynamics_(dynamics),
       gnss_satellites_(gnss_satellites),
@@ -123,10 +120,6 @@ void GnssReceiver::CheckAntennaCone(const libra::Vector<3> position_true_eci_m, 
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
 
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    // check if gnss ID is compatible with the receiver
-    std::string gnss_system_id_string = ConvertIndexToGnssSatelliteNumber(i);
-    if (gnss_system_id_.find(gnss_system_id_string[0]) == std::string::npos) continue;
-
     // compute direction from sat to gnss in body-fixed frame
     libra::Vector<3> gnss_satellite_position_i_m = gnss_satellites_->GetPosition_eci_m(i);
     libra::Vector<3> antenna_to_gnss_satellite_i_m = gnss_satellite_position_i_m - antenna_position_i_m;
@@ -153,7 +146,7 @@ void GnssReceiver::CheckAntennaCone(const libra::Vector<3> position_true_eci_m, 
     if (inner2 > cos(half_width_deg_ * libra::deg_to_rad) && is_satellite_visible) {
       // is visible
       visible_satellite_number_++;
-      SetGnssInfo(antenna_to_gnss_satellite_i_m, quaternion_i2b, gnss_system_id_string);
+      SetGnssInfo(antenna_to_gnss_satellite_i_m, quaternion_i2b, i);
     }
   }
 
@@ -165,7 +158,7 @@ void GnssReceiver::CheckAntennaCone(const libra::Vector<3> position_true_eci_m, 
 }
 
 void GnssReceiver::SetGnssInfo(const libra::Vector<3> antenna_to_satellite_i_m, const libra::Quaternion quaternion_i2b,
-                               const std::string gnss_system_id) {
+                               const std::size_t gnss_system_id) {
   libra::Vector<3> antenna_to_satellite_direction_b = quaternion_i2b.FrameConversion(antenna_to_satellite_i_m);
   libra::Vector<3> antenna_to_satellite_direction_c = quaternion_b2c_.FrameConversion(antenna_to_satellite_direction_b);
 
@@ -258,7 +251,6 @@ typedef struct _gnss_receiver_param {
   libra::Vector<3> antenna_pos_b;
   libra::Quaternion quaternion_b2c;
   double half_width_deg;
-  std::string gnss_system_id;
   libra::Vector<3> position_noise_standard_deviation_ecef_m;
   libra::Vector<3> velocity_noise_standard_deviation_ecef_m_s;
 } GnssReceiverParam;
@@ -287,7 +279,6 @@ GnssReceiverParam ReadGnssReceiverIni(const std::string file_name, const GnssSat
   gnssr_conf.ReadVector(GSection, "antenna_position_b_m", gnss_receiver_param.antenna_pos_b);
   gnssr_conf.ReadQuaternion(GSection, "quaternion_b2c", gnss_receiver_param.quaternion_b2c);
   gnss_receiver_param.half_width_deg = gnssr_conf.ReadDouble(GSection, "antenna_half_width_deg");
-  gnss_receiver_param.gnss_system_id = gnssr_conf.ReadString(GSection, "gnss_system_id");
   gnssr_conf.ReadVector(GSection, "white_noise_standard_deviation_position_ecef_m", gnss_receiver_param.position_noise_standard_deviation_ecef_m);
   gnssr_conf.ReadVector(GSection, "white_noise_standard_deviation_velocity_ecef_m_s", gnss_receiver_param.velocity_noise_standard_deviation_ecef_m_s);
 
@@ -298,9 +289,9 @@ GnssReceiver InitGnssReceiver(ClockGenerator* clock_generator, const size_t comp
                               const GnssSatellites* gnss_satellites, const SimulationTime* simulation_time) {
   GnssReceiverParam gr_param = ReadGnssReceiverIni(file_name, gnss_satellites, component_id);
 
-  GnssReceiver gnss_r(gr_param.prescaler, clock_generator, component_id, gr_param.gnss_system_id, gr_param.antenna_model, gr_param.antenna_pos_b,
-                      gr_param.quaternion_b2c, gr_param.half_width_deg, gr_param.position_noise_standard_deviation_ecef_m,
-                      gr_param.velocity_noise_standard_deviation_ecef_m_s, dynamics, gnss_satellites, simulation_time);
+  GnssReceiver gnss_r(gr_param.prescaler, clock_generator, component_id, gr_param.antenna_model, gr_param.antenna_pos_b, gr_param.quaternion_b2c,
+                      gr_param.half_width_deg, gr_param.position_noise_standard_deviation_ecef_m, gr_param.velocity_noise_standard_deviation_ecef_m_s,
+                      dynamics, gnss_satellites, simulation_time);
   return gnss_r;
 }
 
@@ -311,8 +302,8 @@ GnssReceiver InitGnssReceiver(ClockGenerator* clock_generator, PowerPort* power_
   // PowerPort
   power_port->InitializeWithInitializeFile(file_name);
 
-  GnssReceiver gnss_r(gr_param.prescaler, clock_generator, power_port, component_id, gr_param.gnss_system_id, gr_param.antenna_model,
-                      gr_param.antenna_pos_b, gr_param.quaternion_b2c, gr_param.half_width_deg, gr_param.position_noise_standard_deviation_ecef_m,
+  GnssReceiver gnss_r(gr_param.prescaler, clock_generator, power_port, component_id, gr_param.antenna_model, gr_param.antenna_pos_b,
+                      gr_param.quaternion_b2c, gr_param.half_width_deg, gr_param.position_noise_standard_deviation_ecef_m,
                       gr_param.velocity_noise_standard_deviation_ecef_m_s, dynamics, gnss_satellites, simulation_time);
   return gnss_r;
 }

--- a/src/components/real/aocs/gnss_receiver.hpp
+++ b/src/components/real/aocs/gnss_receiver.hpp
@@ -30,7 +30,7 @@ enum class AntennaModel {
  * @brief Information of GNSS satellites
  */
 typedef struct _gnss_info {
-  std::string id;        //!< ID of GNSS satellites
+  size_t gnss_id;        //!< ID of GNSS satellites
   double latitude_rad;   //!< Latitude on the antenna frame [rad]
   double longitude_rad;  //!< Longitude on the antenna frame [rad]
   double distance_m;     //!< Distance between the GNSS satellite and the GNSS receiver antenna [m]
@@ -48,7 +48,6 @@ class GnssReceiver : public Component, public ILoggable {
    * @param [in] prescaler: Frequency scale factor for update
    * @param [in] clock_generator: Clock generator
    * @param [in] component_id: Component ID
-   * @param [in] gnss_system_id: Target GNSS system IDs
    * @param [in] antenna_model: Antenna model
    * @param [in] antenna_position_b_m: GNSS antenna position at the body-fixed frame [m]
    * @param [in] quaternion_b2c: Quaternion from body frame to component frame (antenna frame)
@@ -59,18 +58,16 @@ class GnssReceiver : public Component, public ILoggable {
    * @param [in] gnss_satellites: GNSS Satellites information
    * @param [in] simulation_time: Simulation time information
    */
-  GnssReceiver(const int prescaler, ClockGenerator* clock_generator, const size_t component_id, const std::string gnss_system_id,
-               const AntennaModel antenna_model, const libra::Vector<3> antenna_position_b_m, const libra::Quaternion quaternion_b2c,
-               const double half_width_deg, const libra::Vector<3> position_noise_standard_deviation_ecef_m,
-               const libra::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const Dynamics* dynamics, const GnssSatellites* gnss_satellites,
-               const SimulationTime* simulation_time);
+  GnssReceiver(const int prescaler, ClockGenerator* clock_generator, const size_t component_id, const AntennaModel antenna_model,
+               const libra::Vector<3> antenna_position_b_m, const libra::Quaternion quaternion_b2c, const double half_width_deg,
+               const libra::Vector<3> position_noise_standard_deviation_ecef_m, const libra::Vector<3> velocity_noise_standard_deviation_ecef_m_s,
+               const Dynamics* dynamics, const GnssSatellites* gnss_satellites, const SimulationTime* simulation_time);
   /**
    * @fn GnssReceiver
    * @brief Constructor with power port
    * @param [in] prescaler: Frequency scale factor for update
    * @param [in] clock_generator: Clock generator
    * @param [in] power_port: Power port
-   * @param [in] gnss_system_id: Target GNSS system IDs
    * @param [in] antenna_model: Antenna model
    * @param [in] antenna_position_b_m: GNSS antenna position at the body-fixed frame [m]
    * @param [in] quaternion_b2c: Quaternion from body frame to component frame (antenna frame)
@@ -82,8 +79,8 @@ class GnssReceiver : public Component, public ILoggable {
    * @param [in] simulation_time: Simulation time information
    */
   GnssReceiver(const int prescaler, ClockGenerator* clock_generator, PowerPort* power_port, const size_t component_id,
-               const std::string gnss_system_id, const AntennaModel antenna_model, const libra::Vector<3> antenna_position_b_m,
-               const libra::Quaternion quaternion_b2c, const double half_width_deg, const libra::Vector<3> position_noise_standard_deviation_ecef_m,
+               const AntennaModel antenna_model, const libra::Vector<3> antenna_position_b_m, const libra::Quaternion quaternion_b2c,
+               const double half_width_deg, const libra::Vector<3> position_noise_standard_deviation_ecef_m,
                const libra::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const Dynamics* dynamics, const GnssSatellites* gnss_satellites,
                const SimulationTime* simulation_time);
 
@@ -137,7 +134,6 @@ class GnssReceiver : public Component, public ILoggable {
   libra::Vector<3> antenna_position_b_m_;  //!< GNSS antenna position at the body-fixed frame [m]
   libra::Quaternion quaternion_b2c_;       //!< Quaternion from body frame to component frame (antenna frame)
   double half_width_deg_ = 0.0;            //!< Half width of the antenna cone model [deg]
-  std::string gnss_system_id_;             //!< GNSS satellite number defined by GNSS system
   AntennaModel antenna_model_;             //!< Antenna model
 
   // Simple position observation
@@ -194,7 +190,7 @@ class GnssReceiver : public Component, public ILoggable {
    * @param [in] quaternion_i2b: True attitude of the spacecraft expressed by quaternion from the inertial frame to the body-fixed frame
    * @param [in] gnss_system_id: ID of target GNSS satellite
    */
-  void SetGnssInfo(const libra::Vector<3> antenna_to_satellite_i_m, const libra::Quaternion quaternion_i2b, const std::string gnss_system_id);
+  void SetGnssInfo(const libra::Vector<3> antenna_to_satellite_i_m, const libra::Quaternion quaternion_i2b, const size_t gnss_system_id);
   /**
    * @fn AddNoise
    * @brief Substitutional method for "Measure" in other sensor models inherited Sensor class

--- a/src/environment/global/gnss_satellites.hpp
+++ b/src/environment/global/gnss_satellites.hpp
@@ -63,6 +63,12 @@ class GnssSatellites : public ILoggable {
   inline bool IsCalcEnabled() const { return is_calc_enabled_; }
 
   /**
+   * @fn GetNumberOfCalculatedSatellite
+   * @brief Return number of calculated satellite
+   */
+  inline size_t GetNumberOfCalculatedSatellite() const { return number_of_calculated_gnss_satellites_; }
+
+  /**
    * @fn Update
    * @brief Update both GNSS satellite information
    * @param [in] simulation_time: Simulation time information


### PR DESCRIPTION
## Related issues
#276 

## Description
The GNSS satellite visibility calculation was modified.
- The satellite number threshold was fixed from 0 to 4.
- The `gnss_system_id` was removed because the target GNSS system should be managed in the `GnssSatellite` class.

## Test results
NA

## Impact
Major update for GnssReceiver users.

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
