### PR TITLE
Make C2A command sender optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(S2E
 # build config
 option(USE_HILS "Use HILS" OFF)
 option(USE_C2A "Use C2A" OFF)
+option(USE_C2A_COMMAND_SENDER "Use command sender to C2A" OFF)
 option(BUILD_64BIT "Build 64bit" OFF)
 option(GOOGLE_TEST "Execute GoogleTest" OFF)
 

--- a/src/components/CMakeLists.txt
+++ b/src/components/CMakeLists.txt
@@ -25,7 +25,6 @@ real/cdh/on_board_computer_with_c2a.cpp
 real/communication/antenna.cpp
 real/communication/antenna_radiation_pattern.cpp
 real/communication/ground_station_calculator.cpp
-real/communication/wings_command_sender_to_c2a.cpp
 
 examples/example_change_structure.cpp
 examples/example_serial_communication_with_obc.cpp
@@ -59,6 +58,13 @@ if(USE_HILS)
     ${SOURCE_FILES}
     hils/ports/hils_uart_port.cpp
     hils/ports/hils_i2c_target_port.cpp
+  )
+endif()
+
+if(USE_C2A_COMMAND_SENDER)
+  set(SOURCE_FILES
+    ${SOURCE_FILES}
+    real/communication/wings_command_sender.cpp
   )
 endif()
 


### PR DESCRIPTION
## Related Issue / PR
- #477 
- #485 

## Description
C2A command sender feature was implemented by #485.
However, this feature is still experimental & optional.
To make this explicit, this patch split C2A command sender feature with CMake option and turned off by default.

## Impact
- Split C2A command sender feature to CMake option: `USE_C2A_COMMAND_SENDER`
- Make `USE_C2A_COMMAND_SENDER` default off