### PR TITLE
Fix C2A command sender source file path

### DIFF
--- a/src/components/CMakeLists.txt
+++ b/src/components/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 if(USE_C2A_COMMAND_SENDER)
   set(SOURCE_FILES
     ${SOURCE_FILES}
-    real/communication/wings_command_sender.cpp
+    real/communication/wings_command_sender_to_c2a.cpp
   )
 endif()
 


### PR DESCRIPTION
## Related issue / PR
- #619 

## Description
Fixes source file path typo in #619.

## Test results
- C2A command sender feature disabled (default)
```sh
$ cmake -B build
$ cmake --build build
```
- C2A command sender feature enabled
```sh
$ cmake -B build -DUSE_C2A_COMMAND_SENDER=ON
$ cmake --build build
```

## Impact
bug fix

## Supplementary information
N/A