### PR TITLE
Fix build on linux64 (non-x86_64)

### DIFF
--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -41,6 +41,15 @@ else()
     set(CSPICE_SHA256 "60a95b51a6472f1afe7e40d77ebdee43c12bb5b8823676ccc74692ddfede06ce")
     set(CSPICE_CONFIGURE_COMMAND "")
     set(CSPICE_BUILD_COMMAND "")
+
+    # If we build on aarch64 linux, we cannot use binary package. Let's (super-slow) build
+    if(NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+      # super remove no-need compile option
+      set(CSPICE_CONFIGURE_COMMAND find . -type f -exec sed -i "s/-m64//g" {} +)
+
+      # build cspice by host C-compiler with original build logic
+      set(CSPICE_BUILD_COMMAND "./makeall.csh")
+    endif()
   else()
     set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_32bit/packages/cspice.tar.Z)
     set(CSPICE_SHA256 "33d75cd94acf6546e53d7ebc4e7d3d6d42ac27c83cb0d8f04c91a8b50c1149e3")

--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -25,11 +25,13 @@ elseif(APPLE)
     # APPLE Silicon
     set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit//C/MacM1_OSX_clang_64bit/packages/cspice.tar.Z)
     set(CSPICE_SHA256 "0deae048443e11ca4d093cac651d9785d4f2594631a183d85a3d58949f4d0aa9")
+    set(CSPICE_CONFIGURE_COMMAND "")
     set(CSPICE_BUILD_COMMAND "")
   else()
     # APPLE Intel
     set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit//C/MacIntel_OSX_AppleC_64bit/packages/cspice.tar.Z)
     set(CSPICE_SHA256 "6f4980445fee4d363dbce6f571819f4a248358d2c1bebca47e0743eedfe9935e")
+    set(CSPICE_CONFIGURE_COMMAND "")
     set(CSPICE_BUILD_COMMAND "")
   endif()
 else()
@@ -37,10 +39,12 @@ else()
   if(BUILD_64BIT)
     set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z)
     set(CSPICE_SHA256 "60a95b51a6472f1afe7e40d77ebdee43c12bb5b8823676ccc74692ddfede06ce")
+    set(CSPICE_CONFIGURE_COMMAND "")
     set(CSPICE_BUILD_COMMAND "")
   else()
     set(CSPICE_URL https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_32bit/packages/cspice.tar.Z)
     set(CSPICE_SHA256 "33d75cd94acf6546e53d7ebc4e7d3d6d42ac27c83cb0d8f04c91a8b50c1149e3")
+    set(CSPICE_CONFIGURE_COMMAND "")
     set(CSPICE_BUILD_COMMAND "")
   endif()
 endif()
@@ -51,7 +55,7 @@ ExternalProject_Add(cspice
   URL_HASH SHA256=${CSPICE_SHA256}
   # DOWNLOAD_EXTRACT_TIMESTAMP false # prepare for CMake 3.24
   SOURCE_DIR "cspice"
-  CONFIGURE_COMMAND ""
+  CONFIGURE_COMMAND ${CSPICE_CONFIGURE_COMMAND}
   BUILD_IN_SOURCE true
   BUILD_COMMAND "${CSPICE_BUILD_COMMAND}"
   INSTALL_COMMAND ""


### PR DESCRIPTION
## Related issues / PRs
- #634 

## Description
Currently, we install the `ExtLibraries/cspice` by downloading pre-compiled binaries specific to each environment. However, NASA/JPL does not not provide binaries for all environments. Specifically, the `PC_Linux_GCC_64bit` variant is actually intended for x86_64 Linux environments. As a result, when attempting to use cspice in aarch64 Linux environment, it inadvertently installs the x86_64 version, which causes the build of S2E to fail.

To address this issue, this patch add a mechanism to build cspice from source code in non-x86_64 (but 64bit Linux) environments.

## Test results
Provide the test results and a link to the detailed results log.

## Impact
Make `ExtLibraries/cspice` usable in 64-bit Linux environments with non-x86_64 architectures, such as aarch64 Linux (e.g., Raspberry Pi OS).

## Supplementary information
The NASA/JPL's original build scripts for cspice indiscriminately apply the `-m64` compile option. However, within `ExtLibraries/cspice`, it is assumed that the C compiler used for building is installed on the target environment’s host. Therefore, there is no need for cross-compilation flags like `-m64` (although it is necessary to consider such options when building SILS-S2E with C2A for the i686 architecture, in which case the entire project is built for i686 and uses the `PC_Linux_GCC_32bit` variant).

Moreover, compile options like `-m32` and `-m64` are often not implemented in compilers for architectures other than x86_64. For example, it is impossible to use `-m64` on an aarch64 Linux system.

Consequently, this patch includes modifications to remove the `-m64` option from the cspice original build script prior to building.