### PR TITLE
[hotfix] Add const getter of PowerPort in PowerControlUnit

### DIFF
--- a/src/components/real/power/power_control_unit.hpp
+++ b/src/components/real/power/power_control_unit.hpp
@@ -61,7 +61,8 @@ class PowerControlUnit : public Component, public ILoggable {
    * @brief Return power port information
    * @param port_id: Power port ID
    */
-  inline PowerPort* GetPowerPort(const int port_id) { return power_ports_[port_id]; };
+  inline PowerPort* GetPowerPort(const int port_id) { return power_ports_.at(port_id); };
+  inline const PowerPort* GetPowerPort(const int port_id) const { return power_ports_.at(port_id); };
 
   // Port control functions
   /**


### PR DESCRIPTION
## Related issues
NA

## Description
`PowerControlUnit` において，`PowerPort` の getter である `GetPowerPort` に const な overload member function を追加した。
`PowerPort` は `GetVoltage_V` などの getter を持つが，`PowerControlUnit::GetPowerPort` が const でないと `GetLogValue` などの const function から呼び出すことができず不便であったため。

## Test results
ビルドについてはCIで確認可能。
動作についてはuserプロジェクトで確認済み。

## Impact
既存のものへの影響はない想定。

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
