### PR TITLE
Add CSPICE settings

### DIFF
--- a/ExtLibraries/cspice/CMakeLists.txt
+++ b/ExtLibraries/cspice/CMakeLists.txt
@@ -8,6 +8,9 @@ include(FetchContent)
 set(CSPICE_INSTALL_DIR ${EXT_LIB_DIR}/cspice)
 set(GENERIC_KERNEL_URL_BASE https://naif.jpl.nasa.gov/pub/naif/generic_kernels)
 
+set(SETTINGS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../settings/")
+set(GENERIC_KERNEL_INSTALL_DIR ${SETTINGS_DIR}/environment/cspice)
+
 if(WIN32)
   # Windows
   if(BUILD_64BIT)
@@ -118,5 +121,5 @@ configure_file(
 )
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generic_kernels
-  DESTINATION ${CSPICE_INSTALL_DIR}
+  DESTINATION ${GENERIC_KERNEL_INSTALL_DIR}
 )

--- a/settings/sample_simulation_base.ini
+++ b/settings/sample_simulation_base.ini
@@ -115,11 +115,11 @@ rotation_mode(10) = DISABLE
 
 [CSPICE_KERNELS]
 // CSPICE Kernel files definition
-tls  = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/lsk/naif0010.tls
-tpc1 = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/pck/de-403-masses.tpc
-tpc2 = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/pck/gm_de431.tpc
-tpc3 = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/pck/pck00010.tpc
-bsp  = EXT_LIB_DIR_FROM_EXE/cspice/generic_kernels/spk/planets/de430.bsp
+tls  = INI_FILE_DIR_FROM_EXE/environment/cspice/generic_kernels/lsk/naif0010.tls
+tpc1 = INI_FILE_DIR_FROM_EXE/environment/cspice/generic_kernels/pck/de-403-masses.tpc
+tpc2 = INI_FILE_DIR_FROM_EXE/environment/cspice/generic_kernels/pck/gm_de431.tpc
+tpc3 = INI_FILE_DIR_FROM_EXE/environment/cspice/generic_kernels/pck/pck00010.tpc
+bsp  = INI_FILE_DIR_FROM_EXE/environment/cspice/generic_kernels/spk/planets/de430.bsp
 
 
 [HIPPARCOS_CATALOGUE]


### PR DESCRIPTION
## Related issues
#613 

## Description
CSPICE setting files are added to `settings/environment/cspice` directory.

## Test results
See CI

## Impact
Major update

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
