### PR TITLE
Add setting file copy when cache is available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
         working-directory: ./ExtLibraries
         run: |
           cmake --install .
+
       - name: check extlib
         shell: powershell
         working-directory: ./ExtLibraries
@@ -102,6 +103,13 @@ jobs:
           ls nrlmsise00/lib*
           ls nrlmsise00/lib*/libnrlmsise00.lib
           ls nrlmsise00/src
+
+      - name: copy to settings
+        if: steps.cache-extlib.outputs.cache-hit = 'true'
+        shell: powershell
+        working-directory: ./ExtLibraries
+        run: |
+          cp -r "cspice/generic_kernels" "../settings/cspice/generic_kernels"
 
       - name: build 32bit
         if: matrix.build_bit == 'BUILD_64BIT=OFF'
@@ -189,6 +197,7 @@ jobs:
         working-directory: ./ExtLibraries
         run: |
           cmake --install .
+
       - name: check extlib
         working-directory: ./ExtLibraries
         run: |
@@ -200,6 +209,12 @@ jobs:
           ls nrlmsise00/lib*
           ls nrlmsise00/lib*/libnrlmsise00.a
           ls nrlmsise00/src
+
+      - name: copy to settings
+        if: steps.cache-extlib.outputs.cache-hit = 'true'
+        working-directory: ./ExtLibraries
+        run: |
+          cp -r "cspice/generic_kernels" "../settings/cspice/generic_kernels"
 
       - name: build
         env:


### PR DESCRIPTION
## Related issues
#316 

## Description
ActionsでExtLibのcacheが存在していたとしても、cspiceファイルはsettingsへコピーしなければならないので、そのための修正。

## Test results
See CI.

## Impact
NA

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
