### PR TITLE
Feature/add ralative position stm

### DIFF
--- a/src/library/orbit/relative_orbit_models.cpp
+++ b/src/library/orbit/relative_orbit_models.cpp
@@ -1,8 +1,11 @@
-/**
+  /**
  * @file relative_orbit_models.cpp
  * @brief Functions for relative orbit
  */
 #include "relative_orbit_models.hpp"
+
+#include <environment/global/physical_constants.hpp>
+#include "../external/sgp4/sgp4unit.h"  // for getgravconst()
 
 libra::Matrix<6, 6> CalcHillSystemMatrix(double orbit_radius_m, double gravity_constant_m3_s2) {
   libra::Matrix<6, 6> system_matrix;
@@ -89,5 +92,42 @@ libra::Matrix<6, 6> CalcHcwStm(double orbit_radius_m, double gravity_constant_m3
   stm[5][3] = 0.0;
   stm[5][4] = 0.0;
   stm[5][5] = cos(n * t);
+  return stm;
+}
+
+// 定数やreferenceの軌道要素は以下のように取得できます
+// gravconsttype whichconst = wgs72;
+// double mu_km3_s2, radius_earth_km, tumin, xke, j2, j3, j4, j3oj2;
+// getgravconst(whichconst, tumin, mu_km3_s2, radius_earth_km, xke, j2, j3, j4, j3oj2);
+// double semi_major_axis_m = reference_oe->GetSemiMajorAxis_m();
+// double eccentricity = reference_oe->GetEccentricity();
+
+libra::Matrix<6, 6> CalcMeltonStm(double orbit_radius_m, double gravity_constant_m3_s2, double elapsed_time_s, OrbitalElements* reference_oe) {
+  libra::Matrix<6, 6> stm;
+  // ここでstmを計算してください
+  return stm;
+}
+
+libra::Matrix<6, 6> CalcSsStm(double orbit_radius_m, double gravity_constant_m3_s2, double elapsed_time_s, OrbitalElements* reference_oe) {
+  libra::Matrix<6, 6> stm;
+  // ここでstmを計算してください
+  return stm;
+}
+
+libra::Matrix<6, 6> CalcSabatiniStm(double orbit_radius_m, double gravity_constant_m3_s2, double elapsed_time_s, OrbitalElements* reference_oe) {
+  libra::Matrix<6, 6> stm;
+  // ここでstmを計算してください
+  return stm;
+}
+
+libra::Matrix<6, 6> CalcCarterStm(double orbit_radius_m, double gravity_constant_m3_s2, double f_ref_rad, OrbitalElements* reference_oe){
+  libra::Matrix<6, 6> stm;
+  // ここでstmを計算してください
+  return stm;
+}
+
+libra::Matrix<6, 6> CalcYamakawaAnkersenStm(double orbit_radius_m, double gravity_constant_m3_s2, double f_ref_rad, OrbitalElements* reference_oe){
+  libra::Matrix<6, 6> stm;
+  // ここでstmを計算してください
   return stm;
 }

--- a/src/library/orbit/relative_orbit_models.cpp
+++ b/src/library/orbit/relative_orbit_models.cpp
@@ -1,4 +1,4 @@
-  /**
+/**
  * @file relative_orbit_models.cpp
  * @brief Functions for relative orbit
  */

--- a/src/library/orbit/relative_orbit_models.hpp
+++ b/src/library/orbit/relative_orbit_models.hpp
@@ -8,6 +8,7 @@
 
 #include "../math/matrix.hpp"
 #include "../math/vector.hpp"
+#include "./orbital_elements.hpp"
 
 /**
  * @enum RelativeOrbitModel
@@ -19,7 +20,7 @@ enum class RelativeOrbitModel { kHill = 0 };
  * @enum StmModel
  * @brief State Transition Matrix for the relative orbit
  */
-enum class StmModel { kHcw = 0 };
+enum class StmModel { kHcw = 0, kMelton = 1, kSs = 2, kSabatini = 3, kCarter = 4, kYamakawaAnkersen = 5 };
 
 // Dynamics Models
 /**
@@ -41,5 +42,60 @@ libra::Matrix<6, 6> CalcHillSystemMatrix(const double orbit_radius_m, const doub
  * @return State Transition Matrix
  */
 libra::Matrix<6, 6> CalcHcwStm(const double orbit_radius_m, const double gravity_constant_m3_s2, const double elapsed_time_s);
+
+/**
+ * @fn CalcMeltonStm
+ * @brief Calculate Melton State Transition Matrix
+ * @param [in] orbit_radius_m: Orbit radius [m]
+ * @param [in] gravity_constant_m3_s2: Gravity constant of the center body [m3/s2]
+ * @param [in] elapsed_time_s: Elapsed time [s]
+ * @param [in] reference_oe: Orbital elements of reference satellite
+ * @return State Transition Matrix
+ */
+libra::Matrix<6, 6> CalcMeltonStm(double orbit_radius_m, double gravity_constant_m3_s2, double elapsed_time_s, OrbitalElements* reference_oe);
+
+/**
+ * @fn CalcSsStm
+ * @brief Calculate SS State Transition Matrix
+ * @param [in] orbit_radius_m: Orbit radius [m]
+ * @param [in] gravity_constant_m3_s2: Gravity constant of the center body [m3/s2]
+ * @param [in] elapsed_time_s: Elapsed time [s]
+ * @param [in] reference_oe: Orbital elements of reference satellite
+ * @return State Transition Matrix
+ */
+libra::Matrix<6, 6> CalcSsStm(double orbit_radius_m, double gravity_constant_m3_s2, double elapsed_time_s, OrbitalElements* reference_oe);
+
+/**
+ * @fn CalcSabatiniStm
+ * @brief Calculate Sabatani State Transition Matrix
+ * @param [in] orbit_radius_m: Orbit radius [m]
+ * @param [in] gravity_constant_m3_s2: Gravity constant of the center body [m3/s2]
+ * @param [in] elapsed_time_s: Elapsed time [s]
+ * @param [in] reference_oe: Orbital elements of reference satellite
+ * @return State Transition Matrix
+ */
+libra::Matrix<6, 6> CalcSabatiniStm(double orbit_radius_m, double gravity_constant_m3_s2, double elapsed_time_s, OrbitalElements* reference_oe);
+
+/**
+ * @fn CalcCarterStm
+ * @brief Calculate Carter State Transition Matrix
+ * @param [in] orbit_radius_m: Orbit radius [m]
+ * @param [in] gravity_constant_m3_s2: Gravity constant of the center body [m3/s2]
+ * @param [in] f_ref_rad: True anomaly of the reference satellite [rad]
+ * @param [in] reference_oe: Orbital elements of reference satellite
+ * @return State Transition Matrix
+ */
+libra::Matrix<6, 6> CalcCarterStm(double orbit_radius_m, double gravity_constant_m3_s2, double f_ref_rad, OrbitalElements* reference_oe);
+
+/**
+ * @fn CalcYamakawaAnkersenStm
+ * @brief Calculate Yamakawa-Ankersen State Transition Matrix
+ * @param [in] orbit_radius_m: Orbit radius [m]
+ * @param [in] gravity_constant_m3_s2: Gravity constant of the center body [m3/s2]
+ * @param [in] f_ref_rad: True anomaly of the reference satellite [rad]
+ * @param [in] reference_oe: Orbital elements of reference satellite
+ * @return State Transition Matrix
+ */
+libra::Matrix<6, 6> CalcYamakawaAnkersenStm(double orbit_radius_m, double gravity_constant_m3_s2, double f_ref_rad, OrbitalElements* reference_oe);
 
 #endif  // S2E_LIBRARY_ORBIT_RELATIVE_ORBIT_MODEL_HPP_


### PR DESCRIPTION
## Related issues
#689 

## Description
Add relative orbit stm for ff-gnss rg camp
- true anomalyで積分するタイプのSTMですが、実装時間がなかったためtとfを単純に変換しています。stm*初期値を計算しているのみなのでこれで動作だけは問題ないかと思います
- j2がphysical constantsにいなかったのでライブラリからとっています。あんまりよくないかもです。

## Test results

とりあえず0になることだけを確認しています。
![240920_175147_relative_position_rtn](https://github.com/user-attachments/assets/8d6012bf-a1c6-4d9b-88d5-769262081538)

## Impact
Describe the scope of influence of the changes, e.g., `The behavior of feature ** changes.`

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
