### PR TITLE
Fix errror in nrlmsise library download script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13)
 project(S2E
   LANGUAGES CXX
   DESCRIPTION "S2E: Spacecraft Simulation Environment"
-  VERSION 7.2.8
+  VERSION 7.2.9
 )
 
 # build config

--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -16,7 +16,7 @@ set(NRLMSISE_TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp)
 # download source files
 FetchContent_Declare(
   nrlmsise
-  GIT_REPOSITORY git://git.linta.de/~brodo/nrlmsise-00.git
+  GIT_REPOSITORY https://git.linta.de/~brodo/nrlmsise-00.git
   GIT_TAG bc9a2feba4344e74201281e563332688a4d09cc3
   SOURCE_DIR ${NRLMSISE_TMP_DIR}
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
## Related issues
NA

## Description
nrlmsiseのgit cloneでエラーが出ていたので修正。

## Test results
See CI

## Impact
NA

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
