### PR TITLE
Make build_s2e_win CI job matrix clearly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
           cmake --build .
 
       - name: build 64bit
-        if: matrix.build_bit == 'BUILD_64BIT=ON' && matrix.use_c2a == 'USE_C2A=OFF'
+        if: matrix.build_bit == 'BUILD_64BIT=ON'
         shell: cmd
         run: |
           cl.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        use_c2a: ['USE_C2A=OFF', 'USE_C2A=ON']
-        build_bit: ['BUILD_64BIT=OFF', 'BUILD_64BIT=ON']
+        include:
+          - build_bit: 'BUILD_64BIT=OFF'
+            use_c2a: 'USE_C2A=OFF'
+          - build_bit: 'BUILD_64BIT=OFF'
+            use_c2a: 'USE_C2A=ON'
+          - build_bit: 'BUILD_64BIT=ON'
+            use_c2a: 'USE_C2A=OFF'
 
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
## Related issues
- #710 

## Description
`USE_C2A=ON` && `BUILD_64BIT=ON` is ignored (because C2A is 32bit app).
However, this conditional branching is implemented in build step, so the CI job status is displayed as it this condition is being performed.

This PR changes to run only the combination of existing jobs.