### PR TITLE
[Hotfix] Fix build error on WINGS command sender

### DIFF
--- a/src/components/real/communication/wings_command_sender_to_c2a.hpp
+++ b/src/components/real/communication/wings_command_sender_to_c2a.hpp
@@ -39,12 +39,12 @@ class WingsCommandSenderToC2a : public Component {
   ~WingsCommandSenderToC2a() {}
 
  protected:
-  C2aCommandDatabase c2a_command_database_;  //!< Command database
-  WingsOperationFile wings_operation_file_;  //!< WINGS operation file
-  bool is_enabled_;                          //!< Enable flag
-  const double step_width_s_;                //!< Step width to execute this component [s]
-  double wait_s_ = 0.0;                      //!< Wait counter [s]
-  bool is_end_of_line_ = false;              //!< Flag to detect end of line
+  s2e::setting_file_reader::C2aCommandDatabase c2a_command_database_;  //!< Command database
+  s2e::setting_file_reader::WingsOperationFile wings_operation_file_;  //!< WINGS operation file
+  bool is_enabled_;                                                    //!< Enable flag
+  const double step_width_s_;                                          //!< Step width to execute this component [s]
+  double wait_s_ = 0.0;                                                //!< Wait counter [s]
+  bool is_end_of_line_ = false;                                        //!< Flag to detect end of line
 
   // Override functions for Component
   /**


### PR DESCRIPTION
## Related issues
#718 

## Description
Fix namespace of members in `WingsCommandSenderToC2a` to resolve build error.

## Test results
Able to build with `USE_C2A_COMMAND_SENDER == ON` in my local environment.

## Impact
Make it possible to build with command sender.

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
