### PR TITLE
Fix C2A interface

### DIFF
--- a/src/components/real/cdh/c2a_communication.hpp
+++ b/src/components/real/cdh/c2a_communication.hpp
@@ -6,8 +6,6 @@
 #ifndef C2A_COMMUNICATION_H_
 #define C2A_COMMUNICATION_H_
 
-namespace s2e::components {
-
 // If the character encoding of C2A is UTF-8, the following functions are not necessary,
 // and users can directory use SendFromObc_C2A and ReceivedByObc_C2A UART
 // TODO: Delete these functions since C2A is changed to use UTF-8
@@ -24,7 +22,5 @@ int OBC_C2A_I2cReadRegister(int port_id, const unsigned char i2c_address, unsign
 // GPIO
 int OBC_C2A_GpioWrite(int port_id, const bool is_high);
 bool OBC_C2A_GpioRead(int port_id);  // return false when the port_id is not used
-
-}  // namespace s2e::components
 
 #endif  // C2A_COMMUNICATION_H_

--- a/src/components/real/cdh/on_board_computer_with_c2a.cpp
+++ b/src/components/real/cdh/on_board_computer_with_c2a.cpp
@@ -133,15 +133,6 @@ int ObcWithC2a::ReceivedByObc_C2A(int port_id, unsigned char* buffer, int offset
   return port->ReadRx(buffer, offset, length);
 }
 
-// If the character encoding of C2A is UTF-8, these functions are not necessary,
-// and users can directory use SendFromObc_C2A and ReceivedByObc_C2A
-int OBC_C2A_SendFromObc(int port_id, unsigned char* buffer, int offset, int length) {
-  return ObcWithC2a::SendFromObc_C2A(port_id, buffer, offset, length);
-}
-int OBC_C2A_ReceivedByObc(int port_id, unsigned char* buffer, int offset, int length) {
-  return ObcWithC2a::ReceivedByObc_C2A(port_id, buffer, offset, length);
-}
-
 int ObcWithC2a::I2cConnectPort(int port_id, const unsigned char i2c_address) {
   if (i2c_com_ports_c2a_[port_id] != nullptr) {
     // Port already used
@@ -212,16 +203,6 @@ int ObcWithC2a::I2cComponentReadCommand(int port_id, const unsigned char i2c_add
   return 0;
 }
 
-int OBC_C2A_I2cWriteCommand(int port_id, const unsigned char i2c_address, const unsigned char* data, const unsigned char length) {
-  return ObcWithC2a::I2cWriteCommand(port_id, i2c_address, data, length);
-}
-int OBC_C2A_I2cWriteRegister(int port_id, const unsigned char i2c_address, const unsigned char* data, const unsigned char length) {
-  return ObcWithC2a::I2cWriteRegister(port_id, i2c_address, data, length);
-}
-int OBC_C2A_I2cReadRegister(int port_id, const unsigned char i2c_address, unsigned char* data, const unsigned char length) {
-  return ObcWithC2a::I2cReadRegister(port_id, i2c_address, data, length);
-}
-
 int ObcWithC2a::GpioConnectPort(int port_id) {
   if (gpio_ports_c2a_[port_id] != nullptr) {
     // Port already used
@@ -255,8 +236,28 @@ bool ObcWithC2a::GpioRead_C2A(int port_id) {
   return port->DigitalRead();
 }
 
-int OBC_C2A_GpioWrite(int port_id, const bool is_high) { return ObcWithC2a::GpioWrite_C2A(port_id, is_high); }
-
-bool OBC_C2A_GpioRead(int port_id) { return ObcWithC2a::GpioRead_C2A(port_id); }
-
 }  // namespace s2e::components
+
+// C2A用
+// If the character encoding of C2A is UTF-8, these functions are not necessary,
+// and users can directory use SendFromObc_C2A and ReceivedByObc_C2A
+int OBC_C2A_SendFromObc(int port_id, unsigned char* buffer, int offset, int length) {
+  return s2e::components::ObcWithC2a::SendFromObc_C2A(port_id, buffer, offset, length);
+}
+int OBC_C2A_ReceivedByObc(int port_id, unsigned char* buffer, int offset, int length) {
+  return s2e::components::ObcWithC2a::ReceivedByObc_C2A(port_id, buffer, offset, length);
+}
+
+int OBC_C2A_I2cWriteCommand(int port_id, const unsigned char i2c_address, const unsigned char* data, const unsigned char length) {
+  return s2e::components::ObcWithC2a::I2cWriteCommand(port_id, i2c_address, data, length);
+}
+int OBC_C2A_I2cWriteRegister(int port_id, const unsigned char i2c_address, const unsigned char* data, const unsigned char length) {
+  return s2e::components::ObcWithC2a::I2cWriteRegister(port_id, i2c_address, data, length);
+}
+int OBC_C2A_I2cReadRegister(int port_id, const unsigned char i2c_address, unsigned char* data, const unsigned char length) {
+  return s2e::components::ObcWithC2a::I2cReadRegister(port_id, i2c_address, data, length);
+}
+
+int OBC_C2A_GpioWrite(int port_id, const bool is_high) { return s2e::components::ObcWithC2a::GpioWrite_C2A(port_id, is_high); }
+
+bool OBC_C2A_GpioRead(int port_id) { return s2e::components::ObcWithC2a::GpioRead_C2A(port_id); }


### PR DESCRIPTION
## Related issues
NA

## Description
C2AとのIFに当たる部分であまり深く考えずに名前空間を切っており、予想せずC2A側に修正が必要になった。

色々検討したが、ひとまずC2A側に影響がないようにしてこの部分の根本解決をゆっくりする方針とするため、この部分の名前空間は削除する。

## Test results
下記のPRでCIが通ること
https://github.com/ut-issl/s2e-aobc/pull/102

## Impact
NA

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
