### PR TITLE
Add GNSS receiver pseudorange calculation

### DIFF
--- a/scripts/Plot/plot_gnss_receiver_pseudorange.py
+++ b/scripts/Plot/plot_gnss_receiver_pseudorange.py
@@ -70,8 +70,7 @@ for gps_idx in range(32):
   geometric_range = np.linalg.norm(gps_position - spacecraft_position_ecef_m, axis=0)
   pseudorange_error = pseudorange - geometric_range
   plt.scatter(time[0][:-1], pseudorange_error, marker=".", label=gps_str)
-print(spacecraft_position_ecef_m[0])
-print(geometric_range[0])
+
 plt.title("GPS Pseudorange Error")
 plt.xlabel("Time [s]")
 plt.ylabel("Pseudorange Error [m]")

--- a/scripts/Plot/plot_gnss_receiver_pseudorange.py
+++ b/scripts/Plot/plot_gnss_receiver_pseudorange.py
@@ -53,7 +53,7 @@ plt.figure(0)
 for gps_idx in range(32):
   gps_str = 'GPS' + str(gps_idx)
   pseudorange = read_scalar_from_csv(read_file_name, gps_str + '_pseudorange[m]')
-  plt.plot(time[0][1:], pseudorange[0][1:], marker=".", label=gps_str)
+  plt.scatter(time[0][1:], pseudorange[0][1:], marker=".", label=gps_str)
 
 plt.title("GPS Psuedorange")
 plt.xlabel("Time [s]")

--- a/scripts/Plot/plot_gnss_receiver_pseudorange.py
+++ b/scripts/Plot/plot_gnss_receiver_pseudorange.py
@@ -1,0 +1,84 @@
+#
+# Plot GNSS Receiver Pseudorange
+#
+# arg[1] : read_file_tag : time tag for default CSV output log file. ex. 220627_142946
+#
+
+#
+# Import
+#
+# plots
+import matplotlib.pyplot as plt
+# numpy
+import numpy as np
+# local function
+from common import find_latest_log_tag
+from common import add_log_file_arguments
+from common import read_3d_vector_from_csv
+from common import read_scalar_from_csv
+# arguments
+import argparse
+
+# Arguments
+aparser = argparse.ArgumentParser()
+aparser = add_log_file_arguments(aparser)
+aparser.add_argument('--no-gui', action='store_true')
+args = aparser.parse_args()
+
+#
+# Read Arguments
+#
+# log file path
+path_to_logs = args.logs_dir
+
+read_file_tag = args.file_tag
+if read_file_tag == None:
+  print("file tag does not found. use latest.")
+  read_file_tag = find_latest_log_tag(path_to_logs)
+
+print("log: " + read_file_tag)
+
+#
+# CSV file name
+#
+read_file_name  = path_to_logs + '/' + 'logs_' + read_file_tag + '/' + read_file_tag + '_default.csv'
+
+#
+# Data read and edit
+#
+# Read S2E CSV
+time = read_scalar_from_csv(read_file_name, 'elapsed_time[s]')
+
+plt.figure(0)
+for gps_idx in range(32):
+  gps_str = 'GPS' + str(gps_idx)
+  pseudorange = read_scalar_from_csv(read_file_name, gps_str + '_pseudorange[m]')
+  plt.plot(time[0][1:], pseudorange[0][1:], marker=".", label=gps_str)
+
+plt.title("GPS Psuedorange")
+plt.xlabel("Time [s]")
+plt.ylabel("Psuedorange [m]")
+plt.legend(fontsize=7, loc="upper right")
+
+
+plt.figure(1)
+spacecraft_position_ecef_m = read_3d_vector_from_csv(read_file_name, 'spacecraft_position_ecef', 'm')[:, :-1]
+for gps_idx in range(32):
+  gps_str = 'GPS' + str(gps_idx)
+  pseudorange = read_scalar_from_csv(read_file_name, gps_str + '_pseudorange[m]')[:, 1:]
+  gps_position = read_3d_vector_from_csv(read_file_name, gps_str + '_position_ecef', 'm')[:, 1:]
+  geometric_range = np.linalg.norm(gps_position - spacecraft_position_ecef_m, axis=0)
+  pseudorange_error = pseudorange - geometric_range
+  plt.scatter(time[0][:-1], pseudorange_error, marker=".", label=gps_str)
+print(spacecraft_position_ecef_m[0])
+print(geometric_range[0])
+plt.title("GPS Pseudorange Error")
+plt.xlabel("Time [s]")
+plt.ylabel("Pseudorange Error [m]")
+plt.legend(fontsize=7, loc="upper right")
+
+# Data save
+if args.no_gui:
+  plt.savefig(read_file_tag + "_gnss_receiver_pseudorange.png") # save last figure only
+else:
+  plt.show()

--- a/settings/sample_satellite/components/gnss_receiver.ini
+++ b/settings/sample_satellite/components/gnss_receiver.ini
@@ -24,6 +24,9 @@ antenna_model = SIMPLE
 // Antenna half width [deg]
 antenna_half_width_deg = 60
 
+// Random noise for pseudorange observation
+white_noise_standard_deviation_pseudorange_m = 10.0
+
 // Random noise for simple position observation
 white_noise_standard_deviation_position_ecef_m(0) = 2000.0
 white_noise_standard_deviation_position_ecef_m(1) = 1000.0

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -71,8 +71,8 @@ void GnssReceiver::MainRoutine(const int time_count) {
   // Pseudorange calculation
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
-    math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
+    // math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
+    // math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
   //   double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
   //   randomization::NormalRand pseudorange_random_noise_m;
   //   pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -71,7 +71,7 @@ void GnssReceiver::MainRoutine(const int time_count) {
   // Pseudorange calculation
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    // math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
+    math::Vector<3> gnss_satellite_position_ecef_m = math::Vector<3>(0.0);
     math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
     // double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
     // randomization::NormalRand pseudorange_random_noise_m;

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -68,11 +68,13 @@ void GnssReceiver::MainRoutine(const int time_count) {
   math::Quaternion quaternion_i2b = dynamics_->GetAttitude().GetQuaternion_i2b();
   CheckAntenna(position_true_eci, quaternion_i2b);
 
+  // Pseudorange calculation
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
     math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
     math::Vector<3> receiver_position_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
-    double geometric_distance_m = (gnss_satellite_position_ecef_m - receiver_position_ecef_m).CalcNorm();
+    math::Vector<3> a = gnss_satellite_position_ecef_m - receiver_position_ecef_m;
+    double geometric_distance_m = a.CalcNorm();
     randomization::NormalRand pseudorange_random_noise_m;
     pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
     double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
@@ -256,7 +258,7 @@ std::string GnssReceiver::GetLogValue() const  // For logs
   str_tmp += logger::WriteScalar(is_gnss_visible_);
   str_tmp += logger::WriteScalar(visible_satellite_number_);
   for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
-    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index]);
+    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 16);
   }
 
   return str_tmp;
@@ -343,3 +345,4 @@ GnssReceiver InitGnssReceiver(environment::ClockGenerator* clock_generator, Powe
 }
 
 }  // namespace s2e::components
+

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -257,7 +257,7 @@ std::string GnssReceiver::GetLogValue() const  // For logs
   str_tmp += logger::WriteScalar(is_gnss_visible_);
   str_tmp += logger::WriteScalar(visible_satellite_number_);
   for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
-    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 10);
+    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 16);
   }
 
   return str_tmp;

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -233,9 +233,9 @@ std::string GnssReceiver::GetLogHeader() const  // For logs
   str_tmp += logger::WriteScalar(sensor_name + "measured_altitude", "m");
   str_tmp += logger::WriteScalar(sensor_name + "satellite_visible_flag");
   str_tmp += logger::WriteScalar(sensor_name + "number_of_visible_satellites");
-  // for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
-  //   str_tmp += logger::WriteScalar("GPS" + std::to_string(gps_index) + "_pseudorange", "m");
-  // }
+  for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
+    str_tmp += logger::WriteScalar("GPS" + std::to_string(gps_index) + "_pseudorange", "m");
+  }
 
   return str_tmp;
 }
@@ -256,9 +256,9 @@ std::string GnssReceiver::GetLogValue() const  // For logs
   str_tmp += logger::WriteScalar(geodetic_position_.GetAltitude_m(), 10);
   str_tmp += logger::WriteScalar(is_gnss_visible_);
   str_tmp += logger::WriteScalar(visible_satellite_number_);
-  // for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
-  //   str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 16);
-  // }
+  for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
+    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 16);
+  }
 
   return str_tmp;
 }

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -69,16 +69,16 @@ void GnssReceiver::MainRoutine(const int time_count) {
   CheckAntenna(position_true_eci, quaternion_i2b);
 
   // Pseudorange calculation
-  size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
-  for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
-    math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
-    double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
-    randomization::NormalRand pseudorange_random_noise_m;
-    pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
-    double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
-    pseudorange_list_m_[i] = pseudorange_m;
-  }
+  // size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
+  // for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
+  //   math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
+  //   math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
+  //   double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
+  //   randomization::NormalRand pseudorange_random_noise_m;
+  //   pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
+  //   double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
+  //   pseudorange_list_m_[i] = pseudorange_m;
+  // }
 
   if (is_gnss_visible_) {
     // Antenna of GNSS-R can detect GNSS signal
@@ -233,9 +233,9 @@ std::string GnssReceiver::GetLogHeader() const  // For logs
   str_tmp += logger::WriteScalar(sensor_name + "measured_altitude", "m");
   str_tmp += logger::WriteScalar(sensor_name + "satellite_visible_flag");
   str_tmp += logger::WriteScalar(sensor_name + "number_of_visible_satellites");
-  for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
-    str_tmp += logger::WriteScalar("GPS" + std::to_string(gps_index) + "_pseudorange", "m");
-  }
+  // for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
+  //   str_tmp += logger::WriteScalar("GPS" + std::to_string(gps_index) + "_pseudorange", "m");
+  // }
 
   return str_tmp;
 }
@@ -256,9 +256,9 @@ std::string GnssReceiver::GetLogValue() const  // For logs
   str_tmp += logger::WriteScalar(geodetic_position_.GetAltitude_m(), 10);
   str_tmp += logger::WriteScalar(is_gnss_visible_);
   str_tmp += logger::WriteScalar(visible_satellite_number_);
-  for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
-    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 16);
-  }
+  // for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
+  //   str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 16);
+  // }
 
   return str_tmp;
 }

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -186,18 +186,18 @@ void GnssReceiver::SetGnssInfo(const math::Vector<3> antenna_to_satellite_i_m, c
   gnss_information_list_.push_back(gnss_info_new);
 }
 
-double GnssReceiver::CalcGeometricDistance(const size_t gnss_system_id) {
+double GnssReceiver::CalcGeometricDistance_m(const size_t gnss_system_id) {
   math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(gnss_system_id);
   math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
   double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
   return geometric_distance_m;
 }
 
-double GnssReceiver::CalcPseudorange(const size_t gnss_system_id) {
+double GnssReceiver::CalcPseudorange_m(const size_t gnss_system_id) {
   // TODO: Add effect of radio wave propagation time
   // TODO: Add effect of clock bias
   // TODO: Add ionospheric delay
-  double geometric_distance_m = CalcGeometricDistance(gnss_system_id);
+  double geometric_distance_m = CalcGeometricDistance_m(gnss_system_id);
   double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m_;
   return pseudorange_m;
 }
@@ -207,7 +207,7 @@ void GnssReceiver::SetGnssObservationList() {
   pseudorange_list_m_.assign(kTotalNumberOfGnssSatellite, 0.0);
   for (size_t i = 0; i < gnss_information_list_.size(); i++) {
     size_t gnss_system_id = gnss_information_list_[i].gnss_id;
-    double pseudorange_m = CalcPseudorange(gnss_system_id);
+    double pseudorange_m = CalcPseudorange_m(gnss_system_id);
     pseudorange_list_m_[gnss_system_id] = pseudorange_m;
   }
 }

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -71,9 +71,9 @@ void GnssReceiver::MainRoutine(const int time_count) {
   // Pseudorange calculation
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    math::Vector<3> gnss_satellite_position_i_m = gnss_satellites_->GetPosition_eci_m(i);
-    math::Vector<3> position_true_i_m = dynamics_->GetOrbit().GetPosition_i_m();
-    double geometric_distance_m = (gnss_satellite_position_i_m - position_true_i_m).CalcNorm();
+    math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
+    math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
+    double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
     randomization::NormalRand pseudorange_random_noise_m;
     pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
     double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -71,8 +71,8 @@ void GnssReceiver::MainRoutine(const int time_count) {
   // Pseudorange calculation
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
-    // math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
+    // math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
+    math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
     // double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
     // randomization::NormalRand pseudorange_random_noise_m;
     // pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -71,13 +71,13 @@ void GnssReceiver::MainRoutine(const int time_count) {
   // Pseudorange calculation
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    // math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
+    math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
     // math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
-  //   double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
-  //   randomization::NormalRand pseudorange_random_noise_m;
-  //   pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
-  //   double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
-  //   pseudorange_list_m_[i] = pseudorange_m;
+    // double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
+    // randomization::NormalRand pseudorange_random_noise_m;
+    // pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
+    // double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
+    // pseudorange_list_m_[i] = pseudorange_m;
   }
 
   if (is_gnss_visible_) {

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -71,13 +71,13 @@ void GnssReceiver::MainRoutine(const int time_count) {
   // Pseudorange calculation
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-    math::Vector<3> gnss_satellite_position_ecef_m = math::Vector<3>(0.0);
-    math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
-    // double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
-    // randomization::NormalRand pseudorange_random_noise_m;
-    // pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
-    // double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
-    // pseudorange_list_m_[i] = pseudorange_m;
+    math::Vector<3> gnss_satellite_position_i_m = gnss_satellites_->GetPosition_eci_m(i);
+    math::Vector<3> position_true_i_m = dynamics_->GetOrbit().GetPosition_i_m();
+    double geometric_distance_m = (gnss_satellite_position_i_m - position_true_i_m).CalcNorm();
+    randomization::NormalRand pseudorange_random_noise_m;
+    pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
+    double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
+    pseudorange_list_m_[i] = pseudorange_m;
   }
 
   if (is_gnss_visible_) {

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -345,4 +345,3 @@ GnssReceiver InitGnssReceiver(environment::ClockGenerator* clock_generator, Powe
 }
 
 }  // namespace s2e::components
-

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -69,16 +69,16 @@ void GnssReceiver::MainRoutine(const int time_count) {
   CheckAntenna(position_true_eci, quaternion_i2b);
 
   // Pseudorange calculation
-  // size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
-  // for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
-  //   math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
-  //   math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
+  size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
+  for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
+    math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
+    math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
   //   double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
   //   randomization::NormalRand pseudorange_random_noise_m;
   //   pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
   //   double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
   //   pseudorange_list_m_[i] = pseudorange_m;
-  // }
+  }
 
   if (is_gnss_visible_) {
     // Antenna of GNSS-R can detect GNSS signal

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -72,9 +72,8 @@ void GnssReceiver::MainRoutine(const int time_count) {
   size_t number_of_calculated_gnss_satellites = gnss_satellites_->GetNumberOfCalculatedSatellite();
   for (size_t i = 0; i < number_of_calculated_gnss_satellites; i++) {
     math::Vector<3> gnss_satellite_position_ecef_m = gnss_satellites_->GetPosition_ecef_m(i);
-    math::Vector<3> receiver_position_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
-    math::Vector<3> a = gnss_satellite_position_ecef_m - receiver_position_ecef_m;
-    double geometric_distance_m = a.CalcNorm();
+    math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
+    double geometric_distance_m = (gnss_satellite_position_ecef_m - position_true_ecef_m).CalcNorm();
     randomization::NormalRand pseudorange_random_noise_m;
     pseudorange_random_noise_m.SetParameters(0.0, pseudorange_noise_standard_deviation_m_, randomization::global_randomization.MakeSeed());
     double pseudorange_m = geometric_distance_m + pseudorange_random_noise_m;
@@ -258,7 +257,7 @@ std::string GnssReceiver::GetLogValue() const  // For logs
   str_tmp += logger::WriteScalar(is_gnss_visible_);
   str_tmp += logger::WriteScalar(visible_satellite_number_);
   for (size_t gps_index = 0; gps_index < kNumberOfGpsSatellite; gps_index++) {
-    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 16);
+    str_tmp += logger::WriteScalar(pseudorange_list_m_[gps_index], 10);
   }
 
   return str_tmp;

--- a/src/components/real/aocs/gnss_receiver.hpp
+++ b/src/components/real/aocs/gnss_receiver.hpp
@@ -18,6 +18,15 @@
 
 namespace s2e::components {
 
+// GNSS satellite number definition
+// TODO: Move to initialized file?
+const size_t kNumberOfGpsSatellite = 32;      //!< Number of GPS satellites
+const size_t kNumberOfGlonassSatellite = 26;  //!< Number of GLONASS satellites
+const size_t kNumberOfGalileoSatellite = 28;  //!< Number of Galileo satellites
+const size_t kNumberOfBeidouSatellite = 62;   //!< Number of BeiDou satellites
+const size_t kNumberOfQzssSatellite = 5;      //!< Number of QZSS satellites
+const size_t kNumberOfNavicSatellite = 7;     //!< Number of NavIC satellites
+
 /**
  * @enum AntennaModel
  * @brief Antenna pattern model to emulate GNSS antenna
@@ -54,6 +63,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
    * @param [in] antenna_position_b_m: GNSS antenna position at the body-fixed frame [m]
    * @param [in] quaternion_b2c: Quaternion from body frame to component frame (antenna frame)
    * @param [in] half_width_deg: Half width of the antenna cone model [deg]
+   * @param [in] pseudorange_noise_standard_deviation_m: Standard deviation of normal random noise for pseudorange [m]
    * @param [in] position_noise_standard_deviation_ecef_m: Standard deviation of normal random noise for position in the ECEF frame [m]
    * @param [in] velocity_noise_standard_deviation_ecef_m_s: Standard deviation of normal random noise for velocity in the ECEF frame [m/s]
    * @param [in] dynamics: Dynamics information
@@ -62,9 +72,9 @@ class GnssReceiver : public Component, public logger::ILoggable {
    */
   GnssReceiver(const int prescaler, environment::ClockGenerator* clock_generator, const size_t component_id, const AntennaModel antenna_model,
                const math::Vector<3> antenna_position_b_m, const math::Quaternion quaternion_b2c, const double half_width_deg,
-               const math::Vector<3> position_noise_standard_deviation_ecef_m, const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s,
-               const dynamics::Dynamics* dynamics, const environment::GnssSatellites* gnss_satellites,
-               const environment::SimulationTime* simulation_time);
+               const double pseudorange_noise_standard_deviation_m, const math::Vector<3> position_noise_standard_deviation_ecef_m,
+               const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const dynamics::Dynamics* dynamics,
+               const environment::GnssSatellites* gnss_satellites, const environment::SimulationTime* simulation_time);
   /**
    * @fn GnssReceiver
    * @brief Constructor with power port
@@ -76,6 +86,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
    * @param [in] quaternion_b2c: Quaternion from body frame to component frame (antenna frame)
    * @param [in] half_width_deg: Half width of the antenna cone model [rad]
    * @param [in] position_noise_standard_deviation_ecef_m: Standard deviation of normal random noise for position in the ECEF frame [m]
+   * @param [in] position_noise_standard_deviation_ecef_m: Standard deviation of normal random noise for position in the ECEF frame [m]
    * @param [in] velocity_noise_standard_deviation_ecef_m_s: Standard deviation of normal random noise for velocity in the ECEF frame [m/s]
    * @param [in] dynamics: Dynamics information
    * @param [in] gnss_satellites: GNSS Satellites information
@@ -83,9 +94,10 @@ class GnssReceiver : public Component, public logger::ILoggable {
    */
   GnssReceiver(const int prescaler, environment::ClockGenerator* clock_generator, PowerPort* power_port, const size_t component_id,
                const AntennaModel antenna_model, const math::Vector<3> antenna_position_b_m, const math::Quaternion quaternion_b2c,
-               const double half_width_deg, const math::Vector<3> position_noise_standard_deviation_ecef_m,
-               const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const dynamics::Dynamics* dynamics,
-               const environment::GnssSatellites* gnss_satellites, const environment::SimulationTime* simulation_time);
+               const double half_width_deg, const double pseudorange_noise_standard_deviation_m,
+               const math::Vector<3> position_noise_standard_deviation_ecef_m, const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s,
+               const dynamics::Dynamics* dynamics, const environment::GnssSatellites* gnss_satellites,
+               const environment::SimulationTime* simulation_time);
 
   // Override functions for Component
   /**
@@ -138,6 +150,10 @@ class GnssReceiver : public Component, public logger::ILoggable {
   math::Quaternion quaternion_b2c_;       //!< Quaternion from body frame to component frame (antenna frame)
   double half_width_deg_ = 0.0;           //!< Half width of the antenna cone model [deg]
   AntennaModel antenna_model_;            //!< Antenna model
+
+  // GNSS observation
+  double pseudorange_noise_standard_deviation_m_;           //!< Random noise for pseudorange [m]
+  math::Vector<kNumberOfGpsSatellite> pseudorange_list_m_;  //!< Pseudorange list for each GPS satellite
 
   // Simple position observation
   randomization::NormalRand position_random_noise_ecef_m_[3];    //!< Random noise for position at the ECEF frame [m]

--- a/src/components/real/aocs/gnss_receiver.hpp
+++ b/src/components/real/aocs/gnss_receiver.hpp
@@ -220,14 +220,14 @@ class GnssReceiver : public Component, public logger::ILoggable {
    * @param [in] gnss_system_id: ID of target GNSS satellite
    * @return Geometric distance between the GNSS satellite and the GNSS receiver antenna [m]
    */
-  double CalcGeometricDistance(const size_t gnss_system_id);
+  double CalcGeometricDistance_m(const size_t gnss_system_id);
   /**
    * @fn CalcPseudorange
    * @brief Calculate the pseudorange between the GNSS satellite and the GNSS receiver antenna
    * @param [in] gnss_system_id: ID of target GNSS satellite
    * @return Pseudorange between the GNSS satellite and the GNSS receiver antenna [m]
    */
-  double CalcPseudorange(const size_t gnss_id);
+  double CalcPseudorange_m(const size_t gnss_id);
   /**
    * @fn SetGnssObservationList
    * @brief Calculate and set the GNSS observation list for each GNSS satellite

--- a/src/components/real/aocs/gnss_receiver.hpp
+++ b/src/components/real/aocs/gnss_receiver.hpp
@@ -85,7 +85,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
    * @param [in] antenna_position_b_m: GNSS antenna position at the body-fixed frame [m]
    * @param [in] quaternion_b2c: Quaternion from body frame to component frame (antenna frame)
    * @param [in] half_width_deg: Half width of the antenna cone model [rad]
-   * @param [in] position_noise_standard_deviation_ecef_m: Standard deviation of normal random noise for position in the ECEF frame [m]
+   * @param [in] pseudorange_noise_standard_deviation_m: Standard deviation of normal random noise for pseudorange [m]
    * @param [in] position_noise_standard_deviation_ecef_m: Standard deviation of normal random noise for position in the ECEF frame [m]
    * @param [in] velocity_noise_standard_deviation_ecef_m_s: Standard deviation of normal random noise for velocity in the ECEF frame [m/s]
    * @param [in] dynamics: Dynamics information
@@ -264,3 +264,4 @@ GnssReceiver InitGnssReceiver(environment::ClockGenerator* clock_generator, Powe
 }  // namespace s2e::components
 
 #endif  // S2E_COMPONENTS_REAL_AOCS_GNSS_RECEIVER_HPP_
+

--- a/src/components/real/aocs/gnss_receiver.hpp
+++ b/src/components/real/aocs/gnss_receiver.hpp
@@ -264,4 +264,3 @@ GnssReceiver InitGnssReceiver(environment::ClockGenerator* clock_generator, Powe
 }  // namespace s2e::components
 
 #endif  // S2E_COMPONENTS_REAL_AOCS_GNSS_RECEIVER_HPP_
-


### PR DESCRIPTION
## Related issues
[#600](https://github.com/ut-issl/s2e-core/issues/600)

## Description
擬似距離の計算を以下の式に従って追加した．
擬似距離=幾何学的距離+白色ノイズ
また各GPSから得られる擬似距離と，擬似距離と幾何学的距離の差をプロットするコードを追加した．

## Test results
gnss_receiver.iniのprescaler は 1とした．
【各GPSから得られる擬似距離の値】
![pseudorange](https://github.com/user-attachments/assets/9e061bab-794b-411d-b8d1-19fdba49ffd4)

【擬似距離の白色ノイズ標準偏差を0mとしたときの擬似距離と幾何学的距離の差】
差は10^-8m程度である．
![pseudorange_error_0](https://github.com/user-attachments/assets/5732b389-d343-4e49-926d-12be77b11497)

【擬似距離の白色ノイズ標準偏差を10mとしたときの擬似距離と幾何学的距離の差】
差は3シグマである30m以内にほぼ収まっている．
![pseudorange_error](https://github.com/user-attachments/assets/8941cf79-7ef2-4286-8d6a-a2eeb46b760e)


## Impact
Describe the scope of influence of the changes, e.g., `The behavior of feature ** changes.`

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
