### PR TITLE
battery.cppのパラメータ指定の誤りを訂正

### DIFF
--- a/src/components/real/power/battery.cpp
+++ b/src/components/real/power/battery.cpp
@@ -119,7 +119,7 @@ Battery InitBAT(environment::ClockGenerator* clock_generator, int bat_id, const 
   initial_dod = bat_conf.ReadDouble(section_name.c_str(), "initial_dod");
 
   double cc_charge_c_rate;
-  cc_charge_c_rate = bat_conf.ReadDouble(section_name.c_str(), "constant_charge_current_A_rate_C");
+  cc_charge_c_rate = bat_conf.ReadDouble(section_name.c_str(), "constant_charge_current_rate_C");
 
   double cv_charge_voltage_V;
   cv_charge_voltage_V = bat_conf.ReadDouble(section_name.c_str(), "constant_voltage_charge_voltage_V");


### PR DESCRIPTION
## Related issues
Mention any issues that this pull request is related (e.g., #1). Consider using the `development` field if you want to close the issue automatically when this pull request is merged.

## Description
battery.cppにてCC充電時の電流値を引数にとる際、パラメータ名をconstant_charge_current_rate_Cとすべきところをconstant_charge_current_A_rate_Cとしてしまい引用できず、cc充電が模擬できなくなっていたので修正した。

## Test results
Provide the test results and a link to the detailed results log.

## Impact
Describe the scope of influence of the changes, e.g., `The behavior of feature ** changes.`

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
