### PR TITLE
Add effect of radio wave propagation time to geometric distance calculation

### DIFF
--- a/settings/sample_satellite/components/gnss_receiver.ini
+++ b/settings/sample_satellite/components/gnss_receiver.ini
@@ -36,6 +36,9 @@ white_noise_standard_deviation_velocity_ecef_m_s(0) = 1.0
 white_noise_standard_deviation_velocity_ecef_m_s(1) = 1.5
 white_noise_standard_deviation_velocity_ecef_m_s(2) = 2.0
 
+// Logging
+pseudorange_logging = ENABLE
+
 [POWER_PORT]
 minimum_voltage_V = 3.3
 assumed_power_consumption_W = 1.0

--- a/settings/sample_satellite/components/gnss_receiver.ini
+++ b/settings/sample_satellite/components/gnss_receiver.ini
@@ -37,7 +37,7 @@ white_noise_standard_deviation_velocity_ecef_m_s(1) = 1.5
 white_noise_standard_deviation_velocity_ecef_m_s(2) = 2.0
 
 // Logging
-pseudorange_logging = ENABLE
+pseudorange_logging = DISABLE
 
 [POWER_PORT]
 minimum_voltage_V = 3.3

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -191,9 +191,14 @@ void GnssReceiver::SetGnssInfo(const math::Vector<3> antenna_to_satellite_i_m, c
 }
 
 double GnssReceiver::CalcGeometricDistance_m(const size_t gnss_system_id) {
-
   math::Vector<3> position_true_ecef_m = dynamics_->GetOrbit().GetPosition_ecef_m();
 
+  time_system::DateTime current_date_time((size_t)simulation_time_->GetStartYear(), (size_t)simulation_time_->GetStartMonth(),
+                                        (size_t)simulation_time_->GetStartDay(), (size_t)simulation_time_->GetStartHour(),
+                                        (size_t)simulation_time_->GetStartMinute(), simulation_time_->GetStartSecond());
+  time_system::EpochTime current_epoch_time(current_date_time);
+  time_system::EpochTime signal_travel_time_s((gnss_satellites_->GetPosition_ecef_m(gnss_system_id) - position_true_ecef_m).CalcNorm() / environment::speed_of_light_m_s);
+  time_system::EpochTime signal_emission_time = current_epoch_time - signal_travel_time_s;
   
   double geometric_distance_m = (gnss_satellites_->GetPosition_ecef_m(gnss_system_id) - position_true_ecef_m).CalcNorm();
   return geometric_distance_m;

--- a/src/components/real/aocs/gnss_receiver.cpp
+++ b/src/components/real/aocs/gnss_receiver.cpp
@@ -202,9 +202,12 @@ double GnssReceiver::CalcGeometricDistance_m(const size_t gnss_system_id) {
   time_system::EpochTime signal_emission_epoch_time(current_epoch_time.GetTimeWithFraction_s() - signal_travel_time_s);
 
   math::Vector<3> gnss_position_at_signal_emission_ecef_m = gnss_satellites_->GetPosition_ecef_m(gnss_system_id, signal_emission_epoch_time);
+
+  math::Vector<3> earth_angular_velocity_rad_s{0.0};
+  earth_angular_velocity_rad_s[2] = environment::earth_mean_angular_velocity_rad_s;
+
   double sagnac_correction_m =
-      environment::earth_mean_angular_velocity_rad_s *
-      (gnss_position_at_signal_emission_ecef_m[0] * position_true_ecef_m[1] - gnss_position_at_signal_emission_ecef_m[1] * position_true_ecef_m[0]) /
+      InnerProduct(OuterProduct(gnss_position_at_signal_emission_ecef_m, position_true_ecef_m), earth_angular_velocity_rad_s) /
       environment::speed_of_light_m_s;
 
   double geometric_distance_m = (gnss_position_at_signal_emission_ecef_m - position_true_ecef_m).CalcNorm() + sagnac_correction_m;

--- a/src/components/real/aocs/gnss_receiver.hpp
+++ b/src/components/real/aocs/gnss_receiver.hpp
@@ -65,8 +65,9 @@ class GnssReceiver : public Component, public logger::ILoggable {
   GnssReceiver(const int prescaler, environment::ClockGenerator* clock_generator, const size_t component_id, const AntennaModel antenna_model,
                const math::Vector<3> antenna_position_b_m, const math::Quaternion quaternion_b2c, const double half_width_deg,
                const double pseudorange_noise_standard_deviation_m, const math::Vector<3> position_noise_standard_deviation_ecef_m,
-               const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const bool is_log_pseudorange_enabled, const dynamics::Dynamics* dynamics,
-               const environment::GnssSatellites* gnss_satellites, const environment::SimulationTime* simulation_time);
+               const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const bool is_log_pseudorange_enabled,
+               const dynamics::Dynamics* dynamics, const environment::GnssSatellites* gnss_satellites,
+               const environment::SimulationTime* simulation_time);
   /**
    * @fn GnssReceiver
    * @brief Constructor with power port
@@ -88,8 +89,8 @@ class GnssReceiver : public Component, public logger::ILoggable {
   GnssReceiver(const int prescaler, environment::ClockGenerator* clock_generator, PowerPort* power_port, const size_t component_id,
                const AntennaModel antenna_model, const math::Vector<3> antenna_position_b_m, const math::Quaternion quaternion_b2c,
                const double half_width_deg, const double pseudorange_noise_standard_deviation_m,
-               const math::Vector<3> position_noise_standard_deviation_ecef_m, const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const bool is_log_pseudorange_enabled,
-               const dynamics::Dynamics* dynamics, const environment::GnssSatellites* gnss_satellites,
+               const math::Vector<3> position_noise_standard_deviation_ecef_m, const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s,
+               const bool is_log_pseudorange_enabled, const dynamics::Dynamics* dynamics, const environment::GnssSatellites* gnss_satellites,
                const environment::SimulationTime* simulation_time);
 
   // Override functions for Component
@@ -160,7 +161,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
   // GNSS observation
   randomization::NormalRand pseudorange_random_noise_m_;                      //!< Random noise for pseudorange [m]
   std::vector<double> pseudorange_list_m_{kTotalNumberOfGnssSatellite, 0.0};  //!< Pseudorange list for each GPS satellite
-  bool is_logged_pseudorange_; //!< Flag for log output of pseudorange
+  bool is_logged_pseudorange_;                                                //!< Flag for log output of pseudorange
 
   // Simple position observation
   randomization::NormalRand position_random_noise_ecef_m_[3];    //!< Random noise for position at the ECEF frame [m]

--- a/src/components/real/aocs/gnss_receiver.hpp
+++ b/src/components/real/aocs/gnss_receiver.hpp
@@ -57,6 +57,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
    * @param [in] pseudorange_noise_standard_deviation_m: Standard deviation of normal random noise for pseudorange [m]
    * @param [in] position_noise_standard_deviation_ecef_m: Standard deviation of normal random noise for position in the ECEF frame [m]
    * @param [in] velocity_noise_standard_deviation_ecef_m_s: Standard deviation of normal random noise for velocity in the ECEF frame [m/s]
+   * @param [in] is_log_pseudorange_enabled: Enable flag to log output pseudorange
    * @param [in] dynamics: Dynamics information
    * @param [in] gnss_satellites: GNSS Satellites information
    * @param [in] simulation_time: Simulation time information
@@ -64,7 +65,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
   GnssReceiver(const int prescaler, environment::ClockGenerator* clock_generator, const size_t component_id, const AntennaModel antenna_model,
                const math::Vector<3> antenna_position_b_m, const math::Quaternion quaternion_b2c, const double half_width_deg,
                const double pseudorange_noise_standard_deviation_m, const math::Vector<3> position_noise_standard_deviation_ecef_m,
-               const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const dynamics::Dynamics* dynamics,
+               const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const bool is_log_pseudorange_enabled, const dynamics::Dynamics* dynamics,
                const environment::GnssSatellites* gnss_satellites, const environment::SimulationTime* simulation_time);
   /**
    * @fn GnssReceiver
@@ -79,6 +80,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
    * @param [in] pseudorange_noise_standard_deviation_m: Standard deviation of normal random noise for pseudorange [m]
    * @param [in] position_noise_standard_deviation_ecef_m: Standard deviation of normal random noise for position in the ECEF frame [m]
    * @param [in] velocity_noise_standard_deviation_ecef_m_s: Standard deviation of normal random noise for velocity in the ECEF frame [m/s]
+   * @param [in] is_log_pseudorange_enabled: Enable flag to log output pseudorange
    * @param [in] dynamics: Dynamics information
    * @param [in] gnss_satellites: GNSS Satellites information
    * @param [in] simulation_time: Simulation time information
@@ -86,7 +88,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
   GnssReceiver(const int prescaler, environment::ClockGenerator* clock_generator, PowerPort* power_port, const size_t component_id,
                const AntennaModel antenna_model, const math::Vector<3> antenna_position_b_m, const math::Quaternion quaternion_b2c,
                const double half_width_deg, const double pseudorange_noise_standard_deviation_m,
-               const math::Vector<3> position_noise_standard_deviation_ecef_m, const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s,
+               const math::Vector<3> position_noise_standard_deviation_ecef_m, const math::Vector<3> velocity_noise_standard_deviation_ecef_m_s, const bool is_log_pseudorange_enabled,
                const dynamics::Dynamics* dynamics, const environment::GnssSatellites* gnss_satellites,
                const environment::SimulationTime* simulation_time);
 
@@ -158,6 +160,7 @@ class GnssReceiver : public Component, public logger::ILoggable {
   // GNSS observation
   randomization::NormalRand pseudorange_random_noise_m_;                      //!< Random noise for pseudorange [m]
   std::vector<double> pseudorange_list_m_{kTotalNumberOfGnssSatellite, 0.0};  //!< Pseudorange list for each GPS satellite
+  bool is_logged_pseudorange_; //!< Flag for log output of pseudorange
 
   // Simple position observation
   randomization::NormalRand position_random_noise_ecef_m_[3];    //!< Random noise for position at the ECEF frame [m]

--- a/src/environment/global/simulation_time.cpp
+++ b/src/environment/global/simulation_time.cpp
@@ -49,6 +49,7 @@ SimulationTime::SimulationTime(const double end_sec, const double step_sec, cons
   current_sidereal_ = gstime(current_jd_);
   JdToDecyear(current_jd_, &current_decyear_);
   ConvJDtoCalendarDay(current_jd_);
+  ConvCalendarDayToEpochTime();
   AssertTimeStepParams();
   InitializeState();
   SetParameters();
@@ -139,6 +140,7 @@ void SimulationTime::UpdateTime(void) {
   current_sidereal_ = gstime(current_jd_);
   JdToDecyear(current_jd_, &current_decyear_);
   ConvJDtoCalendarDay(current_jd_);
+  ConvCalendarDayToEpochTime();
 
   attitude_update_flag_ = false;
   if (double(attitude_update_counter_) * step_sec_ >= attitude_update_interval_sec_) {
@@ -244,6 +246,12 @@ void SimulationTime::ConvJDtoCalendarDay(const double JD) {
   current_utc_.hour = (unsigned int)(hr);
   current_utc_.minute = (unsigned int)(minute);
   current_utc_.second = sec;
+}
+
+void SimulationTime::ConvCalendarDayToEpochTime() {
+  time_system::DateTime current_date_time((size_t)current_utc_.year, (size_t)current_utc_.month, (size_t)current_utc_.day, (size_t)current_utc_.hour,
+                                          (size_t)current_utc_.minute, current_utc_.second);
+  current_epoch_time_ = time_system::EpochTime(current_date_time);
 }
 
 SimulationTime* InitSimulationTime(std::string file_name) {

--- a/src/environment/global/simulation_time.cpp
+++ b/src/environment/global/simulation_time.cpp
@@ -49,7 +49,7 @@ SimulationTime::SimulationTime(const double end_sec, const double step_sec, cons
   current_sidereal_ = gstime(current_jd_);
   JdToDecyear(current_jd_, &current_decyear_);
   ConvJDtoCalendarDay(current_jd_);
-  ConvCalendarDayToEpochTime();
+  ConvertCalendarDayToEpochTime();
   AssertTimeStepParams();
   InitializeState();
   SetParameters();
@@ -140,7 +140,7 @@ void SimulationTime::UpdateTime(void) {
   current_sidereal_ = gstime(current_jd_);
   JdToDecyear(current_jd_, &current_decyear_);
   ConvJDtoCalendarDay(current_jd_);
-  ConvCalendarDayToEpochTime();
+  ConvertCalendarDayToEpochTime();
 
   attitude_update_flag_ = false;
   if (double(attitude_update_counter_) * step_sec_ >= attitude_update_interval_sec_) {
@@ -248,7 +248,7 @@ void SimulationTime::ConvJDtoCalendarDay(const double JD) {
   current_utc_.second = sec;
 }
 
-void SimulationTime::ConvCalendarDayToEpochTime() {
+void SimulationTime::ConvertCalendarDayToEpochTime() {
   time_system::DateTime current_date_time((size_t)current_utc_.year, (size_t)current_utc_.month, (size_t)current_utc_.day, (size_t)current_utc_.hour,
                                           (size_t)current_utc_.minute, current_utc_.second);
   current_epoch_time_ = time_system::EpochTime(current_date_time);

--- a/src/environment/global/simulation_time.hpp
+++ b/src/environment/global/simulation_time.hpp
@@ -18,6 +18,7 @@
 #include "math_physics/orbit/sgp4/sgp4ext.h"
 #include "math_physics/orbit/sgp4/sgp4io.h"
 #include "math_physics/orbit/sgp4/sgp4unit.h"
+#include "math_physics/time_system/epoch_time.hpp"
 
 namespace s2e::environment {
 
@@ -209,6 +210,11 @@ class SimulationTime : public logger::ILoggable {
    *@brief Return current Ephemeris time
    */
   inline double GetCurrentEphemerisTime(void) const { return start_ephemeris_time_ + elapsed_time_sec_; };
+  /**
+   *@fn GetCurrentEpochTime
+   *@brief Return current epoch time
+   */
+  inline const time_system::EpochTime GetCurrentEpochTime(void) const { return current_epoch_time_; };
 
   /**
    *@fn GetStartYear
@@ -261,11 +267,12 @@ class SimulationTime : public logger::ILoggable {
 
  private:
   // Variables
-  double elapsed_time_sec_;  //!< Elapsed time from start of simulation [sec]
-  double current_jd_;        //!< Current Julian date [day]
-  double current_sidereal_;  //!< Current Greenwich sidereal time (GST) [day]
-  double current_decyear_;   //!< Current decimal year [year]
-  UTC current_utc_;          //!< UTC calendar day
+  double elapsed_time_sec_;                    //!< Elapsed time from start of simulation [sec]
+  double current_jd_;                          //!< Current Julian date [day]
+  double current_sidereal_;                    //!< Current Greenwich sidereal time (GST) [day]
+  double current_decyear_;                     //!< Current decimal year [year]
+  UTC current_utc_;                            //!< UTC calendar day
+  time_system::EpochTime current_epoch_time_;  //!< Current epoch time
 
   // Timing controller
   int attitude_update_counter_;   //!< Update counter for attitude calculation
@@ -327,6 +334,11 @@ class SimulationTime : public logger::ILoggable {
    * @note wrapper function of invjday @ sgp4ext for interface adjustment
    */
   void ConvJDtoCalendarDay(const double JD);
+  /**
+   * @fn ConvCalendarDayToEpochTime
+   * @brief Convert calendar date to epoch time
+   */
+  void ConvCalendarDayToEpochTime();
 };
 
 /**

--- a/src/environment/global/simulation_time.hpp
+++ b/src/environment/global/simulation_time.hpp
@@ -338,7 +338,7 @@ class SimulationTime : public logger::ILoggable {
    * @fn ConvCalendarDayToEpochTime
    * @brief Convert calendar date to epoch time
    */
-  void ConvCalendarDayToEpochTime();
+  void ConvertCalendarDayToEpochTime();
 };
 
 /**

--- a/src/math_physics/time_system/epoch_time.cpp
+++ b/src/math_physics/time_system/epoch_time.cpp
@@ -32,6 +32,11 @@ EpochTime::EpochTime(const DateTime date_time) {
   fraction_s_ = date_time.GetSecond() - (double)second;
 }
 
+EpochTime::EpochTime(const double time_with_fraction_s) {
+  time_s_ = static_cast<uint64_t>(std::floor(time_with_fraction_s));
+  fraction_s_ = time_with_fraction_s - static_cast<double>(time_s_);
+}
+
 bool EpochTime::operator==(const EpochTime& target) const {
   if (this->time_s_ != target.time_s_) return false;
   if (this->fraction_s_ != target.fraction_s_) return false;  // TODO: comparison of double

--- a/src/math_physics/time_system/epoch_time.cpp
+++ b/src/math_physics/time_system/epoch_time.cpp
@@ -33,8 +33,13 @@ EpochTime::EpochTime(const DateTime date_time) {
 }
 
 EpochTime::EpochTime(const double time_with_fraction_s) {
-  time_s_ = static_cast<uint64_t>(std::floor(time_with_fraction_s));
-  fraction_s_ = time_with_fraction_s - static_cast<double>(time_s_);
+  if (time_with_fraction_s < 0.0) {
+    time_s_ = 0;
+    fraction_s_ = 0.0;
+  } else {
+    time_s_ = static_cast<uint64_t>(std::floor(time_with_fraction_s));
+    fraction_s_ = time_with_fraction_s - static_cast<double>(time_s_);
+  }
 }
 
 bool EpochTime::operator==(const EpochTime& target) const {

--- a/src/math_physics/time_system/epoch_time.hpp
+++ b/src/math_physics/time_system/epoch_time.hpp
@@ -32,6 +32,11 @@ class EpochTime {
    */
   EpochTime(const DateTime date_time);
   /**
+   * @fn EpochTime
+   * @brief Constructor initialized with a double-precision time expression
+   */
+  EpochTime(const double time_with_fraction_s);
+  /**
    * @fn ~EpochTime
    * @brief Destructor
    */


### PR DESCRIPTION
## Related issues
[#600](https://github.com/ut-issl/s2e-core/issues/600)

## Description
以下を幾何学的距離の計算に追加した．
- 見かけの幾何学的距離（受信機に信号が届いた時刻における受信機とGNSS衛星との距離）から電波伝播時間を計算
- 受信機に信号が届いた時刻から電波伝播時間を差し引いた時刻におけるGNSS衛星の位置を計算
- その位置と受信機に信号が届いた時刻における受信機の距離を計算
- サニャック効果による補正量を追加

また，gnss_receiver.iniにpseudorange_loggingを追加し，擬似距離計算のログ出力をするかどうか設定できるようにした（前回実装し忘れていた）

## Test results
受信機に信号が届いた時刻における受信機とGNSS衛星との距離と，電波伝播時間とサニャック効果を考慮した擬似距離（ノイズを0としているので幾何学的距離に等しい）との差をプロットした．
<img width="1249" alt="スクリーンショット 2025-02-01 12 15 13" src="https://github.com/user-attachments/assets/d3de5f7b-a62c-4793-ad3a-27306a0a6af4" />


## Impact
Describe the scope of influence of the changes, e.g., `The behavior of feature ** changes.`

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
