### PR TITLE
Fix smalls for the example directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ Icon
 __pycache__/
 
 # Setting files
-settings/environment/cspice
-settings/environment/space_weather
-settings/environment/gravity_field
-settings/environment/star_catalogue
+**/settings/environment/cspice
+**/settings/environment/space_weather
+**/settings/environment/gravity_field
+**/settings/environment/star_catalogue

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cmake.sourceDirectory": "${workspaceFolder}/example",
+  "cmake.buildDirectory": "${workspaceFolder}/example/build/"
+}

--- a/example/settings/sample_simulation_base.ini
+++ b/example/settings/sample_simulation_base.ini
@@ -147,4 +147,4 @@ number_of_simulated_ground_station = 1
 spacecraft_file(0)      = SETTINGS_DIR_FROM_EXE/sample_satellite/satellite.ini
 ground_station_file(0)  = SETTINGS_DIR_FROM_EXE/sample_ground_station/ground_station.ini
 gnss_file               = SETTINGS_DIR_FROM_EXE/environment/sample_gnss.ini
-log_file_save_directory = ../../logs/
+log_file_save_directory = ../logs/


### PR DESCRIPTION
## Related issues
NA

## Description
exampleディレクトリができた関係で、簡単にs2e-coreを実行できるようにするため次のような微修正を行った
- logsディレクトリをexampleの下に移動させた
- gitignoreの設定を変えた
- VSCodeユーザーに対して、cmakeのディレクトリ設定を行う設定ファイルを追加した。

## Test results
See CI

## Impact
使いやすくなっただけで実態はあまり変わらないはず。

## Supplementary information
NA

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
