### PR TITLE
[bug] fix equation related to cantilever

### DIFF
--- a/src/dynamics/attitude/attitude_with_cantilever_vibration.cpp
+++ b/src/dynamics/attitude/attitude_with_cantilever_vibration.cpp
@@ -32,8 +32,9 @@ AttitudeWithCantileverVibration::AttitudeWithCantileverVibration(
   double spring_coefficient = pow(intrinsic_angular_velocity_cantilever_rad_s, 2.0);
   attitude_ode_.SetSpringCoefficient(spring_coefficient);
   attitude_ode_.SetInverseInertiaTensor(CalcInverseMatrix(inertia_tensor_kgm2_));
+  attitude_ode_.SetInverseTotalInertiaTensor(CalcInverseMatrix(inertia_tensor_kgm2_ + inertia_tensor_cantilever_kgm2));
   math::Matrix<3, 3> inverse_equivalent_inertia_tensor_cantilever =
-      CalcInverseMatrix(inertia_tensor_kgm2_ - inertia_tensor_cantilever_kgm2) * inertia_tensor_kgm2_;
+      attitude_ode_.GetInverseInertiaTensor() * (inertia_tensor_kgm2_ + inertia_tensor_cantilever_kgm2);
   attitude_ode_.SetInverseEquivalentInertiaTensorCantilever(inverse_equivalent_inertia_tensor_cantilever);
   attitude_ode_.SetTorque_b_Nm(torque_b_Nm_);
   attitude_ode_.SetAngularMomentumReactionWheel_b_Nms(angular_momentum_reaction_wheel_b_Nms_);

--- a/src/dynamics/attitude/ode_attitude_with_cantilever_vibration.hpp
+++ b/src/dynamics/attitude/ode_attitude_with_cantilever_vibration.hpp
@@ -90,7 +90,8 @@ class AttitudeWithCantileverVibrationOde : public numerical_integration::Interfa
           (attenuation_coefficient_ * omega_cantilever_rad_s + spring_coefficient_ * euler_angle_cantilever_rad)) -
         inverse_inertia_tensor_ * net_torque_b_Nm;
 
-    math::Vector<3> rhs = inverse_inertia_tensor_ * (net_torque_b_Nm - inertia_tensor_cantilever_kgm2_ * angular_accelaration_cantilever_rad_s2);
+    math::Vector<3> rhs =
+        inverse_total_inertia_tensor_ * (net_torque_b_Nm - inertia_tensor_cantilever_kgm2_ * angular_accelaration_cantilever_rad_s2);
 
     for (size_t i = 0; i < 3; ++i) {
       output[i] = rhs[i];
@@ -152,6 +153,11 @@ class AttitudeWithCantileverVibrationOde : public numerical_integration::Interfa
    * @brief Get inverse of inertia tensor of the cantilever
    */
   inline math::Matrix<3, 3> GetInverseEquivalentInertiaTensorCantilever() { return inverse_equivalent_inertia_tensor_cantilever_; }
+  /**
+   * @fn GetInverseTotalInertiaTensor
+   * @brief Get inverse of total inertia tensor
+   */
+  inline math::Matrix<3, 3> GetInverseTotalInertiaTensor() { return inverse_total_inertia_tensor_; }
 
   // Setter
   /**
@@ -209,6 +215,13 @@ class AttitudeWithCantileverVibrationOde : public numerical_integration::Interfa
   inline void SetInverseEquivalentInertiaTensorCantilever(const math::Matrix<3, 3> inverse_equivalent_inertia_tensor_cantilever) {
     inverse_equivalent_inertia_tensor_cantilever_ = inverse_equivalent_inertia_tensor_cantilever;
   }
+  /**
+   * @fn SetInverseTotalInertiaTensor
+   * @brief Set inverse of total inertia tensor
+   */
+  inline void SetInverseTotalInertiaTensor(const math::Matrix<3, 3> inverse_total_inertia_tensor) {
+    inverse_total_inertia_tensor_ = inverse_total_inertia_tensor;
+  }
 
  protected:
   double attenuation_coefficient_ = 0.0;                                  //!< Attenuation coefficient
@@ -220,6 +233,7 @@ class AttitudeWithCantileverVibrationOde : public numerical_integration::Interfa
   math::Matrix<3, 3> previous_inertia_tensor_kgm2_{0.0};                  //!< Previous inertia tensor [kgm2]
   math::Matrix<3, 3> inertia_tensor_cantilever_kgm2_{0.0};                //!< Inertia tensor of the cantilever [kgm2]
   math::Matrix<3, 3> inverse_equivalent_inertia_tensor_cantilever_{0.0};  //!< Inverse of inertia tensor of the cantilever
+  math::Matrix<3, 3> inverse_total_inertia_tensor_{0.0};                  //!< Inverse of total inertia tensor
 };
 
 }  // namespace s2e::dynamics::attitude


### PR DESCRIPTION
## Related issues and pull requests
- #17
- #639 

## Description
柔軟構造が存在する衛星の姿勢ダイナミクスに関して一部計算式が異なっていたので修正。
#639 に記載している運動方程式 (2), (4) において $T'_c$ を式(5)のように定義する。

$I_p(\ddot{\psi}_b + \ddot{\psi}_d) + c_p\dot{\psi}_d + k_p\psi_d = 0$  (2)

$(I_b + I_p)\ddot{\psi}_b + I_p \ddot{\psi}_d  + \dot{\psi}_b \times \{(I_b + I_p)\dot{\psi}_b\} + (\textrm{Angular momentum})= T_c$  (4)

$T'_c = T_c - \dot{\psi}_b \times \{(I_b + I_p)\dot{\psi}_b\} - (\textrm{Angular momentum})$ (5)

この時、式(2), (4)から $\ddot{\psi}_b$ を消去すると

$\ddot{\psi}_d = -I_b^{-1} (I_b + I_p) I_p^{-1} (c_p \dot{\psi}_d + k_p\psi_d) - I_b^{-1}T'_c$ (6)

となる。

https://github.com/ut-issl/s2e-core/blob/4f2ccdb93372ae6def3b6fc0f3abf15f464e2deb/src/dynamics/attitude/attitude_with_cantilever_vibration.cpp#L30-L32

[attitude_with_cantilever_vibration.cpp](https://github.com/ut-issl/s2e-core/blob/4f2ccdb93372ae6def3b6fc0f3abf15f464e2deb/src/dynamics/attitude/attitude_with_cantilever_vibration.cpp)では

$I_p^{-1}c_p = 2 \zeta \omega, 　 I_p^{-1}k_p = \omega^2$ (7)

で与えられているので、`inverse_equivalent_inertia_tensor_cantilever`に与える行列は

$I_b^{-1} (I_b + I_p)$ (8)

となるはずである。

https://github.com/ut-issl/s2e-core/blob/4f2ccdb93372ae6def3b6fc0f3abf15f464e2deb/src/dynamics/attitude/attitude_with_cantilever_vibration.cpp#L35-L36

一方、実際に与えられている行列は

$(I_b - I_p)^{-1} I_b$ (9)

となり、 $I_b \to I_b + I_p$ で定義されてしまっている。

同様に、式(4)を式変形すると

$\ddot{\psi}_b = (I_b + I_p)^{-1}(T'_c - I_p\ddot{\psi}_d)$ (10)

となるはずだが、[ode_attitude_with_cantilever_vibration.hpp](https://github.com/ut-issl/s2e-core/blob/4f2ccdb93372ae6def3b6fc0f3abf15f464e2deb/src/dynamics/attitude/ode_attitude_with_cantilever_vibration.hpp)では式(11)のようになっており、式(10)に対して $I_b \to I_b + I_p$ となってしまっている。

$\ddot{\psi}_b = I_b^{-1}(T'_c - I_p\ddot{\psi}_d)$ (11)

https://github.com/ut-issl/s2e-core/blob/4f2ccdb93372ae6def3b6fc0f3abf15f464e2deb/src/dynamics/attitude/ode_attitude_with_cantilever_vibration.hpp#L93

よってこの2か所を修正した。

## Test results
伝搬式が誤っていたので、修正前後での比較を明確にできないが、計算が発散しないのかの確認だけは可能であるので修正前後での挙動について以下に結果を示した。
以下の計算結果は、c2aのinitialモードから400秒後にbdotに遷移したときのシミュレーション結果である。

修正前の柔軟構造の姿勢角変動
![image](https://github.com/user-attachments/assets/0473c628-f5c6-49aa-ad16-3841a076de59)

修正後の柔軟構造の姿勢角変動
![image](https://github.com/user-attachments/assets/8ba10c6f-0b1a-40f6-9d8d-1580919dc555)


## Impact
Describe the scope of influence of the changes, e.g., `The behavior of feature ** changes.`

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
