### PR TITLE
Fix simulation progress display not updating on Linux

### DIFF
--- a/src/simulation/case/simulation_case.cpp
+++ b/src/simulation/case/simulation_case.cpp
@@ -68,7 +68,7 @@ void SimulationCase::Main() {
 
     // Debug output
     if (global_environment_->GetSimulationTime().GetState().disp_output) {
-      std::cout << "Progress: " << global_environment_->GetSimulationTime().GetProgressionRate() << "%\r";
+      std::cout << "Progress: " << global_environment_->GetSimulationTime().GetProgressionRate() << "%\r" << std::flush;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `std::flush` to simulation progress output to fix display issue on Linux

## Details
Fixed an issue where the simulation progress percentage was not displaying properly on Linux environments.

The progress display uses `\r` (carriage return) to overwrite the same line, but on Linux, standard output is buffered and does not display immediately without explicitly calling `std::flush`.

### Changes
Added `<< std::flush` to the progress output at `src/simulation/case/simulation_case.cpp:72`.

## Test plan
- [x] Built and ran the example on Linux environment and confirmed that the progress percentage displays correctly

## Related Issues
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)