### PR TITLE
fix: NRLMSISE-00 宇宙天気テーブルのダウンロードURLをFTPからHTTPSに変更

### DIFF
--- a/ExtLibraries/nrlmsise00/CMakeLists.txt
+++ b/ExtLibraries/nrlmsise00/CMakeLists.txt
@@ -8,7 +8,7 @@ include(FetchContent)
 set(NRLMSISE_INSTALL_DIR ${EXT_LIB_DIR}/nrlmsise00)
 set(TABLE_FILE_INSTALL_DIR ${SETTINGS_DIR}/environment/space_weather)
 
-set(NRLMSISE_TABLE_URL_BASE ftp://ftp.agi.com/pub/DynamicEarthData)
+set(NRLMSISE_TABLE_URL_BASE https://ftp.agi.com/pub/DynamicEarthData)
 set(NRLMSISE_TABLE_FILE SpaceWeather-v1.2.txt)
 
 set(NRLMSISE_TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp)

--- a/scripts/Common/download_nrlmsise00_src_and_table.sh
+++ b/scripts/Common/download_nrlmsise00_src_and_table.sh
@@ -4,7 +4,7 @@ cd `dirname $0`
 #set variables
 DIR_NRLMSISE00=../../../ExtLibraries/nrlmsise00/
 URL_NRLMSISE00=git://git.linta.de/~brodo/nrlmsise-00.git
-URL_TABLE=ftp://ftp.agi.com/pub/DynamicEarthData/SpaceWeather-v1.2.txt
+URL_TABLE=https://ftp.agi.com/pub/DynamicEarthData/SpaceWeather-v1.2.txt
 
 mkdir -p $DIR_NRLMSISE00/table/
 mkdir -p $DIR_NRLMSISE00/src/


### PR DESCRIPTION
## Summary

- `ftp://ftp.agi.com` が停止しており、CIビルドが失敗していた
- 同じサーバーの `https://ftp.agi.com` から正常にアクセスできることを確認
- `ftp://` を `https://` に変更してビルドを修正する

## 変更ファイル

- `ExtLibraries/nrlmsise00/CMakeLists.txt`: CMakeによるダウンロードURLを修正
- `scripts/Common/download_nrlmsise00_src_and_table.sh`: レガシースクリプトのURLも合わせて修正

## Test plan

- [ ] CIの `build.yml` と `google-test.yml` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)