### PR TITLE
Fix setting default path in ExtLibraries CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,10 @@ jobs:
         shell: powershell
         run: |
           ls ./example/settings/environment/cspice
-          cp -r "./ExtLibraries/cspice/generic_kernels" "./example/settings/environment/cspice"
+          if (Test-Path "./example/settings/environment/cspice/generic_kernels") {
+            Remove-Item -Path "./example/settings/environment/cspice/generic_kernels" -Recurse -Force
+          }
+          Copy-Item -Path "./ExtLibraries/cspice/generic_kernels" -Destination "./example/settings/environment/cspice" -Recurse
           ls ./example/settings/environment/cspice
           ls ./example/settings/environment/cspice/generic_kernels/lsk
           ls ./example/settings/environment/cspice/generic_kernels/pck

--- a/ExtLibraries/CMakeLists.txt
+++ b/ExtLibraries/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT DEFINED EXT_LIB_DIR)
 endif()
 
 if(NOT DEFINED SETTINGS_DIR)
-  set(SETTINGS_DIR "${CMAKE_CURRENT_LIST_DIR}/../settings/")
+  set(SETTINGS_DIR "${CMAKE_CURRENT_LIST_DIR}/../example/settings/")
 endif()
 
 # windows path


### PR DESCRIPTION
## Related issues
NA

## Description
exampleの位置が変わったので、ExtLibrariesのデフォルトsettingsパスを変えた方が運用が楽になる。

## Test results
CIでは確認できない。ローカルでは確認した。

## Impact
デフォルトが変わるだけで、個別設定している場合は影響なし

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
