### PR TITLE
Modify Earth rotation calculation

### DIFF
--- a/src/environment/global/celestial_information.cpp
+++ b/src/environment/global/celestial_information.cpp
@@ -127,7 +127,7 @@ void CelestialInformation::UpdateAllObjectsInformation(const SimulationTime& sim
   }
 
   // Update earth rotation
-  earth_rotation_->Update(simulation_time.GetCurrentTime_jd());
+  earth_rotation_->Update(simulation_time);
   // Update moon rotation
   moon_rotation_->Update(simulation_time);
 }

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -13,7 +13,7 @@
 #include <sstream>
 
 #include "math_physics/math/constants.hpp"
-#include "math_physics/orbit/sgp4/sgp4ext.h"   // for jday()
+#include "math_physics/orbit/sgp4/sgp4ext.h"  // for jday()
 #include "simulation_time.hpp"
 
 namespace s2e::environment {
@@ -115,8 +115,7 @@ void EarthRotation::InitializeParameters() {
 // Same GMST polynomial as Vallado's gstime(), with Julian centuries evaluated from split time to avoid rounding a full Julian Date.
 double EarthRotation::CalcGmstRadFromSplitJulianDate(const double julian_date_0h, const double seconds_from_0h) {
   const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (86400.0 * 36525.0);
-  double temp =
-      -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
+  double temp = -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
   temp = std::fmod(temp * math::deg_to_rad / 240.0, 2.0 * math::pi);
   if (temp < 0.0) temp += 2.0 * math::pi;
   return temp;
@@ -127,8 +126,8 @@ void EarthRotation::Update(const SimulationTime& simulation_time) {
   jday(simulation_time.GetStartYear(), simulation_time.GetStartMonth(), simulation_time.GetStartDay(), 0, 0, 0.0, julian_date_0h);
 
   const double seconds_per_day = 86400.0;
-  double seconds_from_0h = simulation_time.GetStartHour() * 3600.0 + simulation_time.GetStartMinute() * 60.0 +
-                           simulation_time.GetStartSecond() + simulation_time.GetElapsedTime_s();
+  double seconds_from_0h = simulation_time.GetStartHour() * 3600.0 + simulation_time.GetStartMinute() * 60.0 + simulation_time.GetStartSecond() +
+                           simulation_time.GetElapsedTime_s();
   const double elapsed_days = std::floor(seconds_from_0h / seconds_per_day);
   julian_date_0h += elapsed_days;
   seconds_from_0h -= elapsed_days * seconds_per_day;
@@ -140,8 +139,7 @@ void EarthRotation::Update(const SimulationTime& simulation_time) {
     // The actual unit of tTT_century is [century^(i+1)], i is the index of the array
     double terrestrial_time_julian_century[4];
     terrestrial_time_julian_century[0] =
-        (julian_date_0h - kJulianDateJ2000_) / kDayJulianCentury_ +
-        (seconds_from_0h + kDtUt1Utc_) / (seconds_per_day * kDayJulianCentury_);
+        (julian_date_0h - kJulianDateJ2000_) / kDayJulianCentury_ + (seconds_from_0h + kDtUt1Utc_) / (seconds_per_day * kDayJulianCentury_);
     for (int i = 0; i < 3; i++) {
       terrestrial_time_julian_century[i + 1] = terrestrial_time_julian_century[i] * terrestrial_time_julian_century[0];
     }

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "environment/global/physical_constants.hpp"
 #include "math_physics/math/constants.hpp"
 #include "math_physics/orbit/sgp4/sgp4ext.h"  // for jday()
 #include "simulation_time.hpp"
@@ -114,7 +115,7 @@ void EarthRotation::InitializeParameters() {
 
 // Same GMST polynomial as Vallado's gstime(), with Julian centuries evaluated from split time to avoid rounding a full Julian Date.
 double EarthRotation::CalcGmstFromSplitJulianDate_rad(const double julian_date_0h, const double seconds_from_0h) {
-  const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (86400.0 * 36525.0);
+  const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (seconds_per_day * 36525.0);
   double temp = -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
   temp = std::fmod(temp * math::deg_to_rad / 240.0, 2.0 * math::pi);
   if (temp < 0.0) temp += 2.0 * math::pi;
@@ -125,7 +126,6 @@ void EarthRotation::Update(const SimulationTime& simulation_time) {
   double julian_date_0h;
   jday(simulation_time.GetStartYear(), simulation_time.GetStartMonth(), simulation_time.GetStartDay(), 0, 0, 0.0, julian_date_0h);
 
-  const double seconds_per_day = 86400.0;
   double seconds_from_0h = simulation_time.GetSecondsFrom0h_s();
   const double elapsed_days = std::floor(seconds_from_0h / seconds_per_day);
   julian_date_0h += elapsed_days;

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -113,7 +113,7 @@ void EarthRotation::InitializeParameters() {
 }
 
 // Same GMST polynomial as Vallado's gstime(), with Julian centuries evaluated from split time to avoid rounding a full Julian Date.
-double EarthRotation::CalcGmstRadFromSplitJulianDate(const double julian_date_0h, const double seconds_from_0h) {
+double EarthRotation::CalcGmstFromSplitJulianDate_rad(const double julian_date_0h, const double seconds_from_0h) {
   const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (86400.0 * 36525.0);
   double temp = -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
   temp = std::fmod(temp * math::deg_to_rad / 240.0, 2.0 * math::pi);
@@ -131,7 +131,7 @@ void EarthRotation::Update(const SimulationTime& simulation_time) {
   julian_date_0h += elapsed_days;
   seconds_from_0h -= elapsed_days * seconds_per_day;
 
-  double gmst_rad = CalcGmstRadFromSplitJulianDate(julian_date_0h, seconds_from_0h);
+  double gmst_rad = CalcGmstFromSplitJulianDate_rad(julian_date_0h, seconds_from_0h);
 
   if (rotation_mode_ == EarthRotationMode::kFull) {
     // Compute nth power of julian century for terrestrial time.

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -18,20 +18,6 @@
 
 namespace s2e::environment {
 
-namespace {
-
-// Same GMST polynomial as Vallado's gstime(), with Julian centuries evaluated from split time to avoid rounding a full Julian Date.
-double CalcGmstRadFromSplitJulianDate(const double julian_date_0h, const double seconds_from_0h) {
-  const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (86400.0 * 36525.0);
-  double temp =
-      -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
-  temp = std::fmod(temp * math::deg_to_rad / 240.0, 2.0 * math::pi);
-  if (temp < 0.0) temp += 2.0 * math::pi;
-  return temp;
-}
-
-}  // namespace
-
 // Default constructor
 EarthRotation::EarthRotation(const EarthRotationMode rotation_mode) : rotation_mode_(rotation_mode) {
   dcm_j2000_to_ecef_ = math::MakeIdentityMatrix<3>();
@@ -124,6 +110,16 @@ void EarthRotation::InitializeParameters() {
     // If the rotation mode is neither Simple nor Full, disable the rotation calculation and make the DCM a unit matrix
     dcm_j2000_to_ecef_ = math::MakeIdentityMatrix<3>();
   }
+}
+
+// Same GMST polynomial as Vallado's gstime(), with Julian centuries evaluated from split time to avoid rounding a full Julian Date.
+double EarthRotation::CalcGmstRadFromSplitJulianDate(const double julian_date_0h, const double seconds_from_0h) {
+  const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (86400.0 * 36525.0);
+  double temp =
+      -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
+  temp = std::fmod(temp * math::deg_to_rad / 240.0, 2.0 * math::pi);
+  if (temp < 0.0) temp += 2.0 * math::pi;
+  return temp;
 }
 
 void EarthRotation::Update(const SimulationTime& simulation_time) {

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -126,8 +126,7 @@ void EarthRotation::Update(const SimulationTime& simulation_time) {
   jday(simulation_time.GetStartYear(), simulation_time.GetStartMonth(), simulation_time.GetStartDay(), 0, 0, 0.0, julian_date_0h);
 
   const double seconds_per_day = 86400.0;
-  double seconds_from_0h = simulation_time.GetStartHour() * 3600.0 + simulation_time.GetStartMinute() * 60.0 + simulation_time.GetStartSecond() +
-                           simulation_time.GetElapsedTime_s();
+  double seconds_from_0h = simulation_time.GetSecondsFrom0h_s();
   const double elapsed_days = std::floor(seconds_from_0h / seconds_per_day);
   julian_date_0h += elapsed_days;
   seconds_from_0h -= elapsed_days * seconds_per_day;

--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -8,14 +8,29 @@
 
 #include "earth_rotation.hpp"
 
+#include <cmath>
 #include <iostream>
 #include <sstream>
 
 #include "math_physics/math/constants.hpp"
 #include "math_physics/orbit/sgp4/sgp4ext.h"   // for jday()
-#include "math_physics/orbit/sgp4/sgp4unit.h"  // for gstime()
+#include "simulation_time.hpp"
 
 namespace s2e::environment {
+
+namespace {
+
+// Same GMST polynomial as Vallado's gstime(), with Julian centuries evaluated from split time to avoid rounding a full Julian Date.
+double CalcGmstRadFromSplitJulianDate(const double julian_date_0h, const double seconds_from_0h) {
+  const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (86400.0 * 36525.0);
+  double temp =
+      -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
+  temp = std::fmod(temp * math::deg_to_rad / 240.0, 2.0 * math::pi);
+  if (temp < 0.0) temp += 2.0 * math::pi;
+  return temp;
+}
+
+}  // namespace
 
 // Default constructor
 EarthRotation::EarthRotation(const EarthRotationMode rotation_mode) : rotation_mode_(rotation_mode) {
@@ -111,18 +126,26 @@ void EarthRotation::InitializeParameters() {
   }
 }
 
-void EarthRotation::Update(const double julian_date) {
-  double gmst_rad = gstime(julian_date);  // It is a bit different with 長沢(Nagasawa)'s algorithm. TODO: Check the correctness
+void EarthRotation::Update(const SimulationTime& simulation_time) {
+  double julian_date_0h;
+  jday(simulation_time.GetStartYear(), simulation_time.GetStartMonth(), simulation_time.GetStartDay(), 0, 0, 0.0, julian_date_0h);
+
+  const double seconds_per_day = 86400.0;
+  double seconds_from_0h = simulation_time.GetStartHour() * 3600.0 + simulation_time.GetStartMinute() * 60.0 +
+                           simulation_time.GetStartSecond() + simulation_time.GetElapsedTime_s();
+  const double elapsed_days = std::floor(seconds_from_0h / seconds_per_day);
+  julian_date_0h += elapsed_days;
+  seconds_from_0h -= elapsed_days * seconds_per_day;
+
+  double gmst_rad = CalcGmstRadFromSplitJulianDate(julian_date_0h, seconds_from_0h);
 
   if (rotation_mode_ == EarthRotationMode::kFull) {
-    // Compute Julian date for terrestrial time
-    double terrestrial_time_julian_day =
-        julian_date + kDtUt1Utc_ * kSec2Day_;  // TODO: Check the correctness. Problem is that S2E doesn't have Gregorian calendar.
-
     // Compute nth power of julian century for terrestrial time.
     // The actual unit of tTT_century is [century^(i+1)], i is the index of the array
     double terrestrial_time_julian_century[4];
-    terrestrial_time_julian_century[0] = (terrestrial_time_julian_day - kJulianDateJ2000_) / kDayJulianCentury_;
+    terrestrial_time_julian_century[0] =
+        (julian_date_0h - kJulianDateJ2000_) / kDayJulianCentury_ +
+        (seconds_from_0h + kDtUt1Utc_) / (seconds_per_day * kDayJulianCentury_);
     for (int i = 0; i < 3; i++) {
       terrestrial_time_julian_century[i + 1] = terrestrial_time_julian_century[i] * terrestrial_time_julian_century[0];
     }

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -94,8 +94,8 @@ class EarthRotation {
   /**
    * @fn CalcGmstFromSplitJulianDate_rad
    * @brief Calculate GMST from a 0h Julian Date and seconds from 0h
-   * @param [in] julian_date_0h: Julian Date at 0h UT
-   * @param [in] seconds_from_0h: Elapsed seconds from 0h UT
+   * @param [in] julian_date_0h: Julian Date at 0h UTC
+   * @param [in] seconds_from_0h: Elapsed seconds from 0h UTC
    * @return Greenwich Mean Sidereal Time [rad]
    */
   static double CalcGmstFromSplitJulianDate_rad(const double julian_date_0h, const double seconds_from_0h);

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -92,6 +92,15 @@ class EarthRotation {
   void InitializeParameters();
 
   /**
+   * @fn CalcGmstRadFromSplitJulianDate
+   * @brief Calculate GMST from a 0h Julian Date and seconds from 0h
+   * @param [in] julian_date_0h: Julian Date at 0h UT
+   * @param [in] seconds_from_0h: Elapsed seconds from 0h UT
+   * @return Greenwich Mean Sidereal Time [rad]
+   */
+  static double CalcGmstRadFromSplitJulianDate(const double julian_date_0h, const double seconds_from_0h);
+
+  /**
    * @fn AxialRotation
    * @brief Calculate movement of the coordinate axes due to rotation around the rotation axis
    * @param [in] gast_rad: Greenwich 'Apparent' Sidereal Time [rad]

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -92,13 +92,13 @@ class EarthRotation {
   void InitializeParameters();
 
   /**
-   * @fn CalcGmstRadFromSplitJulianDate
+   * @fn CalcGmstFromSplitJulianDate_rad
    * @brief Calculate GMST from a 0h Julian Date and seconds from 0h
    * @param [in] julian_date_0h: Julian Date at 0h UT
    * @param [in] seconds_from_0h: Elapsed seconds from 0h UT
    * @return Greenwich Mean Sidereal Time [rad]
    */
-  static double CalcGmstRadFromSplitJulianDate(const double julian_date_0h, const double seconds_from_0h);
+  static double CalcGmstFromSplitJulianDate_rad(const double julian_date_0h, const double seconds_from_0h);
 
   /**
    * @fn AxialRotation

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -13,6 +13,8 @@
 
 namespace s2e::environment {
 
+class SimulationTime;
+
 /**
  * @enum EarthRotationMode
  * @brief Definition of calculation mode of earth rotation
@@ -39,9 +41,9 @@ class EarthRotation {
   /**
    * @fn Update
    * @brief Update rotation
-   * @param [in] julian_date: Julian date
+   * @param [in] simulation_time: Simulation time information
    */
-  void Update(const double julian_date);
+  void Update(const SimulationTime& simulation_time);
 
   /**
    * @fn GetDcmJ2000ToEcef
@@ -80,7 +82,6 @@ class EarthRotation {
 
   // TODO: Move to general constant values
   const double kDtUt1Utc_ = 32.184;                     //!< Time difference b/w UT1 and UTC [sec]
-  const double kSec2Day_ = 1.0 / (24.0 * 60.0 * 60.0);  //!< Conversion constant from sec to day
   const double kJulianDateJ2000_ = 2451545.0;           //!< Julian date of J2000 [day]
   const double kDayJulianCentury_ = 36525.0;            //!< Conversion constant from Julian century to day [day/century]
 

--- a/src/environment/global/physical_constants.hpp
+++ b/src/environment/global/physical_constants.hpp
@@ -24,6 +24,7 @@ DEFINE_PHYSICAL_CONSTANT(boltzmann_constant_J_K, 1.380649e-23L)              //!
 DEFINE_PHYSICAL_CONSTANT(stefan_boltzmann_constant_W_m2K4, 5.670374419e-8L)  //!< Stefan-Boltzmann constant [W/m2K4]
 DEFINE_PHYSICAL_CONSTANT(absolute_zero_degC, -273.15L)                       //!< Absolute zero [degC]
 DEFINE_PHYSICAL_CONSTANT(solar_constant_W_m2, 1.366e3L)                      //!< Solar constant [W/m2]
+DEFINE_PHYSICAL_CONSTANT(seconds_per_day, 86400.0L)                          //!< Number of seconds in a day [s]
 }  // namespace physics
 
 inline namespace astronomy {

--- a/src/environment/global/simulation_time.hpp
+++ b/src/environment/global/simulation_time.hpp
@@ -244,9 +244,7 @@ class SimulationTime : public logger::ILoggable {
    *@fn GetSecondsFrom0h_s
    *@brief Return seconds from 0h on the simulation start date [sec]
    */
-  inline double GetSecondsFrom0h_s(void) const {
-    return start_hour_ * 3600.0 + start_minute_ * 60.0 + start_sec_ + elapsed_time_sec_;
-  };
+  inline double GetSecondsFrom0h_s(void) const { return start_hour_ * 3600.0 + start_minute_ * 60.0 + start_sec_ + elapsed_time_sec_; };
 
   // Override logger::ILoggable
   /**

--- a/src/environment/global/simulation_time.hpp
+++ b/src/environment/global/simulation_time.hpp
@@ -240,6 +240,13 @@ class SimulationTime : public logger::ILoggable {
    *@brief Return start time second [sec]
    */
   inline double GetStartSecond(void) const { return start_sec_; };
+  /**
+   *@fn GetSecondsFrom0h_s
+   *@brief Return seconds from 0h on the simulation start date [sec]
+   */
+  inline double GetSecondsFrom0h_s(void) const {
+    return start_hour_ * 3600.0 + start_minute_ * 60.0 + start_sec_ + elapsed_time_sec_;
+  };
 
   // Override logger::ILoggable
   /**


### PR DESCRIPTION
## Related issues
#806 

## Description
Julian Date を1つの `double` で扱うことで生じる浮動小数点の丸め誤差による影響を低減するよう、GMSTの計算を修正した。

## Test results
10 ms step、60 s の条件で、80桁精度の既存のGMST計算方法を基準として旧実装と新実装の GMST 計算誤差を比較した。

<img width="879" height="613" alt="スクリーンショット 2026-08-22 2 11 28" src="https://github.com/user-attachments/assets/b6e3cfb9-0d5b-4089-95ee-6f7e3e4fb25e" />

| Error | Old implementation | New implementation |
|---|---:|---:|
| GMST RMS error [rad] | 8.47e-10 | 8.59e-12 |
| GMST max error [rad] | 1.48e-9 | 2.11e-11 |
| ECI/ECEF座標変換の位置誤差RMS換算値（高度550 km） [mm] | 5.87 | 0.0595 |
| ECI/ECEF座標変換の位置誤差最大値換算（高度550 km） [mm] | 10.24 | 0.146 |

GMSTのRMS誤差は約99倍、最大誤差は約70倍改善した。
GMST角度誤差を Δθ、地球自転軸からの距離を ρ とすると、
Δr = 2ρ sin(|Δθ| / 2) ≈ ρ|Δθ|
として位置誤差に換算した。


## Impact
Describe the scope of influence of the changes, e.g., `The behavior of feature ** changes.`

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
