### PR TITLE
Modify GMST calculation

### DIFF
--- a/src/environment/global/earth_rotation.cpp
+++ b/src/environment/global/earth_rotation.cpp
@@ -3,7 +3,9 @@
  * @brief Class to calculate the earth rotation
  * @note Refs: 福島,"天体の回転運動理論入門講義ノート", 2007 (in Japanese),
  *             長沢,"天体の位置計算(増補版)", 2001 (in Japanese),
- *             IERS Conventions 2003
+ *             IERS Conventions 2003,
+ *             IAU SOFA Library Issue 2023-10-11:
+ *             https://www.iausofa.org/2023-10-11c
  */
 
 #include "earth_rotation.hpp"
@@ -115,11 +117,42 @@ void EarthRotation::InitializeParameters() {
 
 // Same GMST polynomial as Vallado's gstime(), with Julian centuries evaluated from split time to avoid rounding a full Julian Date.
 double EarthRotation::CalcGmstFromSplitJulianDate_rad(const double julian_date_0h, const double seconds_from_0h) {
-  const double tut1 = (julian_date_0h - 2451545.0) / 36525.0 + seconds_from_0h / (seconds_per_day * 36525.0);
-  double temp = -6.2e-6 * tut1 * tut1 * tut1 + 0.093104 * tut1 * tut1 + (876600.0 * 3600 + 8640184.812866) * tut1 + 67310.54841;
-  temp = std::fmod(temp * math::deg_to_rad / 240.0, 2.0 * math::pi);
-  if (temp < 0.0) temp += 2.0 * math::pi;
-  return temp;
+  // IAU 1982 GMST coefficients
+  const double A = 24110.54841 - seconds_per_day / 2.0;
+  const double B = 8640184.812866;
+  const double C = 0.093104;
+  const double D = -6.2e-6;
+
+  // Two-part Julian Date
+  const double dj1 = julian_date_0h;
+  const double dj2 = seconds_from_0h / seconds_per_day;
+
+  // Julian centuries since J2000.
+  double d1;
+  double d2;
+
+  if (dj1 < dj2) {
+    d1 = dj1;
+    d2 = dj2;
+  } else {
+    d1 = dj2;
+    d2 = dj1;
+  }
+
+  const double t = (d1 + (d2 - julian_date_j2000)) / days_per_julian_century;
+
+  // Fractional part of JD(UT1) in seconds.
+  const double fractional_seconds = seconds_per_day * (std::fmod(d1, 1.0) + std::fmod(d2, 1.0));
+
+  // GMST in seconds.
+  double gmst_seconds = A + (B + (C + D * t) * t) * t + fractional_seconds;
+
+  gmst_seconds = std::fmod(gmst_seconds, seconds_per_day);
+  if (gmst_seconds < 0.0) {
+    gmst_seconds += seconds_per_day;
+  }
+
+  return gmst_seconds * 2.0 * math::pi / seconds_per_day;
 }
 
 void EarthRotation::Update(const SimulationTime& simulation_time) {
@@ -137,8 +170,8 @@ void EarthRotation::Update(const SimulationTime& simulation_time) {
     // Compute nth power of julian century for terrestrial time.
     // The actual unit of tTT_century is [century^(i+1)], i is the index of the array
     double terrestrial_time_julian_century[4];
-    terrestrial_time_julian_century[0] =
-        (julian_date_0h - kJulianDateJ2000_) / kDayJulianCentury_ + (seconds_from_0h + kDtUt1Utc_) / (seconds_per_day * kDayJulianCentury_);
+    terrestrial_time_julian_century[0] = (julian_date_0h - julian_date_j2000) / days_per_julian_century +
+                                         (seconds_from_0h + dt_ut1_utc_s) / (seconds_per_day * days_per_julian_century);
     for (int i = 0; i < 3; i++) {
       terrestrial_time_julian_century[i + 1] = terrestrial_time_julian_century[i] * terrestrial_time_julian_century[0];
     }

--- a/src/environment/global/earth_rotation.hpp
+++ b/src/environment/global/earth_rotation.hpp
@@ -80,11 +80,6 @@ class EarthRotation {
   double c_theta_rad_[3];      //!< Coefficients to compute precession angle (theta)
   double c_z_rad_[3];          //!< Coefficients to compute precession angle (z)
 
-  // TODO: Move to general constant values
-  const double kDtUt1Utc_ = 32.184;                     //!< Time difference b/w UT1 and UTC [sec]
-  const double kJulianDateJ2000_ = 2451545.0;           //!< Julian date of J2000 [day]
-  const double kDayJulianCentury_ = 36525.0;            //!< Conversion constant from Julian century to day [day/century]
-
   /**
    * @fn InitializeParameters
    * @brief Initialize parameters

--- a/src/environment/global/physical_constants.hpp
+++ b/src/environment/global/physical_constants.hpp
@@ -31,6 +31,9 @@ inline namespace astronomy {
 // Ref: https://iau-a3.gitlab.io/NSFA/
 DEFINE_PHYSICAL_CONSTANT(astronomical_unit_m, 1.49597870700e11L)               //!< Fixed value of the Astronomical unit [m]
 DEFINE_PHYSICAL_CONSTANT(gravitational_constant_Nm2_kg2, 6.67428e-11L)         //!< Best estimate of the Gravitational constants [Nm2/kg2]
+DEFINE_PHYSICAL_CONSTANT(dt_ut1_utc_s, 32.184L)                                //!< Time difference b/w UT1 and UTC [sec]
+DEFINE_PHYSICAL_CONSTANT(julian_date_j2000, 2451545.0L)                        //!< Julian date of J2000 [day]
+DEFINE_PHYSICAL_CONSTANT(days_per_julian_century, 36525.0L)                    //!< Conversion constant from Julian century to day [day/century]
 DEFINE_PHYSICAL_CONSTANT(earth_equatorial_radius_m, 6378136.6L)                //!< Best estimate of the Earth equatorial radius[m]
 DEFINE_PHYSICAL_CONSTANT(earth_polar_radius_m, 6356752.0L)                     //!< The Earth polar radius from NASA's fact sheet [m]
 DEFINE_PHYSICAL_CONSTANT(earth_gravitational_constant_m3_s2, 3.986004415e14L)  //!< Best estimate of the Earth's gravitational constants, TT [m3/s2]


### PR DESCRIPTION
## Related issues
Mention any issues that this pull request is related (e.g., #1). Consider using the `development` field if you want to close the issue automatically when this pull request is merged.

## Description
[PR807](https://github.com/ut-issl/s2e-core/pull/807)の修正でJulian Dateを分割することで浮動小数点の丸め誤差による影響を低減したが、GMST多項式内で大きな整数日相当の項を直接計算していたため、`fmod`による正規化前に`double`の分解能が低下する問題が残っていた。

それを低減するため、計算方法を[IAU SOFA](https://www.iausofa.org/2023-10-11c)の`iauGmst82()`を参考に修正した。

## Test results
条件:
- 開始時刻: 2020-04-01 12:00:00 UTC
- 刻み幅: 10 ms
- 期間: 60 s（6001点）
- 基準値: 80桁以上の高精度DecimalによるGMST計算
- 位置誤差換算: 高度550 km、赤道上相当（ρ = 6,928,136.6 m）

| Error | Old implementation (`59d482ae`) | New implementation |
|---|---:|---:|
| GMST RMS error [rad] | 5.33e-12 | 1.60e-14 |
| GMST max error [rad] | 1.63e-11 | 5.04e-14 |
| 位置誤差RMS換算 [mm] | 3.69e-2 | 1.11e-4 |
| 位置誤差最大値換算 [mm] | 1.13e-1 | 3.49e-4 |

<img width="1400" height="980" alt="gmst_precision_comparison_branch_base_80digit" src="https://github.com/user-attachments/assets/7fbec327-504f-4591-850d-26d687be847c" />


GMSTのRMS誤差は約333倍、最大誤差は約323倍改善した。
GMST角度誤差を Δθ、地球自転軸からの距離を ρ とすると、
Δr = 2ρ sin(|Δθ| / 2) ≈ ρ|Δθ|
として位置誤差に換算した。

## Impact
Describe the scope of influence of the changes, e.g., `The behavior of feature ** changes.`

## Supplementary information
Provide any supplementary information.

<!--
## Note
- No need to select `Reviewers` because it is automatically assigned.
- Assign the appropriate member(s) to this pull request as `Assignees`.
- Apply the `priority` label.
- Link the issue to any related projects if applicable.
-->
